### PR TITLE
Update and rename inverter.cpp to inverter_asNEPLAN.cpp

### DIFF
--- a/generators/inverter_asNEPLAN.cpp
+++ b/generators/inverter_asNEPLAN.cpp
@@ -3692,7 +3692,7 @@ TIMESTAMP inverter::postsync(TIMESTAMP t0, TIMESTAMP t1)
 			}
 			if (vv_operation) {
 				t2 = t1;
-				allowed_vv_action = (TIMESTAMP)floor((double)t1 + vv_lockout + 0.5);
+				allowed_vv_action = (TIMESTAMP)floor((double)t1 + vv_lockout);
 			}
 		}
 	}


### PR DESCRIPTION
Inverter with the option to set the volt_var_control_lockout property to 0, without rounding it up.