### PR TITLE
MySQL Recorder and Group Recorder Improvements

### DIFF
--- a/gldcore/gridlabd.h
+++ b/gldcore/gridlabd.h
@@ -1288,8 +1288,8 @@ static unsigned long _nan[] = { 0xffffffff, 0x7fffffff, };
  * @defgroup gridlabd_h_classes Module API Classes
  * @{
  **************************************************************************************/
-
 #include <ctype.h>
+#include <stdio.h>
 #include "module.h"
 #include "class.h"
 #include "property.h"
@@ -2043,6 +2043,15 @@ public: // read accessors
 	inline PROPERTY *get_property(void) { return pstruct.prop; };
 	inline gld_class* get_class(void) { return (gld_class*)pstruct.prop->oclass; };
 	inline char *get_name(void) { return pstruct.prop->name; };
+	inline char *get_sql_safe_name(void) {
+		if (pstruct.part[0] != '\0') {
+			char return_val[256];
+			sprintf(return_val, "%s_%s", pstruct.prop->name, pstruct.part);
+			return return_val;
+		} else {
+			return pstruct.prop->name;
+		}
+	};
 	inline gld_type get_type(void) { return gld_type(pstruct.prop->ptype); };
 	inline size_t get_size(void) { return (size_t)(pstruct.prop->size); };
 	inline size_t get_width(void) { return (size_t)(pstruct.prop->width); };

--- a/gldcore/gridlabd.h
+++ b/gldcore/gridlabd.h
@@ -2007,6 +2007,7 @@ public: // constructors/casts
 	};
 	inline gld_property(OBJECT *o) : obj(o), pstruct(nullpstruct) { pstruct.prop=o->oclass->pmap; };
 	inline gld_property(OBJECT *o, PROPERTY *p) : obj(o), pstruct(nullpstruct) { pstruct.prop=p; };
+	inline gld_property(OBJECT *o, PROPERTYSTRUCT *p) : obj(o), pstruct(nullpstruct) { pstruct=*p; };
 	inline gld_property(GLOBALVAR *v) : obj(NULL), pstruct(nullpstruct) { pstruct.prop=v->prop; };
 	inline gld_property(char *n) : obj(NULL), pstruct(nullpstruct)
 	{
@@ -2041,16 +2042,16 @@ public: // constructors/casts
 public: // read accessors
 	inline OBJECT *get_object(void) { return obj; };
 	inline PROPERTY *get_property(void) { return pstruct.prop; };
+	inline PROPERTYSTRUCT *get_property_struct(void) { return &pstruct; };
 	inline gld_class* get_class(void) { return (gld_class*)pstruct.prop->oclass; };
 	inline char *get_name(void) { return pstruct.prop->name; };
-	inline char *get_sql_safe_name(void) {
+	inline char *get_sql_safe_name(char* return_val) {
 		if (pstruct.part[0] != '\0') {
-			char return_val[256];
 			sprintf(return_val, "%s_%s", pstruct.prop->name, pstruct.part);
-			return return_val;
 		} else {
-			return pstruct.prop->name;
+			sprintf(return_val, "%s", pstruct.prop->name);
 		}
+		return return_val;
 	};
 	inline gld_type get_type(void) { return gld_type(pstruct.prop->ptype); };
 	inline size_t get_size(void) { return (size_t)(pstruct.prop->size); };

--- a/mysql/Makefile.mk
+++ b/mysql/Makefile.mk
@@ -22,3 +22,9 @@ mysql_mysql_la_SOURCES += mysql/player.cpp
 mysql_mysql_la_SOURCES += mysql/player.h
 mysql_mysql_la_SOURCES += mysql/recorder.cpp
 mysql_mysql_la_SOURCES += mysql/recorder.h
+mysql_mysql_la_SOURCES += mysql/query_engine.h
+mysql_mysql_la_SOURCES += mysql/table_manager.cpp
+mysql_mysql_la_SOURCES += mysql/query_engine.cpp
+mysql_mysql_la_SOURCES += mysql/group_recorder.cpp
+mysql_mysql_la_SOURCES += mysql/group_recorder.h
+

--- a/mysql/autotest/test_mysql_collector.glm
+++ b/mysql/autotest/test_mysql_collector.glm
@@ -18,8 +18,13 @@ clock {
 }
 
 module mysql;
-object database {
-	options NEWDB;
+object database {   
+   hostname "localhost";
+   username "gridlabd";
+   password "";
+   schema "gridlabd";
+   port 3306;
+   tz_offset 0;
 }
 
 class test {

--- a/mysql/autotest/test_mysql_group_recorder_1.glm
+++ b/mysql/autotest/test_mysql_group_recorder_1.glm
@@ -4,9 +4,13 @@
 #set profiler=1
 
 module mysql;
-object database {
-   options NEWDB;
-//   port 3307;
+object database {   
+   hostname "localhost";
+   username "gridlabd";
+   password "";
+   schema "gridlabd";
+   port 3306;
+   tz_offset 0;
 }
 module powerflow {
 	solver_method NR;

--- a/mysql/autotest/test_mysql_group_recorder_1.glm
+++ b/mysql/autotest/test_mysql_group_recorder_1.glm
@@ -1,0 +1,234 @@
+// Simple model with three loads for testing mysql group_recorder
+#ifdef MYSQL
+
+#set profiler=1
+
+module mysql;
+object database {
+   options NEWDB;
+//   port 3307;
+}
+module powerflow {
+	solver_method NR;
+};
+
+clock {
+	timezone PST+8PDT;
+	starttime '2001-01-01 00:00:00';
+	stoptime '2001-01-02 00:00:00';
+}
+
+// swing node
+object meter {
+	name substation_node;
+	phases ABCN;
+	nominal_voltage 7200;
+	bustype SWING;
+}
+
+// line configuration objects
+object line_configuration {
+    name overhead_line_1;
+    conductor_A overhead_line_conductor_1;
+    conductor_B overhead_line_conductor_1;
+    conductor_C overhead_line_conductor_1;
+    conductor_N overhead_line_conductor_1;
+    spacing line_spacing_1;
+}
+
+object line_spacing {
+    name line_spacing_1;
+    distance_AB 4;
+    distance_BC 4;
+    distance_AC 4;
+    distance_AN 3;
+    distance_BN 3;
+    distance_CN 3;
+}
+
+object overhead_line_conductor {
+    name overhead_line_conductor_1;
+    geometric_mean_radius 0.0271;
+    resistance 0.0369;
+}
+
+// Line, load, and meter 1
+object overhead_line {
+    name ol_1;
+    phases ABCN;
+    from substation_node;
+    to meter_1;
+    length 606.04;
+    configuration overhead_line_1;
+}
+
+object load {
+	phases ABCN;
+	name load_1;
+	parent meter_1;
+	base_power_A 120000;
+	base_power_B 130000;
+	base_power_C 110000;
+	power_pf_A 0.98;
+	current_pf_A 0.92;
+	impedance_pf_A 0.95;
+	power_fraction_A 0.8;
+	current_fraction_A 0.15;
+	impedance_fraction_A 0.05;
+	power_pf_B 0.98;
+	current_pf_B 0.92;
+	impedance_pf_B 0.95;
+	power_fraction_B 0.1;
+	current_fraction_B 0.3;
+	impedance_fraction_B 0.6;
+	power_pf_C 0.98;
+	current_pf_C 0.92;
+	impedance_pf_C 0.95;
+	power_fraction_C 0.5;
+	current_fraction_C 0.1;
+	impedance_fraction_C 0.4;
+	nominal_voltage 7200;
+}
+
+object meter {
+	name meter_1;
+	phases ABCN;
+	nominal_voltage 7200;
+	groupid meter_group;
+}
+
+// Line, load, and meter 2
+object overhead_line {
+    name ol_2;
+    phases ABCN;
+    from substation_node;
+    to meter_2;
+    length 1606.04;
+    configuration overhead_line_1;
+}
+
+object load {
+	phases ABCN;
+	name load_2;
+	parent meter_2;
+	base_power_A 130000;
+	base_power_B 110000;
+	base_power_C 120000;
+	power_pf_A 0.98;
+	current_pf_A 0.92;
+	impedance_pf_A 0.95;
+	power_fraction_A 0.8;
+	current_fraction_A 0.15;
+	impedance_fraction_A 0.05;
+	power_pf_B 0.98;
+	current_pf_B 0.92;
+	impedance_pf_B 0.95;
+	power_fraction_B 0.1;
+	current_fraction_B 0.3;
+	impedance_fraction_B 0.6;
+	power_pf_C 0.98;
+	current_pf_C 0.92;
+	impedance_pf_C 0.95;
+	power_fraction_C 0.5;
+	current_fraction_C 0.1;
+	impedance_fraction_C 0.4;
+	nominal_voltage 7200;
+}
+
+object meter {
+	name meter_2;
+	phases ABCN;
+	nominal_voltage 7200;
+	groupid meter_group;
+}
+
+// Line, load, and meter 3
+object overhead_line {
+    name ol_3;
+    phases ABCN;
+    from substation_node;
+    to meter_3;
+    length 66.04;
+    configuration overhead_line_1;
+}
+
+object load {
+	phases ABCN;
+	name load_3;
+	parent meter_3;
+	base_power_A 110000;
+	base_power_B 120000;
+	base_power_C 130000;
+	power_pf_A 0.98;
+	current_pf_A 0.92;
+	impedance_pf_A 0.95;
+	power_fraction_A 0.8;
+	current_fraction_A 0.15;
+	impedance_fraction_A 0.05;
+	power_pf_B 0.98;
+	current_pf_B 0.92;
+	impedance_pf_B 0.95;
+	power_fraction_B 0.1;
+	current_fraction_B 0.3;
+	impedance_fraction_B 0.6;
+	power_pf_C 0.98;
+	current_pf_C 0.92;
+	impedance_pf_C 0.95;
+	power_fraction_C 0.5;
+	current_fraction_C 0.1;
+	impedance_fraction_C 0.4;
+	nominal_voltage 7200;
+}
+
+object meter {
+	name meter_3;
+	phases ABCN;
+	nominal_voltage 7200;
+	groupid meter_group;
+}
+
+// Group recorders
+// energy
+object group_recorder {
+  interval 3600;
+  group "groupid=meter_group";
+  property measured_real_energy;
+  file energy.csv;
+  mode "w";
+  flush_interval -1; // This will catch it if anyone removes the unused, but necessary "flush_inverval[s]" variable from code
+  format FALSE; // This will catch it if anyone removes the unused, but necessary "format" variable from code
+};
+// power
+object group_recorder {
+  interval 3600;
+  group "groupid=meter_group";
+  property measured_power;
+  table power.csv;
+  print_units TRUE;
+  limit 20;
+  query_buffer_limit 10;
+  mode "w";
+};
+//voltage
+object group_recorder {
+  interval 3600;
+  group "groupid=meter_group";
+  property measured_voltage_A;
+  file voltage_A;
+  data_type "DECIMAL(8,2)";
+  complex_part MAG|Imag|real; // tests different case and mixed case options. All should work.
+  column_limit 3; // produces two tables to verify table handling.
+  mode "w";
+};
+//current
+object group_recorder {
+  interval 3600;
+  group "groupid=meter_group";
+  property measured_current_C;
+  table current_C;
+  complex_part MAG;
+  print_units TRUE;
+  mode "w";
+};
+
+#endif

--- a/mysql/autotest/test_mysql_group_recorder_1_err.glm
+++ b/mysql/autotest/test_mysql_group_recorder_1_err.glm
@@ -4,9 +4,13 @@
 #set profiler=1
 
 module mysql;
-object database {
-   options NEWDB;
-//   port 3307;
+object database {   
+   hostname "localhost";
+   username "gridlabd";
+   password "";
+   schema "gridlabd";
+   port 3306;
+   tz_offset 0;
 }
 module powerflow {
 	solver_method NR;

--- a/mysql/autotest/test_mysql_group_recorder_1_err.glm
+++ b/mysql/autotest/test_mysql_group_recorder_1_err.glm
@@ -1,0 +1,206 @@
+// Simple model with three loads for testing mysql group_recorder
+#ifdef MYSQL
+
+#set profiler=1
+
+module mysql;
+object database {
+   options NEWDB;
+//   port 3307;
+}
+module powerflow {
+	solver_method NR;
+};
+
+clock {
+	timezone PST+8PDT;
+	starttime '2001-01-01 00:00:00';
+	stoptime '2001-01-02 00:00:00';
+}
+
+// swing node
+object meter {
+	name substation_node;
+	phases ABCN;
+	nominal_voltage 7200;
+	bustype SWING;
+}
+
+// line configuration objects
+object line_configuration {
+    name overhead_line_1;
+    conductor_A overhead_line_conductor_1;
+    conductor_B overhead_line_conductor_1;
+    conductor_C overhead_line_conductor_1;
+    conductor_N overhead_line_conductor_1;
+    spacing line_spacing_1;
+}
+
+object line_spacing {
+    name line_spacing_1;
+    distance_AB 4;
+    distance_BC 4;
+    distance_AC 4;
+    distance_AN 3;
+    distance_BN 3;
+    distance_CN 3;
+}
+
+object overhead_line_conductor {
+    name overhead_line_conductor_1;
+    geometric_mean_radius 0.0271;
+    resistance 0.0369;
+}
+
+// Line, load, and meter 1
+object overhead_line {
+    name ol_1;
+    phases ABCN;
+    from substation_node;
+    to meter_1;
+    length 606.04;
+    configuration overhead_line_1;
+}
+
+object load {
+	phases ABCN;
+	name load_1;
+	parent meter_1;
+	base_power_A 120000;
+	base_power_B 130000;
+	base_power_C 110000;
+	power_pf_A 0.98;
+	current_pf_A 0.92;
+	impedance_pf_A 0.95;
+	power_fraction_A 0.8;
+	current_fraction_A 0.15;
+	impedance_fraction_A 0.05;
+	power_pf_B 0.98;
+	current_pf_B 0.92;
+	impedance_pf_B 0.95;
+	power_fraction_B 0.1;
+	current_fraction_B 0.3;
+	impedance_fraction_B 0.6;
+	power_pf_C 0.98;
+	current_pf_C 0.92;
+	impedance_pf_C 0.95;
+	power_fraction_C 0.5;
+	current_fraction_C 0.1;
+	impedance_fraction_C 0.4;
+	nominal_voltage 7200;
+}
+
+object meter {
+	name meter_1;
+	phases ABCN;
+	nominal_voltage 7200;
+	groupid meter_group;
+}
+
+// Line, load, and meter 2
+object overhead_line {
+    name ol_2;
+    phases ABCN;
+    from substation_node;
+    to meter_2;
+    length 1606.04;
+    configuration overhead_line_1;
+}
+
+object load {
+	phases ABCN;
+	name load_2;
+	parent meter_2;
+	base_power_A 130000;
+	base_power_B 110000;
+	base_power_C 120000;
+	power_pf_A 0.98;
+	current_pf_A 0.92;
+	impedance_pf_A 0.95;
+	power_fraction_A 0.8;
+	current_fraction_A 0.15;
+	impedance_fraction_A 0.05;
+	power_pf_B 0.98;
+	current_pf_B 0.92;
+	impedance_pf_B 0.95;
+	power_fraction_B 0.1;
+	current_fraction_B 0.3;
+	impedance_fraction_B 0.6;
+	power_pf_C 0.98;
+	current_pf_C 0.92;
+	impedance_pf_C 0.95;
+	power_fraction_C 0.5;
+	current_fraction_C 0.1;
+	impedance_fraction_C 0.4;
+	nominal_voltage 7200;
+}
+
+object meter {
+	name meter_2;
+	phases ABCN;
+	nominal_voltage 7200;
+	groupid meter_group;
+}
+
+// Line, load, and meter 3
+object overhead_line {
+    name ol_3;
+    phases ABCN;
+    from substation_node;
+    to meter_3;
+    length 66.04;
+    configuration overhead_line_1;
+}
+
+object load {
+	phases ABCN;
+	name load_3;
+	parent meter_3;
+	base_power_A 110000;
+	base_power_B 120000;
+	base_power_C 130000;
+	power_pf_A 0.98;
+	current_pf_A 0.92;
+	impedance_pf_A 0.95;
+	power_fraction_A 0.8;
+	current_fraction_A 0.15;
+	impedance_fraction_A 0.05;
+	power_pf_B 0.98;
+	current_pf_B 0.92;
+	impedance_pf_B 0.95;
+	power_fraction_B 0.1;
+	current_fraction_B 0.3;
+	impedance_fraction_B 0.6;
+	power_pf_C 0.98;
+	current_pf_C 0.92;
+	impedance_pf_C 0.95;
+	power_fraction_C 0.5;
+	current_fraction_C 0.1;
+	impedance_fraction_C 0.4;
+	nominal_voltage 7200;
+}
+
+object meter {
+	name meter_3;
+	phases ABCN;
+	nominal_voltage 7200;
+	groupid meter_group;
+}
+// Neither group recorder has a table or file name
+// Group recorders
+//voltage
+object group_recorder {
+  interval 3600;
+  group "groupid=meter_group";
+  property measured_voltage_A;
+  mode "w";
+};
+//current
+object group_recorder {
+  interval 3600;
+  group "groupid=meter_group";
+  property measured_current_C;
+  mode "w";
+};
+
+#endif

--- a/mysql/autotest/test_mysql_group_recorder_2_err.glm
+++ b/mysql/autotest/test_mysql_group_recorder_2_err.glm
@@ -4,9 +4,13 @@
 #set profiler=1
 
 module mysql;
-object database {
-   options NEWDB;
-//   port 3307;
+object database {   
+   hostname "localhost";
+   username "gridlabd";
+   password "";
+   schema "gridlabd";
+   port 3306;
+   tz_offset 0;
 }
 module powerflow {
 	solver_method NR;

--- a/mysql/autotest/test_mysql_group_recorder_2_err.glm
+++ b/mysql/autotest/test_mysql_group_recorder_2_err.glm
@@ -1,0 +1,200 @@
+// Simple model with three loads for testing mysql group_recorder
+#ifdef MYSQL
+
+#set profiler=1
+
+module mysql;
+object database {
+   options NEWDB;
+//   port 3307;
+}
+module powerflow {
+	solver_method NR;
+};
+
+clock {
+	timezone PST+8PDT;
+	starttime '2001-01-01 00:00:00';
+	stoptime '2001-01-02 00:00:00';
+}
+
+// swing node
+object meter {
+	name substation_node;
+	phases ABCN;
+	nominal_voltage 7200;
+	bustype SWING;
+}
+
+// line configuration objects
+object line_configuration {
+    name overhead_line_1;
+    conductor_A overhead_line_conductor_1;
+    conductor_B overhead_line_conductor_1;
+    conductor_C overhead_line_conductor_1;
+    conductor_N overhead_line_conductor_1;
+    spacing line_spacing_1;
+}
+
+object line_spacing {
+    name line_spacing_1;
+    distance_AB 4;
+    distance_BC 4;
+    distance_AC 4;
+    distance_AN 3;
+    distance_BN 3;
+    distance_CN 3;
+}
+
+object overhead_line_conductor {
+    name overhead_line_conductor_1;
+    geometric_mean_radius 0.0271;
+    resistance 0.0369;
+}
+
+// Line, load, and meter 1
+object overhead_line {
+    name ol_1;
+    phases ABCN;
+    from substation_node;
+    to meter_1;
+    length 606.04;
+    configuration overhead_line_1;
+}
+
+object load {
+	phases ABCN;
+	name load_1;
+	parent meter_1;
+	base_power_A 120000;
+	base_power_B 130000;
+	base_power_C 110000;
+	power_pf_A 0.98;
+	current_pf_A 0.92;
+	impedance_pf_A 0.95;
+	power_fraction_A 0.8;
+	current_fraction_A 0.15;
+	impedance_fraction_A 0.05;
+	power_pf_B 0.98;
+	current_pf_B 0.92;
+	impedance_pf_B 0.95;
+	power_fraction_B 0.1;
+	current_fraction_B 0.3;
+	impedance_fraction_B 0.6;
+	power_pf_C 0.98;
+	current_pf_C 0.92;
+	impedance_pf_C 0.95;
+	power_fraction_C 0.5;
+	current_fraction_C 0.1;
+	impedance_fraction_C 0.4;
+	nominal_voltage 7200;
+}
+
+object meter {
+	name meter_1;
+	phases ABCN;
+	nominal_voltage 7200;
+	groupid meter_group;
+}
+
+// Line, load, and meter 2
+object overhead_line {
+    name ol_2;
+    phases ABCN;
+    from substation_node;
+    to meter_2;
+    length 1606.04;
+    configuration overhead_line_1;
+}
+
+object load {
+	phases ABCN;
+	name load_2;
+	parent meter_2;
+	base_power_A 130000;
+	base_power_B 110000;
+	base_power_C 120000;
+	power_pf_A 0.98;
+	current_pf_A 0.92;
+	impedance_pf_A 0.95;
+	power_fraction_A 0.8;
+	current_fraction_A 0.15;
+	impedance_fraction_A 0.05;
+	power_pf_B 0.98;
+	current_pf_B 0.92;
+	impedance_pf_B 0.95;
+	power_fraction_B 0.1;
+	current_fraction_B 0.3;
+	impedance_fraction_B 0.6;
+	power_pf_C 0.98;
+	current_pf_C 0.92;
+	impedance_pf_C 0.95;
+	power_fraction_C 0.5;
+	current_fraction_C 0.1;
+	impedance_fraction_C 0.4;
+	nominal_voltage 7200;
+}
+
+object meter {
+	name meter_2;
+	phases ABCN;
+	nominal_voltage 7200;
+	groupid meter_group;
+}
+
+// Line, load, and meter 3
+object overhead_line {
+    name ol_3;
+    phases ABCN;
+    from substation_node;
+    to meter_3;
+    length 66.04;
+    configuration overhead_line_1;
+}
+
+object load {
+	phases ABCN;
+	name load_3;
+	parent meter_3;
+	base_power_A 110000;
+	base_power_B 120000;
+	base_power_C 130000;
+	power_pf_A 0.98;
+	current_pf_A 0.92;
+	impedance_pf_A 0.95;
+	power_fraction_A 0.8;
+	current_fraction_A 0.15;
+	impedance_fraction_A 0.05;
+	power_pf_B 0.98;
+	current_pf_B 0.92;
+	impedance_pf_B 0.95;
+	power_fraction_B 0.1;
+	current_fraction_B 0.3;
+	impedance_fraction_B 0.6;
+	power_pf_C 0.98;
+	current_pf_C 0.92;
+	impedance_pf_C 0.95;
+	power_fraction_C 0.5;
+	current_fraction_C 0.1;
+	impedance_fraction_C 0.4;
+	nominal_voltage 7200;
+}
+
+object meter {
+	name meter_3;
+	phases ABCN;
+	nominal_voltage 7200;
+	groupid meter_group;
+}
+// Neither group recorder has a table or file name
+// Group recorders
+//voltage
+object group_recorder {
+  interval 3600;
+  group "groupid=meter_group";
+  property 0_measured_voltage_A;
+  table Voltage_A;
+  mode "w";
+};
+
+#endif

--- a/mysql/autotest/test_mysql_player.glm
+++ b/mysql/autotest/test_mysql_player.glm
@@ -22,9 +22,14 @@ clock {
 module mysql;
 object database {
 	// use defaults as though replacing a tape module
-	on_init ../test_mysql_player_init.sql;
-	options NEWDB;
-	clientflags LOCAL_FILES;
+   on_init ../test_mysql_player_init.sql;
+   hostname "localhost";
+   username "gridlabd";
+   password "";
+   schema "gridlabd";
+   port 3306;
+   tz_offset 0;
+   clientflags LOCAL_FILES;
 }
 
 class test {

--- a/mysql/autotest/test_mysql_recorder.glm
+++ b/mysql/autotest/test_mysql_recorder.glm
@@ -25,8 +25,13 @@ object database {
 	on_init "../test_mysql_recorder_init.sql";
 	on_sync "../test_mysql_recorder_sync.sql";
 	on_term "../test_mysql_recorder_term.sql";
-	sync_interval 1 day;
-	options NEWDB;
+	sync_interval 1 day; 
+   hostname "localhost";
+   username "gridlabd";
+   password "";
+   schema "gridlabd";
+   port 3306;
+   tz_offset 0;
 }
 
 class test {

--- a/mysql/autotest/test_mysql_recorder_properties.glm
+++ b/mysql/autotest/test_mysql_recorder_properties.glm
@@ -196,10 +196,10 @@ object meter {
 object recorder {
   parent meter_3;
   interval 30;
-  property "voltage_A.real", "voltage_A.imag", "voltage_B";
+  property "voltage_A.real", "voltage_A.imag[V]", "voltage_B";
   file property_test_1;
   mode "w+";
-  options UNITS|PURGE;
+  options UNITS;
   query_buffer_limit 500;
 };
 
@@ -210,8 +210,18 @@ object recorder {
   file property_test_2;
   header_fieldnames "name";
   mode "w+";
-  options UNITS|PURGE;
+  options UNITS;
     query_buffer_limit 500;
+};
+
+object recorder {
+  group "groupid=meter_group";
+  interval 30;
+  property "voltage_A.real","voltage_A.imag","voltage_B";
+  file property_group_test;
+  mode "w+";
+  options UNITS;
+    query_buffer_limit 2000;
 };
 
 #endif

--- a/mysql/autotest/test_mysql_recorder_properties.glm
+++ b/mysql/autotest/test_mysql_recorder_properties.glm
@@ -1,0 +1,217 @@
+// Simple model with three loads for testing mysql group_recorder
+#ifdef MYSQL
+
+#set profiler=1
+
+module mysql;
+object database {   
+   hostname "localhost";
+   username "gridlabd";
+   password "";
+   schema "gridlabd";
+   port 3306;
+   tz_offset 0;
+}
+module powerflow {
+	solver_method NR;
+};
+
+clock {
+	timezone PST+8PDT;
+	starttime '2001-01-01 00:00:00';
+	stoptime '2001-01-02 00:00:00';
+}
+
+// swing node
+object meter {
+	name substation_node;
+	phases ABCN;
+	nominal_voltage 7200;
+	bustype SWING;
+}
+
+// line configuration objects
+object line_configuration {
+    name overhead_line_1;
+    conductor_A overhead_line_conductor_1;
+    conductor_B overhead_line_conductor_1;
+    conductor_C overhead_line_conductor_1;
+    conductor_N overhead_line_conductor_1;
+    spacing line_spacing_1;
+}
+
+object line_spacing {
+    name line_spacing_1;
+    distance_AB 4;
+    distance_BC 4;
+    distance_AC 4;
+    distance_AN 3;
+    distance_BN 3;
+    distance_CN 3;
+}
+
+object overhead_line_conductor {
+    name overhead_line_conductor_1;
+    geometric_mean_radius 0.0271;
+    resistance 0.0369;
+}
+
+// Line, load, and meter 1
+object overhead_line {
+    name ol_1;
+    phases ABCN;
+    from substation_node;
+    to meter_1;
+    length 606.04;
+    configuration overhead_line_1;
+}
+
+object load {
+	phases ABCN;
+	name load_1;
+	parent meter_1;
+	base_power_A 120000;
+	base_power_B 130000;
+	base_power_C 110000;
+	power_pf_A 0.98;
+	current_pf_A 0.92;
+	impedance_pf_A 0.95;
+	power_fraction_A 0.8;
+	current_fraction_A 0.15;
+	impedance_fraction_A 0.05;
+	power_pf_B 0.98;
+	current_pf_B 0.92;
+	impedance_pf_B 0.95;
+	power_fraction_B 0.1;
+	current_fraction_B 0.3;
+	impedance_fraction_B 0.6;
+	power_pf_C 0.98;
+	current_pf_C 0.92;
+	impedance_pf_C 0.95;
+	power_fraction_C 0.5;
+	current_fraction_C 0.1;
+	impedance_fraction_C 0.4;
+	nominal_voltage 7200;
+}
+
+object meter {
+	name meter_1;
+	phases ABCN;
+	nominal_voltage 7200;
+	groupid meter_group;
+}
+
+// Line, load, and meter 2
+object overhead_line {
+    name ol_2;
+    phases ABCN;
+    from substation_node;
+    to meter_2;
+    length 1606.04;
+    configuration overhead_line_1;
+}
+
+object load {
+	phases ABCN;
+	name load_2;
+	parent meter_2;
+	base_power_A 130000;
+	base_power_B 110000;
+	base_power_C 120000;
+	power_pf_A 0.98;
+	current_pf_A 0.92;
+	impedance_pf_A 0.95;
+	power_fraction_A 0.8;
+	current_fraction_A 0.15;
+	impedance_fraction_A 0.05;
+	power_pf_B 0.98;
+	current_pf_B 0.92;
+	impedance_pf_B 0.95;
+	power_fraction_B 0.1;
+	current_fraction_B 0.3;
+	impedance_fraction_B 0.6;
+	power_pf_C 0.98;
+	current_pf_C 0.92;
+	impedance_pf_C 0.95;
+	power_fraction_C 0.5;
+	current_fraction_C 0.1;
+	impedance_fraction_C 0.4;
+	nominal_voltage 7200;
+}
+
+object meter {
+	name meter_2;
+	phases ABCN;
+	nominal_voltage 7200;
+	groupid meter_group;
+}
+
+// Line, load, and meter 3
+object overhead_line {
+    name ol_3;
+    phases ABCN;
+    from substation_node;
+    to meter_3;
+    length 66.04;
+    configuration overhead_line_1;
+}
+
+object load {
+	phases ABCN;
+	name load_3;
+	parent meter_3;
+	base_power_A 110000;
+	base_power_B 120000;
+	base_power_C 130000;
+	power_pf_A 0.98;
+	current_pf_A 0.92;
+	impedance_pf_A 0.95;
+	power_fraction_A 0.8;
+	current_fraction_A 0.15;
+	impedance_fraction_A 0.05;
+	power_pf_B 0.98;
+	current_pf_B 0.92;
+	impedance_pf_B 0.95;
+	power_fraction_B 0.1;
+	current_fraction_B 0.3;
+	impedance_fraction_B 0.6;
+	power_pf_C 0.98;
+	current_pf_C 0.92;
+	impedance_pf_C 0.95;
+	power_fraction_C 0.5;
+	current_fraction_C 0.1;
+	impedance_fraction_C 0.4;
+	nominal_voltage 7200;
+}
+
+object meter {
+	name meter_3;
+	phases ABCN;
+	nominal_voltage 7200;
+	groupid meter_group;
+}
+
+// Group recorders
+// energy
+object recorder {
+  parent meter_3;
+  interval 30;
+  property "voltage_A.real", "voltage_A.imag", "voltage_B";
+  file property_test_1;
+  mode "w+";
+  options UNITS|PURGE;
+  query_buffer_limit 500;
+};
+
+object recorder {
+  parent meter_3;
+  interval 30;
+  property "voltage_A", "voltage_B";
+  file property_test_2;
+  header_fieldnames "name";
+  mode "w+";
+  options UNITS|PURGE;
+    query_buffer_limit 500;
+};
+
+#endif

--- a/mysql/database.cpp
+++ b/mysql/database.cpp
@@ -241,7 +241,7 @@ bool database::table_exists(char *t)
 	return false;
 }
 
-char *database::get_sqltype(gld_property &prop)
+const char *database::get_sqltype(gld_property &prop)
 {
 	switch ( prop.get_type() ) {
 	case PT_double:
@@ -263,7 +263,8 @@ char *database::get_sqltype(gld_property &prop)
 	case PT_char1024:
 		return "TEXT(1024)";
 	case PT_complex:
-		return "CHAR(40)";
+		// special handling for complex
+		return (prop.get_partname()[0] != '\0') ?	"DOUBLE" : "CHAR(40)";
 	case PT_set:
 		return "LARGETEXT";
 	case PT_bool:
@@ -339,6 +340,11 @@ char *database::get_sqldata(char *buffer, size_t size, gld_property &prop, gld_u
 		else
 			sprintf(buffer,"%g",prop.get_double());
 		return buffer;
+	case PT_complex:
+		if(prop.get_partname()[0] != '\0'){
+			sprintf(buffer, "%f", prop.get_part(prop.get_partname()));
+			return buffer;
+		}
 	}
 	char tmp[65536];
 	if ( prop.to_string(tmp,sizeof(tmp))<size )

--- a/mysql/database.cpp
+++ b/mysql/database.cpp
@@ -381,7 +381,6 @@ bool database::query(const char *command)
 	check_schema();
 	if ( mysql_query(mysql,command)!=0 )
 		exception("%s->query[%s] failed - %s", get_name(), buffer, mysql_error(mysql));
-//		exception("%s->query[%s] failed - %s", get_name(), command, mysql_error(mysql));
 	else if ( get_options()&DBO_SHOWQUERY )
 		gl_verbose("%s->query[%s] ok", get_name(), command);
 

--- a/mysql/database.cpp
+++ b/mysql/database.cpp
@@ -370,8 +370,10 @@ bool database::query(char *fmt,...)
 bool database::query(const char *command)
 {
 	// this fixes an issue where it would blind seg-fault on very large queries.
+	int command_length = strlen(command);
+	if(command_length > 1023){command_length = 1023;}
 	char buffer[1024];
-	memcpy( buffer, command, 1023 );
+	memcpy( buffer, command, command_length );
 	buffer[1023] = '\0';
 
 	// query mysql

--- a/mysql/database.h
+++ b/mysql/database.h
@@ -114,7 +114,7 @@ public:
 #define TD_BACKUP 0x0002 ///< table dump is formatted as SQL backup dump
 	size_t dump(char *table, char *file=NULL, unsigned long options=0x0000);
 
-	char *get_sqltype(gld_property &p);
+	const char *get_sqltype(gld_property &p);
 	char *get_sqldata(char *buffer, size_t size, gld_property &p, double scale=1.0);
 	char *get_sqldata(char *buffer, size_t size, gld_property &p, gld_unit *unit=NULL);
 	bool get_sqlbind(MYSQL_BIND &value,gld_property &target, my_bool *error=NULL);

--- a/mysql/database.h
+++ b/mysql/database.h
@@ -8,6 +8,7 @@
 #define _DATABASE_H
 
 #include "gridlabd.h"
+#include "property.h"
 
 #ifdef WIN32
 #undef int64
@@ -34,6 +35,9 @@
 #define EXTERN extern
 #define INIT(A)
 #endif
+
+typedef enum {VT_INTEGER, VT_DOUBLE, VT_STRING} VARIABLETYPE;
+typedef enum e_complex_part {NONE = 0x00, REAL=0x01, IMAG=0x02, MAG=0x04, ANG=0x08, ANG_RAD=0x10} CPLPT;
 
 EXTERN char default_hostname[256] INIT("127.0.0.1");
 EXTERN char default_username[32] INIT("gridlabd");
@@ -100,6 +104,7 @@ public:
 	const char *get_last_error(void);
 	bool table_exists(char *table);
 	bool query(char *query,...);
+	bool query(const char *query);
 	unsigned int64 get_last_index(void);
 	MYSQL_RES *select(char *query,...);
 	MYSQL_RES get_next(MYSQL_RES*res);
@@ -121,6 +126,7 @@ public:
 
 EXTERN database *last_database INIT(NULL);
 
+#include "group_recorder.h"
 #include "recorder.h"
 #include "player.h"
 #include "collector.h"

--- a/mysql/group_recorder.cpp
+++ b/mysql/group_recorder.cpp
@@ -522,7 +522,7 @@ int group_recorder::build_row(TIMESTAMP t1) {
 		// get value as a complex
 		cptr = gl_get_complex(curr->obj, &(curr->prop));
 		if (0 == cptr) {
-			gl_error("group_recorder::read_line(): unable to get complex property '%s' from object '%s'", curr->prop.name, gl_name(curr->obj, objname, 127));
+			gl_error("group_recorder::build_row(): unable to get complex property '%s' from object '%s'", curr->prop.name, gl_name(curr->obj, objname, 127));
 			/* TROUBLESHOOT
 			 Could not read a complex property as a complex value.
 			 */
@@ -579,7 +579,7 @@ int group_recorder::build_row(TIMESTAMP t1) {
 		} else {
 			size_t offset = gl_get_value(curr->obj, GETADDR(curr->obj, &(curr->prop)), buffer, 127, &(curr->prop));
 			if (0 == offset) {
-				gl_error("group_recorder::read_line(): unable to get value for '%s' in object '%s'", curr->prop.name, curr->obj->name);
+				gl_error("group_recorder::build_row(): unable to get value for '%s' in object '%s'", curr->prop.name, curr->obj->name);
 				/* TROUBLESHOOT
 				 An error occured while reading the specified property in one of the objects.
 				 */

--- a/mysql/group_recorder.cpp
+++ b/mysql/group_recorder.cpp
@@ -1,6 +1,7 @@
 #include "group_recorder.h"
 #include <sstream>
 #include <iostream>
+#include <algorithm>
 
 #ifdef HAVE_MYSQL
 
@@ -45,20 +46,22 @@ group_recorder::group_recorder(MODULE *mod) {
 				PT_char1024, "file", PADDR(table), PT_DESCRIPTION, "output file name (legacy compatibility, applied to table field)",
 				PT_char1024, "table", PADDR(table), PT_DESCRIPTION, "database table name",
 				PT_char1024, "group", PADDR(group_def), PT_DESCRIPTION, "group definition string",
-				PT_bool, "strict", PADDR(strict), PT_DESCRIPTION, "causes the group_recorder to stop the simulation should there be a problem opening or writing with the group_recorder",
-//				PT_bool, "print_units", PADDR(print_units), PT_DESCRIPTION, "flag to append units to each written value, if applicable", // TODO: figure out how to meaningfully restore this functionality
+				PT_bool, "strict", PADDR(strict), PT_DESCRIPTION, "causes the group_recorder to stop the simulation should there be a problem communicating with the database",
+				PT_bool, "print_units", PADDR(print_units), PT_DESCRIPTION, "flag to record units for each written object, if applicable",
 				PT_char256, "property", PADDR(property_name), PT_DESCRIPTION, "property to record",
 				PT_int32, "limit", PADDR(limit), PT_DESCRIPTION, "the maximum number of lines to write to the database",
-				PT_object, "connection", PADDR(connection), PT_DESCRIPTION, "database connection",
-				PT_set, "options", PADDR(options), PT_DESCRIPTION, "SQL options",
 				PT_char32, "mode", PADDR(mode), PT_DESCRIPTION, "table output mode",
 				PT_int32, "query_buffer_limit", PADDR(query_buffer_limit), PT_DESCRIPTION, "max number of queries to buffer before pushing to database",
-				PT_int32, "formatter_limit", PADDR(formatter_limit), PT_DESCRIPTION, "maximum string length of an individual query segment",
 				PT_int32, "column_limit", PADDR(column_limit), PT_DESCRIPTION, "maximum number of columns per MySQL table (default 200)",
 				PT_char32, "datetime_fieldname", PADDR(datetime_fieldname), PT_DESCRIPTION, "name of date-time field",
 				PT_char32, "recordid_fieldname", PADDR(recordid_fieldname), PT_DESCRIPTION, "name of record-id field",
-				PT_char256, "complex_part", PADDR(complex_part), PT_DESCRIPTION, "the complex part(s) to record if complex properties are gathered (default REAL|IMAG)",
+				PT_char256, "complex_part[s]", PADDR(complex_part), PT_DESCRIPTION, "the complex part(s) to record if complex properties are gathered (default REAL|IMAG)",
 				PT_char256, "data_type", PADDR(data_type), PT_DESCRIPTION, "the data format MySQL should use to store the values (default is DOUBLE with no precision set). Acceptable types are DECIMAL(M,D), FLOAT(M,D), and DOUBLE(M,D)",
+				PT_double, "interval[s]", PADDR(dInterval), PT_DESCRIPTION, "recording interval (0 'every iteration', -1 'on change')",
+
+				// legacy compatibility components.
+				PT_bool, "format", PADDR(format), PT_DESCRIPTION, "(unused) legacy variable for compatibility with tape group_recorder",
+				PT_double, "flush_interval[s]", PADDR(dFlush_interval), PT_DESCRIPTION, "(unused) legacy variable for compatibility with tape group_recorder",
 				NULL) < 1) {
 			; //GL_THROW("unable to publish properties in %s",__FILE__);
 		}
@@ -79,9 +82,8 @@ int group_recorder::create(void) {
 	strcpy(data_type, "DOUBLE");
 	strcpy(complex_part, "REAL|IMAG");
 	query_buffer_limit = 200;
-	formatter_limit = 65535;
 	column_limit = 200;
-
+	print_units = false;
 
 	return 1; /* return 1 on success, 0 on failure */
 }
@@ -91,10 +93,7 @@ int group_recorder::init(OBJECT *obj) {
 
 	// check the connection
 	group_recorder_connection = new query_engine(
-			get_connection() != NULL ? (database*) (get_connection() + 1) : db, get_options(), query_buffer_limit, column_limit);
-
-	if (formatter_limit > 0)
-		group_recorder_connection->set_formatter_max(formatter_limit);
+			get_connection() != NULL ? (database*) (get_connection() + 1) : db, query_buffer_limit, column_limit);
 
 	// check mode
 	if (strlen(mode) > 0) {
@@ -128,6 +127,16 @@ int group_recorder::init(OBJECT *obj) {
 			gl_warning("group_recorder::init(): no group defined");
 			return 1; // nothing more to do
 		}
+	}
+
+	// check valid write interval
+	write_interval = (int64) (dInterval);
+	if (-1 > write_interval) {
+		gl_error("group_recorder::init(): invalid write_interval of %i, must be -1 or greater", write_interval);
+		/* TROUBLESHOOT
+		 The group_recorder interval must be -1, 0, or a positive number of seconds.
+		 */
+		return 0;
 	}
 
 	// build group
@@ -179,7 +188,7 @@ int group_recorder::init(OBJECT *obj) {
 			obj_list->tack(gr_obj, prop_ptr);
 		}
 	}
-//
+
 	// check if we should expunge the units from our copied PROP structs
 	if (!print_units) {
 		quickobjlist *itr = obj_list;
@@ -188,25 +197,21 @@ int group_recorder::init(OBJECT *obj) {
 		}
 	}
 
-//	tape_status = TS_OPEN;
 	if (0 == write_header()) {
 		gl_error("group_recorder::init(): an error occured when writing the file header");
 		/* TROUBLESHOOT
 		 Unexpected IO error.
 		 */
-//		tape_status = TS_ERROR;
 		return 0;
 	}
 
 	return 1;
-//	}
 }
 
 TIMESTAMP group_recorder::postsync(TIMESTAMP t0, TIMESTAMP t1) {
-	// if eventful interval, read
-	if (0 == write_interval) {	//
+	if (0 == write_interval) {
 		if (0 == build_row(t1)) {
-			gl_error("group_recorder::commit(): error building query");
+			gl_error("group_recorder::postsync(): error building query");
 			return 0;
 		}
 	} else if (0 < write_interval) {
@@ -220,13 +225,6 @@ TIMESTAMP group_recorder::postsync(TIMESTAMP t0, TIMESTAMP t1) {
 	} else {
 		// on-change intervals simply short-circuit
 		return TS_NEVER;
-	}
-	// if every iteration, write
-	if (0 == write_interval) {
-		if (0 == build_row(t1)) {
-			gl_error("group_recorder::commit(): error building query");
-			return 0;
-		}
 	}
 
 	// the interval recorders have already return'ed out, earlier in the sequence.
@@ -304,6 +302,8 @@ int group_recorder::write_header() {
 		set complex_part_buffer = 0x00;
 
 		for (size_t n = 0; n < complex_part_vector.size(); n++) {
+			std::transform(complex_part_vector[n].begin(), complex_part_vector[n].end(), complex_part_vector[n].begin(), std::ptr_fun<
+					int, int>(std::toupper));
 			if (complex_part_vector[n].compare("REAL") == 0)
 				complex_part_buffer += 0x01;
 			else if (complex_part_vector[n].compare("IMAG") == 0)
@@ -317,68 +317,112 @@ int group_recorder::write_header() {
 		}
 
 		for (qol = obj_list; qol != 0; qol = qol->next) {
+			gld_property target_prop(qol->obj, &(qol->prop));
+			if (!target_prop.is_valid())
+			{
+				gl_error("%s: target %s is not valid", &(qol->prop), get_name());
+				/*  TROUBLESHOOT
+				 Check to make sure the target you are specifying is a published variable for the object
+				 that you are pointing to.  Refer to the documentation of the command flag --modhelp, or
+				 check the wiki page to determine which variables can be published within the object you
+				 are pointing to with the assert function.
+				 */
+				return 0;
+			}
+
 			stringstream property_name_buffer, property_name_local_buffer;
 			string property_name_string;
 			set compare = 0x01;
 			set complex_part_local_buffer = complex_part_buffer;
 
-			if (0 != qol->obj->name) {
-				property_name_buffer << qol->obj->name;
+			if (0 != target_prop.get_object()->name) {
+				property_name_buffer << target_prop.get_object()->name;
 			} else {
-				property_name_buffer << qol->obj->name << ":" << qol->obj->id;
+				property_name_buffer << target_prop.get_object()->name << ":" << target_prop.get_object()->id;
 			}
 
 			const string property_name_string_buffer = property_name_buffer.str();
-			while (complex_part_local_buffer != NONE) {
-				property_name_local_buffer << property_name_string_buffer;
-				switch (complex_part_local_buffer & compare) {
-					case NONE:
-						default:
-						// FIXME: this is setting and wiping the buffer each iteration. There's definitely a better way.
-						cleanup_property_buffer(&property_name_local_buffer);
-						compare <<= 1;
-						break;
-					case REAL:
-						property_name_string = setup_property_buffer(&property_name_local_buffer, "_REAL");
-						property_list << "`" << property_name_string << "` " << data_type << ", ";
-						grc->get_table_path()->add_table_header(grc, property_list, &property_name_string);
-						complex_part_local_buffer ^= compare;
-						cleanup_property_buffer(&property_name_local_buffer);
-						compare <<= 1;
-						break;
-					case IMAG:
-						property_name_string = setup_property_buffer(&property_name_local_buffer, "_IMAG");
-						property_list << "`" << property_name_string << "` " << data_type << ", ";
-						grc->get_table_path()->add_table_header(grc, property_list, &property_name_string);
-						complex_part_local_buffer ^= compare;
-						cleanup_property_buffer(&property_name_local_buffer);
-						compare <<= 1;
-						break;
-					case MAG:
-						property_name_string = setup_property_buffer(&property_name_local_buffer, "_MAG");
-						property_list << "`" << property_name_string << "` " << data_type << ", ";
-						grc->get_table_path()->add_table_header(grc, property_list, &property_name_string);
-						complex_part_local_buffer ^= compare;
-						cleanup_property_buffer(&property_name_local_buffer);
-						compare <<= 1;
-						break;
-					case ANG:
-						property_name_string = setup_property_buffer(&property_name_local_buffer, "_ANG_DEG");
-						property_list << "`" << property_name_string << "` " << data_type << ", ";
-						grc->get_table_path()->add_table_header(grc, property_list, &property_name_string);
-						complex_part_local_buffer ^= compare;
-						cleanup_property_buffer(&property_name_local_buffer);
-						compare <<= 1;
-						break;
-					case ANG_RAD:
-						property_name_string = setup_property_buffer(&property_name_local_buffer, "_ANG_RAD");
-						property_list << "`" << property_name_string << "` " << data_type << ", ";
-						grc->get_table_path()->add_table_header(grc, property_list, &property_name_string);
-						complex_part_local_buffer ^= compare;
-						cleanup_property_buffer(&property_name_local_buffer);
-						compare <<= 1;
-						break;
+			if (target_prop.is_complex()) {
+				while (complex_part_local_buffer != NONE) {
+					property_name_local_buffer << property_name_string_buffer;
+					switch (complex_part_local_buffer & compare) {
+						case NONE:
+							default:
+							// FIXME: this is setting and wiping the buffer each iteration. There's definitely a better way.
+							cleanup_property_buffer(&property_name_local_buffer);
+							compare <<= 1;
+							break;
+						case REAL:
+							property_name_string = setup_property_buffer(&property_name_local_buffer, "_REAL");
+							property_list << "`" << property_name_string << "` " << data_type << ", ";
+							grc->get_table_path()->add_table_header(grc, property_list, &property_name_string, target_prop.get_unit()->get_name());
+							complex_part_local_buffer ^= compare;
+							cleanup_property_buffer(&property_name_local_buffer);
+							compare <<= 1;
+							break;
+						case IMAG:
+							property_name_string = setup_property_buffer(&property_name_local_buffer, "_IMAG");
+							property_list << "`" << property_name_string << "` " << data_type << ", ";
+							grc->get_table_path()->add_table_header(grc, property_list, &property_name_string, target_prop.get_unit()->get_name());
+							complex_part_local_buffer ^= compare;
+							cleanup_property_buffer(&property_name_local_buffer);
+							compare <<= 1;
+							break;
+						case MAG:
+							property_name_string = setup_property_buffer(&property_name_local_buffer, "_MAG");
+							property_list << "`" << property_name_string << "` " << data_type << ", ";
+							grc->get_table_path()->add_table_header(grc, property_list, &property_name_string, target_prop.get_unit()->get_name());
+							complex_part_local_buffer ^= compare;
+							cleanup_property_buffer(&property_name_local_buffer);
+							compare <<= 1;
+							break;
+						case ANG:
+							property_name_string = setup_property_buffer(&property_name_local_buffer, "_ANG_DEG");
+							property_list << "`" << property_name_string << "` " << data_type << ", ";
+							grc->get_table_path()->add_table_header(grc, property_list, &property_name_string, target_prop.get_unit()->get_name());
+							complex_part_local_buffer ^= compare;
+							cleanup_property_buffer(&property_name_local_buffer);
+							compare <<= 1;
+							break;
+						case ANG_RAD:
+							property_name_string = setup_property_buffer(&property_name_local_buffer, "_ANG_RAD");
+							property_list << "`" << property_name_string << "` " << data_type << ", ";
+							grc->get_table_path()->add_table_header(grc, property_list, &property_name_string, target_prop.get_unit()->get_name());
+							complex_part_local_buffer ^= compare;
+							cleanup_property_buffer(&property_name_local_buffer);
+							compare <<= 1;
+							break;
+					}
 				}
+			} else {
+				property_name_local_buffer << property_name_string_buffer;
+				property_name_string = setup_property_buffer(&property_name_local_buffer, "");
+				if (target_prop.is_double()) {
+					property_list << "`" << property_name_string << "` " << data_type << ", ";
+					grc->get_table_path()->add_table_header(grc, property_list, &property_name_string, target_prop.get_unit()->get_name());
+				} else if (target_prop.is_integer()) {
+					property_list << "`" << property_name_string << "` " << "BIGINT, ";
+					grc->get_table_path()->add_table_header(grc, property_list, &property_name_string, target_prop.get_unit()->get_name());
+				} else if (target_prop.is_enumeration()) {
+					property_list << "`" << property_name_string << "` " << "INTEGER UNSIGNED, ";
+					grc->get_table_path()->add_table_header(grc, property_list, &property_name_string, target_prop.get_unit()->get_name());
+				} else if (target_prop.is_set()) {
+					property_list << "`" << property_name_string << "` " << "BIGINT UNSIGNED, ";
+					grc->get_table_path()->add_table_header(grc, property_list, &property_name_string, target_prop.get_unit()->get_name());
+				}
+				//				else if (target_prop.is_character()) { // TODO: Identify element of gld_property we want saved in this case.
+//					property_list << "`" << property_name_string << "` " << "VARCHAR(256), ";
+//					grc->get_table_path()->add_table_header(grc, property_list, &property_name_string, target_prop.get_unit()->get_name());
+//				}
+				else {
+					if (strict) {
+						gl_error("group_recorder::write_header(): property is not an allowed type");
+						return 0;
+					}
+					gl_warning("group_recorder::write_header(): property is not an allowed type");
+					return 1;
+				}
+				cleanup_property_buffer(&property_name_local_buffer);
 			}
 		}
 
@@ -407,7 +451,7 @@ int group_recorder::write_header() {
 					"INDEX `i_" << datetime_fieldname << "` "
 					"(`" << datetime_fieldname << "`))";
 			if (!db->table_exists(grc->get_table().get_string())) {
-				if (!(options & MO_NOCREATE)) {
+				if (!(get_options() & MO_NOCREATE)) {
 					query_string = query.str();
 					const char* query_char_string = query_string.c_str();
 					if (!db->query(query_char_string))
@@ -433,9 +477,10 @@ int group_recorder::write_header() {
 
 		query << "CREATE TABLE IF NOT EXISTS `" << grc->get_table_references().get_string() << "` ("
 				"`table_name` VARCHAR(256), "
-				"`header` VARCHAR(256));";
+				"`header` VARCHAR(256)" <<
+				(print_units ? ", `units` VARCHAR(64));" : ");");
 		if (!db->table_exists(grc->get_table_references().get_string())) {
-			if (!(options & MO_NOCREATE)) {
+			if (!(get_options() & MO_NOCREATE)) {
 				query_string = query.str();
 				const char* query_char_string = query_string.c_str();
 				if (!db->query(query_char_string))
@@ -454,7 +499,7 @@ int group_recorder::write_header() {
 			gl_verbose("table '%s' ok", grc->get_table_references().get_string());
 		}
 
-		grc->build_table_references();
+		grc->build_table_references(print_units);
 	} else {
 		exception("no property specified");
 		return 0;
@@ -479,6 +524,8 @@ int group_recorder::build_row(TIMESTAMP t1) {
 	set complex_part_buffer = 0x00;
 
 	for (size_t n = 0; n < complex_part_vector.size(); n++) {
+		std::transform(complex_part_vector[n].begin(), complex_part_vector[n].end(), complex_part_vector[n].begin(), std::ptr_fun<
+				int, int>(std::toupper));
 		if (complex_part_vector[n].compare("REAL") == 0)
 			complex_part_buffer += 0x01;
 		else if (complex_part_vector[n].compare("IMAG") == 0)
@@ -492,30 +539,33 @@ int group_recorder::build_row(TIMESTAMP t1) {
 	}
 
 	for (curr = obj_list; curr != 0; curr = curr->next) {
+
+		gld_property target_prop(curr->obj, &(curr->prop));
+		if (!target_prop.is_valid())
+		{
+			gl_error("%s: target %s is not valid", &(curr->prop), get_name());
+			/*  TROUBLESHOOT
+			 Check to make sure the target you are specifying is a published variable for the object
+			 that you are pointing to.  Refer to the documentation of the command flag --modhelp, or
+			 check the wiki page to determine which variables can be published within the object you
+			 are pointing to with the assert function.
+			 */
+			return 0;
+		}
+
 		set compare = 0x01;
 		set complex_part_local_buffer = complex_part_buffer;
 		stringstream property_name_buffer, property_name_local_buffer;
 		string property_name_string;
 
-		if (0 != curr->obj->name) {
-			property_name_buffer << curr->obj->name;
+		if (0 != target_prop.get_object()->name) {
+			property_name_buffer << target_prop.get_object()->name;
 		} else {
-			property_name_buffer << curr->obj->name << ":" << curr->obj->id;
+			property_name_buffer << target_prop.get_object()->name << ":" << target_prop.get_object()->id;
 		}
 
-		// TODO: update to gld_property type
-		complex *cptr = 0;
-		// get value as a complex
-		cptr = gl_get_complex(curr->obj, &(curr->prop));
-		if (0 == cptr) {
-			gl_error("group_recorder::build_row(): unable to get complex property '%s' from object '%s'", curr->prop.name, gl_name(curr->obj, objname, 127));
-			/* TROUBLESHOOT
-			 Could not read a complex property as a complex value.
-			 */
-			return 0;
-		}
-
-		if (curr->prop.ptype == PT_complex) {
+		if (target_prop.is_complex()) {
+			complex cptr = target_prop.get_complex();
 			while (complex_part_local_buffer != NONE) {
 				property_name_local_buffer << property_name_buffer.str();
 
@@ -527,35 +577,35 @@ int group_recorder::build_row(TIMESTAMP t1) {
 						break;
 					case REAL:
 						property_name_string = setup_property_buffer(&property_name_local_buffer, "_REAL");
-						grc->get_table_path()->add_insert_values(grc, &property_name_string, cptr->Re());
+						grc->get_table_path()->add_insert_values(grc, &property_name_string, to_string(cptr.Re()));
 						complex_part_local_buffer ^= compare;
 						compare <<= 1;
 						cleanup_property_buffer(&property_name_local_buffer);
 						break;
 					case IMAG:
 						property_name_string = setup_property_buffer(&property_name_local_buffer, "_IMAG");
-						grc->get_table_path()->add_insert_values(grc, &property_name_string, cptr->Im());
+						grc->get_table_path()->add_insert_values(grc, &property_name_string, to_string(cptr.Im()));
 						complex_part_local_buffer ^= compare;
 						compare <<= 1;
 						cleanup_property_buffer(&property_name_local_buffer);
 						break;
 					case MAG:
 						property_name_string = setup_property_buffer(&property_name_local_buffer, "_MAG");
-						grc->get_table_path()->add_insert_values(grc, &property_name_string, cptr->Mag());
+						grc->get_table_path()->add_insert_values(grc, &property_name_string, to_string(cptr.Mag()));
 						complex_part_local_buffer ^= compare;
 						compare <<= 1;
 						cleanup_property_buffer(&property_name_local_buffer);
 						break;
 					case ANG:
 						property_name_string = setup_property_buffer(&property_name_local_buffer, "_ANG_DEG");
-						grc->get_table_path()->add_insert_values(grc, &property_name_string, cptr->Arg() * 180 / PI);
+						grc->get_table_path()->add_insert_values(grc, &property_name_string, to_string(cptr.Arg() * 180 / PI));
 						complex_part_local_buffer ^= compare;
 						compare <<= 1;
 						cleanup_property_buffer(&property_name_local_buffer);
 						break;
 					case ANG_RAD:
 						property_name_string = setup_property_buffer(&property_name_local_buffer, "_ANG_RAD");
-						grc->get_table_path()->add_insert_values(grc, &property_name_string, cptr->Arg());
+						grc->get_table_path()->add_insert_values(grc, &property_name_string, to_string(cptr.Arg()));
 						complex_part_local_buffer ^= compare;
 						compare <<= 1;
 						cleanup_property_buffer(&property_name_local_buffer);
@@ -563,14 +613,35 @@ int group_recorder::build_row(TIMESTAMP t1) {
 				}
 			}
 		} else {
-			size_t offset = gl_get_value(curr->obj, GETADDR(curr->obj, &(curr->prop)), buffer, 127, &(curr->prop));
-			if (0 == offset) {
-				gl_error("group_recorder::build_row(): unable to get value for '%s' in object '%s'", curr->prop.name, curr->obj->name);
-				/* TROUBLESHOOT
-				 An error occured while reading the specified property in one of the objects.
-				 */
-				return 0;
+			property_name_local_buffer << property_name_buffer.str();
+			property_name_string = setup_property_buffer(&property_name_local_buffer, "");
+			if (target_prop.is_double()) {
+				double property_value = target_prop.get_double();
+				grc->get_table_path()->add_insert_values(grc, &property_name_string, to_string(property_value));
+			} else if (target_prop.is_integer()) {
+				int property_value = target_prop.get_integer();
+				grc->get_table_path()->add_insert_values(grc, &property_name_string, to_string(property_value));
+			} else if (target_prop.is_enumeration()) {
+				enumeration property_value = target_prop.get_enumeration();
+				grc->get_table_path()->add_insert_values(grc, &property_name_string, to_string(property_value));
+			} else if (target_prop.is_set()) {
+				set property_value = target_prop.get_set();
+				grc->get_table_path()->add_insert_values(grc, &property_name_string, to_string(property_value));
 			}
+			//			else if (target_prop.is_character()) { // TODO: Identify element of gld_property we want saved in this case.
+//				gld_object* property_value = target_prop.get_property();
+//				grc->get_table_path()->add_insert_values(grc, &property_name_string, to_string(property_value));
+//			}
+
+			else {
+				if (strict) {
+					gl_error("group_recorder::build_row(): property is not an allowed type");
+					return 0;
+				}
+				gl_warning("group_recorder::build_row(): property is not an allowed type");
+				return 1;
+			}
+			cleanup_property_buffer(&property_name_local_buffer);
 		}
 	}
 
@@ -579,8 +650,6 @@ int group_recorder::build_row(TIMESTAMP t1) {
 		grc->get_table_path()->flush_value_row(&t1);
 	}
 	write_count++;
-	// assume write_line will add newline character
-
 	return 1;
 }
 
@@ -639,6 +708,15 @@ EXPORT int commit_group_recorder(OBJECT *obj) {
 		gl_error("commit_group_recorder: %s", msg);
 	}
 	return rv;
+}
+
+template<class T> std::string group_recorder::to_string(T t) {
+	std::string returnBuffer;
+	std::ostringstream string_conversion_buffer;
+	string_conversion_buffer.precision(15);
+	string_conversion_buffer << t;
+	returnBuffer = string_conversion_buffer.str();
+	return returnBuffer;
 }
 #endif // HAVE_MYSQL
 // EOF

--- a/mysql/group_recorder.cpp
+++ b/mysql/group_recorder.cpp
@@ -1,0 +1,611 @@
+#include "group_recorder.h"
+#include <sstream>
+#include <iostream>
+
+#ifdef HAVE_MYSQL
+
+#include "database.h"
+#include "query_engine.h"
+
+EXPORT_CREATE(group_recorder);
+EXPORT_INIT(group_recorder);
+
+CLASS *group_recorder::oclass = NULL;
+CLASS *group_recorder::pclass = NULL;
+group_recorder *group_recorder::defaults = NULL;
+using namespace std;
+
+vector<string> split(char* str, const char* delim) {
+	char* saveptr;
+	char* token = strtok_r(str, delim, &saveptr);
+
+	vector<string> result;
+
+	while (token != NULL) {
+		result.push_back(token);
+		token = strtok_r(NULL, delim, &saveptr);
+	}
+	return result;
+}
+
+void new_group_recorder(MODULE *mod) {
+	new group_recorder(mod);
+}
+
+group_recorder::group_recorder(MODULE *mod) {
+	if (oclass == NULL) {
+#ifdef _DEBUG
+		gl_debug("construction group_recorder class");
+#endif
+		oclass = gl_register_class(mod, "group_recorder", sizeof(group_recorder), PC_POSTTOPDOWN);
+		if (oclass == NULL)
+			GL_THROW("unable to register object class implemented by %s", __FILE__);
+
+		if (gl_publish_variable(oclass,
+				PT_char1024, "file", PADDR(table), PT_DESCRIPTION, "output file name (legacy compatibility)",
+				PT_char1024, "table", PADDR(table), PT_DESCRIPTION, "database table name",
+				PT_char1024, "group", PADDR(group_def), PT_DESCRIPTION, "group definition string",
+				PT_double, "interval[s]", PADDR(dInterval), PT_DESCRIPTION, "recording interval (0 'every iteration', -1 'on change')",
+				PT_double, "flush_interval[s]", PADDR(dFlush_interval), PT_DESCRIPTION, "file flush interval (0 never, negative on samples)",
+				PT_bool, "strict", PADDR(strict), PT_DESCRIPTION, "causes the group_recorder to stop the simulation should there be a problem opening or writing with the group_recorder",
+				PT_bool, "print_units", PADDR(print_units), PT_DESCRIPTION, "flag to append units to each written value, if applicable",
+				PT_char256, "property", PADDR(property_name), PT_DESCRIPTION, "property to record",
+				PT_int32, "limit", PADDR(limit), PT_DESCRIPTION, "the maximum number of lines to write to the file",
+				PT_object, "connection", PADDR(connection), PT_DESCRIPTION, "database connection",
+				PT_set, "options", PADDR(options), PT_DESCRIPTION, "SQL options",
+				PT_char32, "mode", PADDR(mode), PT_DESCRIPTION, "table output mode",
+				PT_int32, "query_buffer_limit", PADDR(query_buffer_limit), PT_DESCRIPTION, "max number of queries to buffer before pushing to database",
+				PT_int32, "formatter_limit", PADDR(formatter_limit), PT_DESCRIPTION, "maximum string length of an individual query segment",
+				PT_int32, "column_limit", PADDR(column_limit), PT_DESCRIPTION, "maximum number of columns per MySQL table (default 200)",
+				PT_char32, "datetime_fieldname", PADDR(datetime_fieldname), PT_DESCRIPTION, "name of date-time field",
+				PT_char32, "recordid_fieldname", PADDR(recordid_fieldname), PT_DESCRIPTION, "name of record-id field",
+				PT_char256, "complex_part", PADDR(complex_part), PT_DESCRIPTION, "the complex part(s) to record if complex properties are gathered",
+				PT_char256, "data_type", PADDR(data_type), PT_DESCRIPTION, "the data format MySQL should use to store the values (default is DOUBLE with no precision set). Acceptable types are DECIMAL(M,D), FLOAT(M,D), and DOUBLE(M,D)",
+				NULL) < 1) {
+			; //GL_THROW("unable to publish properties in %s",__FILE__);
+		}
+		defaults = this;
+		memset(this, 0, sizeof(group_recorder));
+	}
+}
+
+int group_recorder::create(void) {
+	memcpy(this, defaults, sizeof(*this));
+	db = last_database;
+	strcpy(datetime_fieldname, "t");
+	strcpy(recordid_fieldname, "id");
+	strcpy(data_type, "DOUBLE");
+	query_buffer_limit = 200;
+	formatter_limit = 65535;
+	column_limit = 200;
+
+	return 1; /* return 1 on success, 0 on failure */
+}
+
+int group_recorder::init(OBJECT *obj) {
+	OBJECT *gr_obj = 0;
+
+	// check the connection
+	group_recorder_connection = new query_engine(
+			get_connection() != NULL ? (database*) (get_connection() + 1) : db, get_options(), query_buffer_limit, column_limit);
+
+	if (formatter_limit > 0)
+		group_recorder_connection->set_formatter_max(formatter_limit);
+
+	// check mode
+	if (strlen(mode) > 0) {
+		options = 0xffffffff;
+		struct {
+				char *str;
+				set bits;
+		} modes[] = { { "r", 0xffff }, { "r+", 0xffff }, { "w", MO_DROPTABLES }, { "w+", MO_DROPTABLES }, { "a", 0x0000 }, { "a+", 0x0000 }, };
+		int n;
+		for (n = 0; n < sizeof(modes) / sizeof(modes[0]); n++) {
+			if (strcmp(mode, modes[n].str) == 0) {
+				options = modes[n].bits;
+				break;
+			}
+		}
+		if (options == 0xffffffff)
+			exception("mode '%s' is not recognized", (const char*) mode);
+		else if (options == 0xffff)
+			exception("mode '%s' is not valid for group recorder", (const char*) mode);
+	}
+
+	// check for group
+	if (0 == group_def[0]) {
+		if (strict) {
+			gl_error("group_recorder::init(): no group defined");
+			/* TROUBLESHOOT
+			 group_recorder must define a group in "group_def".
+			 */
+			return 0;
+		} else {
+			gl_warning("group_recorder::init(): no group defined");
+			return 1; // nothing more to do
+		}
+	}
+
+	// check valid write interval
+	write_interval = (int64) (dInterval);
+	if (-1 > write_interval) {
+		gl_error("group_recorder::init(): invalid write_interval of %i, must be -1 or greater", write_interval);
+		/* TROUBLESHOOT
+		 The group_recorder interval must be -1, 0, or a positive number of seconds.
+		 */
+		return 0;
+	}
+
+	// all flush intervals are valid
+	flush_interval = (int64) dFlush_interval;
+//
+//
+//
+	// build group
+	//	* invariant?
+	//	* non-empty set?
+	items = gl_find_objects(FL_GROUP, group_def.get_string());
+	if (0 == items) {
+		if (strict) {
+			gl_error("group_recorder::init(): unable to construct a set with group definition");
+			/* TROUBLESHOOT
+			 An error occured while attempting to build and populate the find list with the specified group definition.
+			 */
+			return 0;
+		} else {
+			gl_warning("group_recorder::init(): unable to construct a set with group definition");
+			return 1; // nothing more to do
+		}
+	}
+	if (1 > items->hit_count) {
+		if (strict) {
+			gl_error("group_recorder::init(): the defined group returned an empty set");
+			/* TROUBLESHOOT
+			 Placeholder.
+			 */
+			return 0;
+		} else {
+			gl_warning("group_recorder::init(): the defined group returned an empty set");
+			return 1;
+		}
+	}
+
+	// turn list into objlist, count items
+	obj_count = 0;
+	for (gr_obj = gl_find_next(items, 0); gr_obj != 0;
+			gr_obj = gl_find_next(items, gr_obj)) {
+		prop_ptr = gl_get_property(gr_obj, property_name.get_string());
+		// might make this a 'strict-only' issue in the future
+		if (prop_ptr == NULL) {
+			gl_error("group_recorder::init(): unable to find property '%s' in an object of type '%s'", property_name.get_string(), gr_obj->oclass->name);
+			/* TROUBLESHOOT
+			 An error occured while reading the specified property in one of the objects.
+			 */
+			return 0;
+		}
+		++obj_count;
+		if (obj_list == 0) {
+			obj_list = new quickobjlist(gr_obj, prop_ptr);
+		} else {
+			obj_list->tack(gr_obj, prop_ptr);
+		}
+	}
+//
+	// check if we should expunge the units from our copied PROP structs
+	if (!print_units) {
+		quickobjlist *itr = obj_list;
+		for (; itr != 0; itr = itr->next) {
+			itr->prop.unit = NULL;
+		}
+	}
+
+//	tape_status = TS_OPEN;
+	if (0 == write_header()) {
+		gl_error("group_recorder::init(): an error occured when writing the file header");
+		/* TROUBLESHOOT
+		 Unexpected IO error.
+		 */
+//		tape_status = TS_ERROR;
+		return 0;
+	}
+
+	return 1;
+//	}
+}
+
+TIMESTAMP group_recorder::postsync(TIMESTAMP t0, TIMESTAMP t1) {
+	// if eventful interval, read
+	if (0 == write_interval) {	//
+		if (0 == build_row(t1)) {
+			gl_error("group_recorder::commit(): error building query");
+			return 0;
+		}
+	} else if (0 < write_interval) {
+		// recalculate next_time, since we know commit() will fire
+		if (last_write + write_interval <= t1) {
+			interval_write = true;
+			last_write = t1;
+			next_write = t1 + write_interval;
+		}
+		return next_write;
+	} else {
+		// on-change intervals simply short-circuit
+		return TS_NEVER;
+	}
+	// if every iteration, write
+	if (0 == write_interval) {
+		if (0 == build_row(t1)) {
+			gl_error("group_recorder::commit(): error building query");
+			return 0;
+		}
+	}
+
+	// the interval recorders have already return'ed out, earlier in the sequence.
+	return TS_NEVER;
+}
+
+int group_recorder::commit(TIMESTAMP t1) {
+	// if periodic interval, check for write
+	if (write_interval > 0) {
+		if (interval_write) {
+			if (0 == build_row(t1)) {
+				gl_error("group_recorder::commit(): error building query");
+				return 0;
+			}
+			last_write = t1;
+			interval_write = false;
+		}
+	}
+
+	// if every change,
+	//	* compare to last values
+	//	* if different, write
+	if (-1 == write_interval) {
+		if (0 == build_row(t1)) {
+			gl_error("group_recorder::commit(): error building query");
+			return 0;
+		}
+	}
+
+	// check if write limit
+	if (limit > 0 && write_count >= limit) {
+		flush_line();
+		group_recorder_connection->set_tables_done();
+	}
+
+	return 1;
+}
+
+int group_recorder::isa(char *classname) {
+	return (strcmp(classname, oclass->name) == 0);
+}
+
+string setup_property_buffer(stringstream* property_name_buffer, const char* suffix) {
+	ostringstream internal_buffer;
+	internal_buffer << property_name_buffer->str() << suffix;
+	return internal_buffer.str();
+}
+
+void cleanup_property_buffer(stringstream* property_name_buffer) {
+	property_name_buffer->str("");
+	property_name_buffer->clear();
+}
+/**
+ @return 0 on failure, 1 on success
+ **/
+int group_recorder::write_header() {
+	time_t now = time(NULL);
+	quickobjlist *qol = 0;
+	OBJECT *obj = OBJECTHDR(this);
+	query_engine* grc = group_recorder_connection;
+	grc->set_table_root(get_table());
+	grc->init_tables();
+	// check for table existence and create if not found
+	if (get_property_name() > 0) {
+		stringstream property_list;
+
+		char buffer[1024];
+		strcpy(buffer, complex_part);
+		vector<string> complex_part_vector = split(buffer, "|");
+		set complex_part_buffer = 0x00;
+
+		for (size_t n = 0; n < complex_part_vector.size(); n++) {
+			if (complex_part_vector[n].compare("REAL") == 0)
+				complex_part_buffer += 0x01;
+			else if (complex_part_vector[n].compare("IMAG") == 0)
+				complex_part_buffer += 0x02;
+			else if (complex_part_vector[n].compare("MAG") == 0)
+				complex_part_buffer += 0x04;
+			else if (complex_part_vector[n].compare("ANG") == 0)
+				complex_part_buffer += 0x08;
+			else if (complex_part_vector[n].compare("ANG_RAD") == 0)
+				complex_part_buffer += 0x10;
+		}
+
+		for (qol = obj_list; qol != 0; qol = qol->next) {
+			stringstream property_name_buffer, property_name_local_buffer;
+			string property_name_string;
+			set compare = 0x01;
+			set complex_part_local_buffer = complex_part_buffer;
+
+			if (0 != qol->obj->name) {
+				property_name_buffer << qol->obj->name;
+			} else {
+				property_name_buffer << qol->obj->name << ":" << qol->obj->id;
+			}
+
+			const string property_name_string_buffer = property_name_buffer.str();
+			while (complex_part_local_buffer != NONE) { // TODO: allow double/float/decimal
+				property_name_local_buffer << property_name_string_buffer;
+				switch (complex_part_local_buffer & compare) {
+					case NONE:
+						default:
+						// FIXME: this is setting and wiping the buffer each iteration. There's definitely a better way.
+						cleanup_property_buffer(&property_name_local_buffer);
+						compare <<= 1;
+						break;
+					case REAL:
+						property_name_string = setup_property_buffer(&property_name_local_buffer, "_REAL");
+						property_list << "`" << property_name_string << "` " << data_type << ", ";
+						grc->get_table_path()->add_table_header(grc, property_list, &property_name_string);
+						complex_part_local_buffer ^= compare;
+						cleanup_property_buffer(&property_name_local_buffer);
+						compare <<= 1;
+						break;
+					case IMAG:
+						property_name_string = setup_property_buffer(&property_name_local_buffer, "_IMAG");
+						property_list << "`" << property_name_string << "` " << data_type << ", ";
+						grc->get_table_path()->add_table_header(grc, property_list, &property_name_string);
+						complex_part_local_buffer ^= compare;
+						cleanup_property_buffer(&property_name_local_buffer);
+						compare <<= 1;
+						break;
+					case MAG:
+						property_name_string = setup_property_buffer(&property_name_local_buffer, "_MAG");
+						property_list << "`" << property_name_string << "` " << data_type << ", ";
+						grc->get_table_path()->add_table_header(grc, property_list, &property_name_string);
+						complex_part_local_buffer ^= compare;
+						cleanup_property_buffer(&property_name_local_buffer);
+						compare <<= 1;
+						break;
+					case ANG:
+						property_name_string = setup_property_buffer(&property_name_local_buffer, "_ANG_DEG");
+						property_list << "`" << property_name_string << "` " << data_type << ", ";
+						grc->get_table_path()->add_table_header(grc, property_list, &property_name_string);
+						complex_part_local_buffer ^= compare;
+						cleanup_property_buffer(&property_name_local_buffer);
+						compare <<= 1;
+						break;
+					case ANG_RAD:
+						property_name_string = setup_property_buffer(&property_name_local_buffer, "_ANG_RAD");
+						property_list << "`" << property_name_string << "` " << data_type << ", ";
+						grc->get_table_path()->add_table_header(grc, property_list, &property_name_string);
+						complex_part_local_buffer ^= compare;
+						cleanup_property_buffer(&property_name_local_buffer);
+						compare <<= 1;
+						break;
+				}
+			}
+		}
+
+		grc->next_table(); // takes us back to first table group.
+
+		for (int index = 0; index < grc->get_table_count(); index++) {
+			// drop table if exists and drop specified
+			if (db->table_exists(grc->get_table().get_string())) {
+				if (get_options() & MO_DROPTABLES && !db->query("DROP TABLE IF EXISTS `%s`", grc->get_table().get_string()))
+					exception("unable to drop table '%s'", grc->get_table().get_string());
+			}
+
+			// create table if not exists
+			ostringstream query;
+			string query_string;
+
+			query << "CREATE TABLE IF NOT EXISTS `" << grc->get_table().get_string() << "` ("
+					"`" << recordid_fieldname << "` INT AUTO_INCREMENT PRIMARY KEY, "
+					"`" << datetime_fieldname << "` DATETIME, "
+					"" << grc->get_table_path()->get_table_header_buffer().str() << ""
+					"INDEX `i_" << datetime_fieldname << "` "
+					"(`" << datetime_fieldname << "`))";
+			if (!db->table_exists(grc->get_table().get_string())) {
+				if (!(options & MO_NOCREATE)) {
+					query_string = query.str();
+					const char* query_char_string = query_string.c_str();
+					if (!db->query(query_char_string))
+						exception("unable to create table '%s' in schema '%s'", get_table(), db->get_schema());
+					else
+						gl_verbose("table %s created ok", grc->get_table().get_string());
+				} else
+					exception("NOCREATE option prevents creation of table '%s'", grc->get_table().get_string());
+			}
+
+			// check row count
+			else {
+				if (db->select("SELECT count(*) FROM `%s`", grc->get_table().get_string()) == NULL)
+					exception("unable to get row count of table '%s'", grc->get_table().get_string());
+
+				gl_verbose("table '%s' ok", grc->get_table().get_string());
+			}
+
+			grc->next_table();
+		}
+	} else {
+		exception("no property specified");
+		return 0;
+	}
+}
+
+/**
+ @return 0 on failure, 1 on success
+ **/
+
+int group_recorder::build_row(TIMESTAMP t1) {
+	char time_str[64];
+	DATETIME dt;
+	quickobjlist *curr = 0;
+	char objname[128];
+
+	query_engine* grc = group_recorder_connection;
+	char buffer[1024];
+	strcpy(buffer, complex_part);
+	vector<string> complex_part_vector = split(buffer, "|");
+	set complex_part_buffer = 0x00;
+
+	for (size_t n = 0; n < complex_part_vector.size(); n++) {
+		if (complex_part_vector[n].compare("REAL") == 0)
+			complex_part_buffer += 0x01;
+		else if (complex_part_vector[n].compare("IMAG") == 0)
+			complex_part_buffer += 0x02;
+		else if (complex_part_vector[n].compare("MAG") == 0)
+			complex_part_buffer += 0x04;
+		else if (complex_part_vector[n].compare("ANG") == 0)
+			complex_part_buffer += 0x08;
+		else if (complex_part_vector[n].compare("ANG_RAD") == 0)
+			complex_part_buffer += 0x10;
+	}
+
+	for (curr = obj_list; curr != 0; curr = curr->next) {
+		set compare = 0x01;
+		set complex_part_local_buffer = complex_part_buffer;
+		stringstream property_name_buffer, property_name_local_buffer;
+		string property_name_string;
+
+		if (0 != curr->obj->name) {
+			property_name_buffer << curr->obj->name;
+		} else {
+			property_name_buffer << curr->obj->name << ":" << curr->obj->id;
+		}
+
+		complex *cptr = 0;
+		// get value as a complex
+		cptr = gl_get_complex(curr->obj, &(curr->prop));
+		if (0 == cptr) {
+			gl_error("group_recorder::read_line(): unable to get complex property '%s' from object '%s'", curr->prop.name, gl_name(curr->obj, objname, 127));
+			/* TROUBLESHOOT
+			 Could not read a complex property as a complex value.
+			 */
+			return 0;
+		}
+
+		if (curr->prop.ptype == PT_complex) {
+			while (complex_part_local_buffer != NONE) {
+				property_name_local_buffer << property_name_buffer.str();
+
+				switch (complex_part_local_buffer & compare) {
+					case NONE:
+						default:
+						cleanup_property_buffer(&property_name_local_buffer);
+						compare <<= 1;
+						break;
+					case REAL:
+						property_name_string = setup_property_buffer(&property_name_local_buffer, "_REAL");
+						grc->get_table_path()->add_insert_values(grc, &property_name_string, cptr->Re());
+						complex_part_local_buffer ^= compare;
+						compare <<= 1;
+						cleanup_property_buffer(&property_name_local_buffer);
+						break;
+					case IMAG:
+						property_name_string = setup_property_buffer(&property_name_local_buffer, "_IMAG");
+						grc->get_table_path()->add_insert_values(grc, &property_name_string, cptr->Im());
+						complex_part_local_buffer ^= compare;
+						compare <<= 1;
+						cleanup_property_buffer(&property_name_local_buffer);
+						break;
+					case MAG:
+						property_name_string = setup_property_buffer(&property_name_local_buffer, "_MAG");
+						grc->get_table_path()->add_insert_values(grc, &property_name_string, cptr->Mag());
+						complex_part_local_buffer ^= compare;
+						compare <<= 1;
+						cleanup_property_buffer(&property_name_local_buffer);
+						break;
+					case ANG:
+						property_name_string = setup_property_buffer(&property_name_local_buffer, "_ANG_DEG");
+						grc->get_table_path()->add_insert_values(grc, &property_name_string, cptr->Arg() * 180 / PI);
+						complex_part_local_buffer ^= compare;
+						compare <<= 1;
+						cleanup_property_buffer(&property_name_local_buffer);
+						break;
+					case ANG_RAD:
+						property_name_string = setup_property_buffer(&property_name_local_buffer, "_ANG_RAD");
+						grc->get_table_path()->add_insert_values(grc, &property_name_string, cptr->Arg());
+						complex_part_local_buffer ^= compare;
+						compare <<= 1;
+						cleanup_property_buffer(&property_name_local_buffer);
+						break;
+				}
+			}
+		} else {
+			size_t offset = gl_get_value(curr->obj, GETADDR(curr->obj, &(curr->prop)), buffer, 127, &(curr->prop));
+			if (0 == offset) {
+				gl_error("group_recorder::read_line(): unable to get value for '%s' in object '%s'", curr->prop.name, curr->obj->name);
+				/* TROUBLESHOOT
+				 An error occured while reading the specified property in one of the objects.
+				 */
+				return 0;
+			}
+		}
+	}
+
+	for (int i = 0; i < grc->get_table_count(); i++) {
+		grc->next_table();
+		grc->get_table_path()->flush_value_row(&t1);
+	}
+	write_count++;
+	// assume write_line will add newline character
+
+	return 1;
+}
+
+/**
+ @return 0 on failure, 1 on success
+ **/
+int group_recorder::flush_line() {
+	if (limit > 0 && write_count >= limit) {
+		for (int i = 0; i < group_recorder_connection->get_table_count(); i++) {
+			group_recorder_connection->get_table_path()->commit_state();
+			group_recorder_connection->next_table();
+		}
+	}
+	return 1;
+}
+
+EXPORT TIMESTAMP sync_group_recorder(OBJECT *obj, TIMESTAMP t0, PASSCONFIG pass) {
+	group_recorder *my = OBJECTDATA(obj, group_recorder);
+	TIMESTAMP rv = 0;
+	try {
+		switch (pass) {
+			case PC_PRETOPDOWN:
+				rv = TS_NEVER;
+				break;
+			case PC_BOTTOMUP:
+				rv = TS_NEVER;
+				break;
+			case PC_POSTTOPDOWN:
+				rv = my->postsync(obj->clock, t0);
+				obj->clock = t0;
+				break;
+			default:
+				throw "invalid pass request";
+		}
+	} catch (char *msg) {
+		gl_error("sync_group_recorder: %s", msg);
+	} catch (const char *msg) {
+		gl_error("sync_group_recorder: %s", msg);
+	}
+	return rv;
+}
+
+EXPORT int commit_group_recorder(OBJECT *obj) {
+	int rv = 0;
+	group_recorder *my = OBJECTDATA(obj, group_recorder);
+	try {
+		rv = my->commit(obj->clock);
+	} catch (char *msg) {
+		gl_error("commit_group_recorder: %s", msg);
+	} catch (const char *msg) {
+		gl_error("commit_group_recorder: %s", msg);
+	}
+	return rv;
+}
+#endif // HAVE_MYSQL
+// EOF

--- a/mysql/group_recorder.cpp
+++ b/mysql/group_recorder.cpp
@@ -55,7 +55,7 @@ group_recorder::group_recorder(MODULE *mod) {
 				PT_int32, "column_limit", PADDR(column_limit), PT_DESCRIPTION, "maximum number of columns per MySQL table (default 200)",
 				PT_char32, "datetime_fieldname", PADDR(datetime_fieldname), PT_DESCRIPTION, "name of date-time field",
 				PT_char32, "recordid_fieldname", PADDR(recordid_fieldname), PT_DESCRIPTION, "name of record-id field",
-				PT_char256, "complex_part[s]", PADDR(complex_part), PT_DESCRIPTION, "the complex part(s) to record if complex properties are gathered (default REAL|IMAG)",
+				PT_char256, "complex_part", PADDR(complex_part), PT_DESCRIPTION, "the complex part(s) to record if complex properties are gathered (default REAL|IMAG)",
 				PT_char256, "data_type", PADDR(data_type), PT_DESCRIPTION, "the data format MySQL should use to store the values (default is DOUBLE with no precision set). Acceptable types are DECIMAL(M,D), FLOAT(M,D), and DOUBLE(M,D)",
 				PT_double, "interval[s]", PADDR(dInterval), PT_DESCRIPTION, "recording interval (0 'every iteration', -1 'on change')",
 

--- a/mysql/group_recorder.h
+++ b/mysql/group_recorder.h
@@ -1,0 +1,85 @@
+// header stuff here
+
+#ifndef _GROUP_RECORDER_H
+#define _GROUP_RECORDER_H
+
+#include "database.h"
+#include "query_engine.h"
+EXPORT void new_group_recorder(MODULE *);
+
+class query_engine;
+
+class quickobjlist{
+public:
+	quickobjlist(){obj = 0; next = 0; memset(&prop, 0, sizeof(PROPERTY));}
+	quickobjlist(OBJECT *o, PROPERTY *p){obj = o; next = 0; memcpy(&prop, p, sizeof(PROPERTY));}
+	~quickobjlist(){if(next != 0) delete next;}
+	void tack(OBJECT *o, PROPERTY *p){if(next){next->tack(o, p);} else {next = new quickobjlist(o, p);}}
+	OBJECT *obj;
+	PROPERTY prop;
+	quickobjlist *next;
+};
+
+class group_recorder : public gld_object {
+public:
+	static group_recorder *defaults;
+	static CLASS *oclass, *pclass;
+
+	group_recorder(MODULE *);
+	int create();
+	int init(OBJECT *);
+	int isa(char *);
+	TIMESTAMP postsync(TIMESTAMP, TIMESTAMP);
+
+	int commit(TIMESTAMP);
+public:
+	GL_STRING(char1024,table);
+	GL_STRING(char1024, group_def);
+	GL_ATOMIC(double, dInterval);
+	GL_ATOMIC(double, dFlush_interval);
+	GL_ATOMIC(bool, strict);
+	GL_ATOMIC(bool, print_units);
+	GL_STRING(char256, property_name);
+	GL_ATOMIC(int32, limit);
+    GL_ATOMIC(bool, format);
+	GL_ATOMIC(object,connection);
+	GL_ATOMIC(set,options);
+	GL_STRING(char32,mode);
+	GL_ATOMIC(int32, query_buffer_limit);
+	GL_ATOMIC(int32, formatter_limit);
+	GL_STRING(char32,datetime_fieldname);
+	GL_STRING(char32,recordid_fieldname);
+	GL_STRING(char1024,header_fieldnames);
+	GL_STRING(char256, complex_part);
+	GL_STRING(char256, data_type);
+	GL_ATOMIC(int32, column_limit);
+
+private:
+	int write_header();
+	int build_row(TIMESTAMP);
+	int flush_line();
+private:
+	MYSQL *mysql;
+	database *db;
+	query_engine* group_recorder_connection;
+	FILE *rec_file;
+	FINDLIST *items;
+	quickobjlist *obj_list;
+	PROPERTY *prop_ptr;
+	int obj_count;
+	int write_count;
+	TIMESTAMP next_write;
+	TIMESTAMP last_write;
+	TIMESTAMP last_flush;
+	TIMESTAMP write_interval;
+	TIMESTAMP flush_interval;
+	int32 write_ct;
+	char *prev_line_buffer;
+	char *line_buffer;
+	size_t line_size;
+	bool interval_write;
+};
+
+#endif // _GROUP_RECORDER_H
+
+// EOF

--- a/mysql/group_recorder.h
+++ b/mysql/group_recorder.h
@@ -36,10 +36,8 @@ public:
 public:
 	GL_STRING(char1024,table);
 	GL_STRING(char1024, group_def);
-	GL_ATOMIC(double, dInterval);
-	GL_ATOMIC(double, dFlush_interval);
 	GL_ATOMIC(bool, strict);
-	GL_ATOMIC(bool, print_units);
+//	GL_ATOMIC(bool, print_units);
 	GL_STRING(char256, property_name);
 	GL_ATOMIC(int32, limit);
     GL_ATOMIC(bool, format);

--- a/mysql/group_recorder.h
+++ b/mysql/group_recorder.h
@@ -1,5 +1,3 @@
-// header stuff here
-
 #ifndef _GROUP_RECORDER_H
 #define _GROUP_RECORDER_H
 
@@ -9,77 +7,95 @@ EXPORT void new_group_recorder(MODULE *);
 
 class query_engine;
 
-class quickobjlist{
-public:
-	quickobjlist(){obj = 0; next = 0; memset(&prop, 0, sizeof(PROPERTY));}
-	quickobjlist(OBJECT *o, PROPERTY *p){obj = o; next = 0; memcpy(&prop, p, sizeof(PROPERTY));}
-	~quickobjlist(){if(next != 0) delete next;}
-	void tack(OBJECT *o, PROPERTY *p){if(next){next->tack(o, p);} else {next = new quickobjlist(o, p);}}
-	OBJECT *obj;
-	PROPERTY prop;
-	quickobjlist *next;
+class quickobjlist {
+	public:
+		quickobjlist() {
+			obj = 0;
+			next = 0;
+			memset(&prop, 0, sizeof(PROPERTY));
+		}
+		quickobjlist(OBJECT *o, PROPERTY *p) {
+			obj = o;
+			next = 0;
+			memcpy(&prop, p, sizeof(PROPERTY));
+		}
+		~quickobjlist() {
+			if (next != 0)
+				delete next;
+		}
+		void tack(OBJECT *o, PROPERTY *p) {
+			if (next) {
+				next->tack(o, p);
+			} else {
+				next = new quickobjlist(o, p);
+			}
+		}
+		OBJECT *obj;
+		PROPERTY prop;
+		quickobjlist *next;
 };
 
 class group_recorder : public gld_object {
-public:
-	static group_recorder *defaults;
-	static CLASS *oclass, *pclass;
+	public:
+		static group_recorder *defaults;
+		static CLASS *oclass, *pclass;
 
-	group_recorder(MODULE *);
-	~group_recorder();
-	int create();
-	int init(OBJECT *);
-	int isa(char *);
-	TIMESTAMP postsync(TIMESTAMP, TIMESTAMP);
+		group_recorder(MODULE *);
+		~group_recorder();
+		int create();
+		int init(OBJECT *);
+		int isa(char *);
+		TIMESTAMP postsync(TIMESTAMP, TIMESTAMP);
+		int commit(TIMESTAMP);
 
-	int commit(TIMESTAMP);
-public:
-	GL_STRING(char1024,table);
-	GL_STRING(char1024, group_def);
-	GL_ATOMIC(bool, strict);
-//	GL_ATOMIC(bool, print_units);
-	GL_STRING(char256, property_name);
-	GL_ATOMIC(int32, limit);
-    GL_ATOMIC(bool, format);
-	GL_ATOMIC(object,connection);
-	GL_ATOMIC(set,options);
-	GL_STRING(char32,mode);
-	GL_ATOMIC(int32, query_buffer_limit);
-	GL_ATOMIC(int32, formatter_limit);
-	GL_STRING(char32,datetime_fieldname);
-	GL_STRING(char32,recordid_fieldname);
-	GL_STRING(char1024,header_fieldnames);
-	GL_STRING(char256, complex_part);
-	GL_STRING(char256, data_type);
-	GL_ATOMIC(int32, column_limit);
+		GL_STRING(char1024,table)
+		GL_STRING(char1024, group_def)
+		GL_ATOMIC(bool, strict)
+		GL_ATOMIC(bool, print_units)
+		GL_STRING(char256, property_name)
+		GL_ATOMIC(int32, limit)
+		GL_ATOMIC(bool, format)
+		GL_ATOMIC(object,connection)
+		GL_ATOMIC(set,options)
+		GL_STRING(char32,mode)
+		GL_ATOMIC(int32, query_buffer_limit)
+		GL_ATOMIC(int32, formatter_limit)
+		GL_STRING(char32,datetime_fieldname)
+		GL_STRING(char32,recordid_fieldname)
+		GL_STRING(char1024,header_fieldnames)
+		GL_STRING(char256, complex_part)
+		GL_STRING(char256, data_type)
+		GL_ATOMIC(int32, column_limit)
+		GL_ATOMIC(double, dInterval)
+		GL_ATOMIC(double, dFlush_interval)
 
-private:
-	int write_header();
-	int build_row(TIMESTAMP);
-	int flush_line();
-	int on_limit_hit();
-private:
-	MYSQL *mysql;
-	database *db;
-	query_engine* group_recorder_connection;
-	FILE *rec_file;
-	FINDLIST *items;
-	quickobjlist *obj_list;
-	PROPERTY *prop_ptr;
-	int obj_count;
-	int write_count;
-	TIMESTAMP next_write;
-	TIMESTAMP last_write;
-	TIMESTAMP last_flush;
-	TIMESTAMP write_interval;
-	TIMESTAMP flush_interval;
-	int32 write_ct;
-	char *prev_line_buffer;
-	char *line_buffer;
-	size_t line_size;
-	bool interval_write;
+	private:
+		int write_header();
+		int build_row(TIMESTAMP);
+		int flush_line();
+		int on_limit_hit();
+		template<class T> std::string to_string(T);
+
+		MYSQL *mysql;
+		database *db;
+		query_engine* group_recorder_connection;
+		FILE *rec_file;
+		FINDLIST *items;
+		quickobjlist *obj_list;
+		PROPERTY *prop_ptr;
+		int obj_count;
+		int write_count;
+		TIMESTAMP next_write;
+		TIMESTAMP last_write;
+		TIMESTAMP last_flush;
+		TIMESTAMP write_interval;
+		TIMESTAMP flush_interval;
+		int32 write_ct;
+		char *prev_line_buffer;
+		char *line_buffer;
+		size_t line_size;
+		bool interval_write;
 };
 
 #endif // _GROUP_RECORDER_H
-
 // EOF

--- a/mysql/group_recorder.h
+++ b/mysql/group_recorder.h
@@ -52,6 +52,7 @@ class group_recorder : public gld_object {
 		GL_STRING(char1024, group_def)
 		GL_ATOMIC(bool, strict)
 		GL_ATOMIC(bool, print_units)
+		GL_ATOMIC(bool, legacy_mode)
 		GL_STRING(char256, property_name)
 		GL_ATOMIC(int32, limit)
 		GL_ATOMIC(bool, format)
@@ -59,7 +60,7 @@ class group_recorder : public gld_object {
 		GL_ATOMIC(set,options)
 		GL_STRING(char32,mode)
 		GL_ATOMIC(int32, query_buffer_limit)
-		GL_ATOMIC(int32, formatter_limit)
+//		GL_ATOMIC(int32, formatter_limit)
 		GL_STRING(char32,datetime_fieldname)
 		GL_STRING(char32,recordid_fieldname)
 		GL_STRING(char1024,header_fieldnames)
@@ -74,7 +75,7 @@ class group_recorder : public gld_object {
 		int build_row(TIMESTAMP);
 		int flush_line();
 		int on_limit_hit();
-		template<class T> std::string to_string(T);
+		template<class T> std::string to_string(T); // This template exists in both Recorder and Group Recorder, and could be cleaned up.
 
 		MYSQL *mysql;
 		database *db;

--- a/mysql/group_recorder.h
+++ b/mysql/group_recorder.h
@@ -26,6 +26,7 @@ public:
 	static CLASS *oclass, *pclass;
 
 	group_recorder(MODULE *);
+	~group_recorder();
 	int create();
 	int init(OBJECT *);
 	int isa(char *);
@@ -58,6 +59,7 @@ private:
 	int write_header();
 	int build_row(TIMESTAMP);
 	int flush_line();
+	int on_limit_hit();
 private:
 	MYSQL *mysql;
 	database *db;

--- a/mysql/init.cpp
+++ b/mysql/init.cpp
@@ -44,6 +44,7 @@ EXPORT CLASS *init(CALLBACKS *fntable, MODULE *module, int argc, char *argv[])
 	new recorder(module);
 	new player(module);
 	new collector(module);
+	new group_recorder(module);
 
 	static int32 mysql_flag = 1;
 	gl_global_create("MYSQL",PT_int32,&mysql_flag,PT_ACCESS,PA_REFERENCE,PT_DESCRIPTION,"indicates that MySQL is available",NULL);

--- a/mysql/query_engine.cpp
+++ b/mysql/query_engine.cpp
@@ -1,0 +1,134 @@
+/*
+ * query_builder.cpp
+ *
+ *  Created on: Nov 21, 2017
+ *      Author: eber205
+ *
+ *      Provides a unified MySQL Connection interface and query constructor.
+ */
+
+#include "query_engine.h"
+
+using namespace std;
+
+query_engine::query_engine(database* db_in, set options_in, int threshold_in, int column_in) {
+	if (!initialized) {
+		if (init(db_in)) {
+			gl_debug("Query Engine startup successful.");
+		} else {
+			gl_debug("Query Engine startup failed.");
+		}
+		set_threshold(threshold_in);
+		set_options(options_in);
+		set_columns(column_in);
+		set_formatter_max(1024);
+		table_count = 0;
+	}
+}
+
+int query_engine::init(database* db_in) {
+	initialized = true;
+	query_count = 0;
+	db = db_in;
+	if (db == NULL) {
+		exception("no database connection available or specified");
+		return 0;
+	}
+	if (!db->isa("database")) {
+		exception("connection is not a mysql database");
+		return 0;
+	}
+	gl_verbose("connection to mysql server '%s', schema '%s' ok",
+			db->get_hostname(), db->get_schema());
+	return 1;
+}
+
+//void query_engine::set_query(string header_in, string footer_in) {
+//	header = header_in;
+//	footer = footer_in;
+//}
+//
+//int query_engine::push_value(string value_in) {
+//	if (query_count < threshold) {
+//		query_buffer.append(value_in);
+//		query_count++;
+//	} else {
+//		if (!query_engine::commit()) {
+//			exception("Database commit failed.");
+//			return 0;
+//		}
+//		query_count = 1;
+//		query_buffer = value_in;
+//	}
+//	return 1;
+//}
+
+//int query_engine::publish() {
+//	if (!query_engine::commit()) {
+//		exception("Database commit failed.");
+//		return 0;
+//	}
+//	return 1;
+//}
+
+int query_engine::query_immediate(string query_in) {
+	if (db->query(query_in.c_str()))
+		return 1;
+	return 0;
+}
+
+//int query_engine::commit() {
+//	MYSQL* mysql = db->get_handle();
+//	if (header.length() != 0) {
+//		query_buffer.insert(0, header.append(" "));
+//	}
+//	if (footer.length() != 0) {
+//		query_buffer.append(footer.insert(0, " "));
+//	}
+//	if (query_buffer.length() != 0) {
+//		db->query(query_buffer.c_str());
+//		return 1;
+//	}
+//	return 0;
+//}
+
+void query_engine::set_formatter_max(int max_in) {
+	formatter_max_characters = max_in;
+}
+
+string query_engine::format(char *fmt, ...) {
+	char command[formatter_max_characters];
+	va_list ptr;
+	va_start(ptr, fmt);
+	vsnprintf(command, formatter_max_characters, fmt, ptr);
+	va_end(ptr);
+
+	return string(command);
+}
+
+void query_engine::next_table(){
+	table_path = table_path->get_next_table();
+}
+
+void query_engine::init_tables() {
+	table_path = new table_manager(db, options, threshold,
+			column_limit,  0, &table);
+	inc_table_count();
+}
+
+void query_engine::set_table_root(char1024 table_in){
+	table = table_in;
+}
+
+char1024 query_engine::get_table(){
+	return table_path->get_table_name();
+}
+
+void query_engine::set_tables_done(){
+	for(int i = 0; i < table_count; i++){
+		table_path->set_done();
+		next_table();
+	}
+}
+
+

--- a/mysql/query_engine.cpp
+++ b/mysql/query_engine.cpp
@@ -104,22 +104,28 @@ void query_engine::set_tables_done() {
 void query_engine::build_table_references() {
 	stringstream query;
 	vector<string*>* table_headers;
+	int local_header_count;
 
 	query << "INSERT INTO `" << table_references.get_string() << "` (`table_name`, `header`) VALUES";
 
-	for (int i = 0; i < table_count; i++) {
+	for (int i = 0; table_count > 0 && i < table_count; i++) {
 		table_headers = table_path->get_table_headers();
 		int header_count = table_headers->size();
-		char1024 table_name = table_path->get_table_name();
-		for (int j = 0; j < header_count-1; j++) {
-			query << "('" << table_name.get_string() << "','" << *((*table_headers)[j]) << "'),";
+		if (header_count > 0) {
+			local_header_count += header_count;
+			char1024 table_name = table_path->get_table_name();
+			for (int j = 0; j < header_count - 1; j++) {
+				query << "('" << table_name.get_string() << "','" << *((*table_headers)[j]) << "'),";
+			}
+			query << "('" << table_name.get_string() << "','" << *((*table_headers)[header_count - 1]) << "')" << (
+					(i == table_count - 1) ? " " : ",");
 		}
-		query << "('" << table_name.get_string() << "','" << *((*table_headers)[header_count-1]) << "')" << ((i == table_count-1) ? " " : ",");
 		next_table();
 	}
 	query << ";";
 	string query_string = query.str();
 	const char* temp = query_string.c_str();
-	db->query(query_string.c_str());
+	if (local_header_count != 0 && table_count != 0)
+		db->query(query_string.c_str());
 }
 

--- a/mysql/query_engine.cpp
+++ b/mysql/query_engine.cpp
@@ -60,8 +60,8 @@ void query_engine::next_table() {
 	table_path = table_path->get_next_table();
 }
 
-void query_engine::init_tables() {
-	table_path = new table_manager(db, threshold, column_limit, 0, &table);
+void query_engine::init_tables(char32 recordid_fieldname, char32 datetime_fieldname, bool single_table_mode) {
+	table_path = new table_manager(db, threshold, column_limit, 0, &table, recordid_fieldname, datetime_fieldname, single_table_mode);
 	inc_table_count();
 }
 
@@ -115,7 +115,6 @@ void query_engine::build_table_references(bool print_units) {
 	}
 	query << ";";
 	string query_string = query.str();
-	const char* temp = query_string.c_str();
 	if (local_header_count != 0 && table_count != 0)
 		db->query(query_string.c_str());
 }

--- a/mysql/query_engine.h
+++ b/mysql/query_engine.h
@@ -32,7 +32,7 @@ class query_engine : public gld_object {
 		}
 		void set_table_root(char1024);
 		void next_table();
-		void init_tables();
+		void init_tables(char32, char32, bool);
 		inline void inc_table_count() {
 			table_count++;
 		}
@@ -61,7 +61,7 @@ class query_engine : public gld_object {
 
 class table_manager : public gld_object, public query_engine {
 	public:
-		table_manager(database*, int, int, int, char1024*);
+		table_manager(database*, int, int, int, char1024*, char32, char32, bool);
 		void init_table(table_manager*);
 		bool query_table(std::string*);
 		inline table_manager* get_next_table() {
@@ -71,6 +71,7 @@ class table_manager : public gld_object, public query_engine {
 			return table;
 		}
 		int add_table_header(query_engine*, std::stringstream&, std::string*, char*);
+		int add_table_header(std::string*, std::string*);
 		void flush_value_row(TIMESTAMP*);
 		inline void commit_state() {
 			if (!done) {
@@ -104,6 +105,7 @@ class table_manager : public gld_object, public query_engine {
 		std::vector<char*> table_units;
 		std::vector<std::string> insert_values;
 		table_manager* next_table;
+		char32 recordid_fieldname, datetime_fieldname;
 };
 
 #endif /* MYSQL_QUERY_ENGINE_H_ */

--- a/mysql/query_engine.h
+++ b/mysql/query_engine.h
@@ -2,7 +2,7 @@
  * query_builder.h
  *
  *  Created on: Nov 21, 2017
- *      Author: eber205
+ *      Author: mark.eberlein@pnnl.gov
  */
 
 #ifndef MYSQL_QUERY_ENGINE_H_
@@ -17,67 +17,93 @@ class query_engine;
 class table_manager;
 
 class query_engine : public gld_object {
-public:
-	query_engine(database*, set, int, int);
-	~query_engine();
-	int query_immediate(std::string);
-	inline void set_threshold(int new_threshold){ threshold = new_threshold; }
-	inline void set_options(set new_options){ options = new_options; }
-	inline void set_columns(set new_columns){ column_limit = new_columns; }
-	inline database* get_database(){ return db; }
-	void set_formatter_max(int);
-	std::string format(char *,...);
-	void set_table_root(char1024);
-	void next_table();
-	void init_tables();
-	inline void inc_table_count(){table_count++;}
-	inline table_manager* get_table_path() {return table_path;}
-	char1024 get_table();
-	char1024 get_table_references();
-	void build_table_references();
-	inline int get_table_count() {return table_count;}
-	void set_tables_done();
-protected:
-	int init(database*);
-	bool initialized;
-	database *db;
-	int threshold, query_count, formatter_max_characters, column_limit;
-	set options;
-private:
-	int table_count;
-	char1024 table, table_references;
-	table_manager* table_path;
+	public:
+		query_engine(database*, int, int);
+		~query_engine();
+		int query_immediate(std::string);
+		inline void set_threshold(int new_threshold) {
+			threshold = new_threshold;
+		}
+		inline void set_columns(set new_columns) {
+			column_limit = new_columns;
+		}
+		inline database* get_database() {
+			return db;
+		}
+		void set_table_root(char1024);
+		void next_table();
+		void init_tables();
+		inline void inc_table_count() {
+			table_count++;
+		}
+		inline table_manager* get_table_path() {
+			return table_path;
+		}
+		char1024 get_table();
+		char1024 get_table_references();
+		void build_table_references(bool);
+		inline int get_table_count() {
+			return table_count;
+		}
+		void set_tables_done();
+
+	protected:
+		int init(database*);
+		bool initialized;
+		database *db;
+		int threshold, query_count, column_limit;
+
+	private:
+		int table_count;
+		char1024 table, table_references;
+		table_manager* table_path;
 };
 
 class table_manager : public gld_object, public query_engine {
-public:
-	table_manager(database*, set, int, int, int, char1024*);
-	void init_table(table_manager*);
-	bool query_table(std::string*);
-	inline table_manager* get_next_table(){return next_table;}
-	inline char1024 get_table_name(){return table;}
-	int add_table_header(query_engine*, std::stringstream&, std::string*);
-	int add_insert_values(query_engine*, std::string*, double);
-	void flush_value_row(TIMESTAMP*);
-	inline void commit_state(){if(!done){commit_values();}}
-	inline void set_done(){done = true;}
+	public:
+		table_manager(database*, int, int, int, char1024*);
+		void init_table(table_manager*);
+		bool query_table(std::string*);
+		inline table_manager* get_next_table() {
+			return next_table;
+		}
+		inline char1024 get_table_name() {
+			return table;
+		}
+		int add_table_header(query_engine*, std::stringstream&, std::string*, char*);
+		void flush_value_row(TIMESTAMP*);
+		inline void commit_state() {
+			if (!done) {
+				commit_values();
+			}
+		}
+		inline void set_done() {
+			done = true;
+		}
+		inline std::ostringstream& get_table_header_buffer() {
+			return table_header_buffer;
+		}
+		inline std::ostringstream& get_insert_values_buffer() {
+			return insert_values_buffer;
+		}
+		std::vector<std::string*>* get_table_headers();
+		std::vector<char*>* get_table_units();
+		int add_insert_values(query_engine*, std::string*, std::string);
 
-	inline std::ostringstream& get_table_header_buffer(){return table_header_buffer;}
-	inline std::ostringstream& get_insert_values_buffer(){return insert_values_buffer;}
-	std::vector<std::string*>* get_table_headers();
-private:
-	int add_insert_values(query_engine*, std::string*, double, int);
-	void extend_list(query_engine*);
-	void commit_values();
-	int table_index;
-	int column_count, insert_count;
-	char1024 table;
-	char1024* table_root;
-	bool insert_values_initialized, done;
-	std::ostringstream table_header_buffer, insert_values_buffer;
-	std::vector<std::string*> table_headers;
-	std::vector<double> insert_values;
-	table_manager* next_table;
+	private:
+		int add_insert_values(query_engine*, std::string*, std::string, int);
+		void extend_list(query_engine*);
+		void commit_values();
+		int table_index;
+		int column_count, insert_count;
+		char1024 table;
+		char1024* table_root;
+		bool insert_values_initialized, done;
+		std::ostringstream table_header_buffer, insert_values_buffer;
+		std::vector<std::string*> table_headers;
+		std::vector<char*> table_units;
+		std::vector<std::string> insert_values;
+		table_manager* next_table;
 };
 
 #endif /* MYSQL_QUERY_ENGINE_H_ */

--- a/mysql/query_engine.h
+++ b/mysql/query_engine.h
@@ -1,0 +1,88 @@
+/*
+ * query_builder.h
+ *
+ *  Created on: Nov 21, 2017
+ *      Author: eber205
+ */
+
+#ifndef MYSQL_QUERY_ENGINE_H_
+#define MYSQL_QUERY_ENGINE_H_
+
+#include "gridlabd.h"
+#include "database.h"
+#include <string>
+#include <sstream>
+#include <vector>
+class query_engine;
+class table_manager;
+
+class query_engine : public gld_object {
+public:
+	query_engine(database*, set, int, int);
+	void set_query(std::string, std::string);
+	int push_value(std::string);
+	int publish();
+	int query_immediate(std::string);
+	inline void set_threshold(int new_threshold){ threshold = new_threshold; }
+	inline void set_options(set new_options){ options = new_options; }
+	inline void set_columns(set new_columns){ column_limit = new_columns; }
+	inline database* get_database(){ return db; }
+	void set_formatter_max(int);
+	std::string format(char *,...);
+	char1024 find_entry(char1024); // optimize this to better than linear time.
+	void set_table_root(char1024);
+	void next_table();
+	void init_tables();
+	inline void inc_table_count(){table_count++;}
+	inline table_manager* get_table_path() {return table_path;}
+	char1024 get_table();
+	inline int get_table_count() {return table_count;}
+	void set_tables_done();
+protected:
+	int init(database*);
+	int commit();
+	bool initialized;
+	database *db;
+//	std::string header, query_buffer, footer;
+	int threshold, query_count, formatter_max_characters, column_limit;
+	set options;
+private:
+	int table_count;
+	char1024 table;
+	table_manager* table_path;
+};
+
+class table_manager : public gld_object, public query_engine {
+public:
+	table_manager(database*, set, int, int, int, char1024*);
+	void init_table(table_manager*, table_manager*);
+	bool query_table(std::string*);
+	inline table_manager* get_next_table(){return next_table;}
+	inline table_manager* get_prev_table(){return prev_table;}
+	inline char1024 get_table_name(){return table;}
+	int add_table_header(query_engine*, std::stringstream&, std::string*);
+	int add_insert_values(query_engine*, std::string*, double);
+	void clear_values_init();
+	void flush_value_row(TIMESTAMP*);
+	inline void commit_state(){if(!done){commit_values();}}
+	inline void set_done(){done = true;}
+
+	inline std::ostringstream& get_table_header_buffer(){return table_header_buffer;}
+	inline std::ostringstream& get_insert_values_buffer(){return insert_values_buffer;}
+private:
+	int add_insert_values(query_engine*, std::string*, double, int);
+	void extend_list(query_engine*);
+	void commit_values();
+	int table_index;
+	int column_count, insert_count;
+	char1024 table;
+	char1024* table_root;
+	bool insert_values_initialized, done;
+	std::ostringstream table_header_buffer, insert_values_buffer;
+	std::vector<std::string*> table_headers;
+	std::vector<double> insert_values;
+	table_manager* next_table;
+	table_manager* prev_table;
+};
+
+#endif /* MYSQL_QUERY_ENGINE_H_ */

--- a/mysql/query_engine.h
+++ b/mysql/query_engine.h
@@ -19,9 +19,7 @@ class table_manager;
 class query_engine : public gld_object {
 public:
 	query_engine(database*, set, int, int);
-	void set_query(std::string, std::string);
-	int push_value(std::string);
-	int publish();
+	~query_engine();
 	int query_immediate(std::string);
 	inline void set_threshold(int new_threshold){ threshold = new_threshold; }
 	inline void set_options(set new_options){ options = new_options; }
@@ -29,46 +27,44 @@ public:
 	inline database* get_database(){ return db; }
 	void set_formatter_max(int);
 	std::string format(char *,...);
-	char1024 find_entry(char1024); // optimize this to better than linear time.
 	void set_table_root(char1024);
 	void next_table();
 	void init_tables();
 	inline void inc_table_count(){table_count++;}
 	inline table_manager* get_table_path() {return table_path;}
 	char1024 get_table();
+	char1024 get_table_references();
+	void build_table_references();
 	inline int get_table_count() {return table_count;}
 	void set_tables_done();
 protected:
 	int init(database*);
-	int commit();
 	bool initialized;
 	database *db;
-//	std::string header, query_buffer, footer;
 	int threshold, query_count, formatter_max_characters, column_limit;
 	set options;
 private:
 	int table_count;
-	char1024 table;
+	char1024 table, table_references;
 	table_manager* table_path;
 };
 
 class table_manager : public gld_object, public query_engine {
 public:
 	table_manager(database*, set, int, int, int, char1024*);
-	void init_table(table_manager*, table_manager*);
+	void init_table(table_manager*);
 	bool query_table(std::string*);
 	inline table_manager* get_next_table(){return next_table;}
-	inline table_manager* get_prev_table(){return prev_table;}
 	inline char1024 get_table_name(){return table;}
 	int add_table_header(query_engine*, std::stringstream&, std::string*);
 	int add_insert_values(query_engine*, std::string*, double);
-	void clear_values_init();
 	void flush_value_row(TIMESTAMP*);
 	inline void commit_state(){if(!done){commit_values();}}
 	inline void set_done(){done = true;}
 
 	inline std::ostringstream& get_table_header_buffer(){return table_header_buffer;}
 	inline std::ostringstream& get_insert_values_buffer(){return insert_values_buffer;}
+	std::vector<std::string*>* get_table_headers();
 private:
 	int add_insert_values(query_engine*, std::string*, double, int);
 	void extend_list(query_engine*);
@@ -82,7 +78,6 @@ private:
 	std::vector<std::string*> table_headers;
 	std::vector<double> insert_values;
 	table_manager* next_table;
-	table_manager* prev_table;
 };
 
 #endif /* MYSQL_QUERY_ENGINE_H_ */

--- a/mysql/recorder.cpp
+++ b/mysql/recorder.cpp
@@ -120,6 +120,8 @@ int recorder::init(OBJECT *parent) {
 	property_specs = split(get_property(), ", \t;");
 
 	if (group_mode) {
+		strcpy(header_fieldnames, "");
+
 		group_items = new gld_objlist(group.get_string());
 		vector<char1024> property_spec_char;
 		for (int property_index = 0; property_index < property_specs.size();
@@ -249,7 +251,7 @@ int recorder::init(OBJECT *parent) {
 		vector<string> header_specs = split(buffer, ",");
 		size_t header_pos = 0;
 		for (size_t n = 0; n < header_specs.size(); n++) {
-			if (header_specs[n].compare("name") == 0) {
+			if (header_specs[n].compare("name") == 0 && !group_mode) {
 				rc->get_table_path()->add_table_header(new string("name"), new string("name CHAR(64), index i_name (name), "));
 			}
 			else if (header_specs[n].compare("class") == 0) {
@@ -493,9 +495,7 @@ TIMESTAMP recorder::commit(TIMESTAMP t0, TIMESTAMP t1) {
 				enabled = false;
 				gl_verbose("table '%s' size limit %d reached", rc->get_table().get_string(), get_limit());
 			}
-
 		}
-
 	}
 	else {
 		gl_debug("%s: sampling is not enabled", get_name());

--- a/mysql/recorder.cpp
+++ b/mysql/recorder.cpp
@@ -1,12 +1,13 @@
 /** $Id: recorder.cpp 4738 2014-07-03 00:55:39Z dchassin $
-    DP Chassin - July 2012
-    Copyright (C) 2012 Battelle Memorial Institute
+ DP Chassin - July 2012
+ Copyright (C) 2012 Battelle Memorial Institute
  **/
 
 #ifdef HAVE_MYSQL
 
 #include <time.h>
 #include "database.h"
+#include "query_engine.h"
 
 EXPORT_CREATE(recorder);
 EXPORT_INIT(recorder);
@@ -16,265 +17,240 @@ CLASS *recorder::oclass = NULL;
 recorder *recorder::defaults = NULL;
 using namespace std;
 
-vector<string> split(char* str, const char* delim)
-{
-    char* saveptr;
-    char* token = strtok_r(str,delim,&saveptr);
+vector<string> split(char* str, const char* delim) {
+	char* saveptr;
+	char* token = strtok_r(str, delim, &saveptr);
 
-    vector<string> result;
+	vector<string> result;
 
-    while(token != NULL)
-    {
-        result.push_back(token);
-        token = strtok_r(NULL,delim,&saveptr);
-    }
-    return result;
+	while (token != NULL) {
+		result.push_back(token);
+		token = strtok_r(NULL, delim, &saveptr);
+	}
+	return result;
 }
 
-recorder::recorder(MODULE *module)
-{
-	if (oclass==NULL)
-	{
+recorder::recorder(MODULE *module) {
+	if (oclass == NULL) {
 		// register to receive notice for first top down. bottom up, and second top down synchronizations
-		oclass = gld_class::create(module,"recorder",sizeof(recorder),PC_AUTOLOCK|PC_OBSERVER);
-		if (oclass==NULL)
+		oclass = gld_class::create(module, "recorder", sizeof(recorder), PC_AUTOLOCK | PC_OBSERVER);
+		if (oclass == NULL)
 			throw "unable to register class recorder";
 		else
 			oclass->trl = TRL_PROTOTYPE;
 
 		defaults = this;
 		if (gl_publish_variable(oclass,
-			PT_char1024,"property",get_property_offset(),PT_DESCRIPTION,"target property name",
-			PT_char32,"trigger",get_trigger_offset(),PT_DESCRIPTION,"recorder trigger condition",
-			PT_char1024,"table",get_table_offset(),PT_DESCRIPTION,"table name to store samples",
-			PT_char1024,"file",get_table_offset(),PT_DESCRIPTION,"file name (for tape compatibility)",
-			PT_char32,"mode",get_mode_offset(),PT_DESCRIPTION,"table output mode",
-			PT_int32,"limit",get_limit_offset(),PT_DESCRIPTION,"maximum number of records to output",
-			PT_double,"interval[s]",get_interval_offset(),PT_DESCRIPTION,"sampling interval",
-			PT_object,"connection",get_connection_offset(),PT_DESCRIPTION,"database connection",
-			PT_set,"options",get_options_offset(),PT_DESCRIPTION,"SQL options",
-				PT_KEYWORD,"PURGE",(set)MO_DROPTABLES,PT_DESCRIPTION,"flag to drop tables before creation",
-				PT_KEYWORD,"UNITS",(set)MO_USEUNITS,PT_DESCRIPTION,"include units in column names",
-			PT_char32,"datetime_fieldname",get_datetime_fieldname_offset(),PT_DESCRIPTION,"name of date-time field",
-			PT_char32,"recordid_fieldname",get_recordid_fieldname_offset(),PT_DESCRIPTION,"name of record-id field",
-			PT_char1024,"header_fieldnames",get_header_fieldnames_offset(),PT_DESCRIPTION,"name of header fields to include",
-			NULL)<1){
-				char msg[256];
-				sprintf(msg, "unable to publish properties in %s",__FILE__);
-				throw msg;
+				PT_char1024, "property", get_property_offset(), PT_DESCRIPTION, "target property name",
+				//				PT_char1024, "group", get_property_offset(), PT_DESCRIPTION,  "group definition string",
+				PT_char32, "trigger", get_trigger_offset(), PT_DESCRIPTION, "recorder trigger condition",
+				PT_char1024, "table", get_table_offset(), PT_DESCRIPTION, "table name to store samples",
+				PT_char1024, "file", get_table_offset(), PT_DESCRIPTION, "file name (for tape compatibility)",
+				PT_char32, "mode", get_mode_offset(), PT_DESCRIPTION, "table output mode",
+				PT_int32, "limit", get_limit_offset(), PT_DESCRIPTION, "maximum number of records to output",
+				PT_double, "interval[s]", get_interval_offset(), PT_DESCRIPTION, "sampling interval",
+				PT_object, "connection", get_connection_offset(), PT_DESCRIPTION, "database connection",
+				PT_set, "options", get_options_offset(), PT_DESCRIPTION, "SQL options",
+				PT_KEYWORD, "PURGE", (set) MO_DROPTABLES, PT_DESCRIPTION, "flag to drop tables before creation",
+				PT_KEYWORD, "UNITS", (set) MO_USEUNITS, PT_DESCRIPTION, "include units in column names",
+				PT_char32, "datetime_fieldname", get_datetime_fieldname_offset(), PT_DESCRIPTION, "name of date-time field",
+				PT_char32, "recordid_fieldname", get_recordid_fieldname_offset(), PT_DESCRIPTION, "name of record-id field",
+				PT_char1024, "header_fieldnames", get_header_fieldnames_offset(), PT_DESCRIPTION, "name of header fields to include",
+				PT_char256, "data_type", get_data_type_offset(), PT_DESCRIPTION, "the data format MySQL should use to store the values (default is DOUBLE with no precision set). Acceptable types are DECIMAL(M,D), FLOAT(M,D), and DOUBLE(M,D)",
+				PT_int32, "query_buffer_limit", get_query_buffer_limit_offset(), PT_DESCRIPTION, "max number of queries to buffer before pushing to database",
+				NULL) < 1) {
+			char msg[256];
+			sprintf(msg, "unable to publish properties in %s", __FILE__);
+			throw msg;
 		}
 
-		memset(this,0,sizeof(recorder));
+		memset(this, 0, sizeof(recorder));
 	}
 }
 
-int recorder::create(void) 
-{
-	memcpy(this,defaults,sizeof(*this));
+int recorder::create(void) {
+	memcpy(this, defaults, sizeof(*this));
 	db = last_database;
-	strcpy(datetime_fieldname,"t");
-	strcpy(recordid_fieldname,"id");
+	strcpy(datetime_fieldname, "t");
+	strcpy(recordid_fieldname, "id");
+	strcpy(data_type, "DOUBLE");
+	query_buffer_limit = 200;
+
 	return 1; /* return 1 on success, 0 on failure */
 }
 
-int recorder::init(OBJECT *parent)
-{
-	// check the connection
-	if ( get_connection()!=NULL )
-		db = (database*)(get_connection()+1);
-	if ( db==NULL )
-		exception("no database connection available or specified");
-	if ( !db->isa("database") )
-		exception("connection is not a mysql database");
-	gl_verbose("connection to mysql server '%s', schema '%s' ok", db->get_hostname(), db->get_schema());
+int recorder::init(OBJECT *parent) {
+// check the connection
+	recorder_connection = new query_engine(
+			get_connection() != NULL ? (database*) (get_connection() + 1) : db, query_buffer_limit, 200);
+
+	query_engine* rc = recorder_connection;
+	rc->set_table_root(get_table());
+	rc->init_tables(recordid_fieldname, datetime_fieldname, true);
 
 	// check mode
-	if ( strlen(mode)>0 )
-	{
+	if (strlen(mode) > 0) {
 		options = 0xffffffff;
 		struct {
-			char *str;
-			set bits;
+				char *str;
+				set bits;
 		} modes[] = {
-			{"r",	0xffff},
-			{"r+",	0xffff},
-			{"w",	MO_DROPTABLES},
-			{"w+",	MO_DROPTABLES},
-			{"a",	0x0000},
-			{"a+",	0x0000},
+				{ "r", 0xffff },
+				{ "r+", 0xffff },
+				{ "w", MO_DROPTABLES },
+				{ "w+", MO_DROPTABLES },
+				{ "a", 0x0000 },
+				{ "a+", 0x0000 },
 		};
 		int n;
-		for ( n=0 ; n<sizeof(modes)/sizeof(modes[0]) ; n++ )
-		{
-			if ( strcmp(mode,modes[n].str)==0 )
-			{
+		for (n = 0; n < sizeof(modes) / sizeof(modes[0]); n++) {
+			if (strcmp(mode, modes[n].str) == 0)
+					{
 				options = modes[n].bits;
 				break;
 			}
 		}
-		if ( options==0xffffffff )
-			exception("mode '%s' is not recognized",(const char*)mode);
-		else if ( options==0xffff )
-			exception("mode '%s' is not valid for a recorder", (const char*)mode);
+		if (options == 0xffffffff)
+			exception("mode '%s' is not recognized", (const char*) mode);
+		else if (options == 0xffff)
+			exception("mode '%s' is not valid for a recorder", (const char*) mode);
 	}
 
 	// connect the target properties
 	vector<string> property_specs = split(get_property(), ", \t;");
-	char property_list[65536]="";
-	for ( size_t n = 0 ; n < property_specs.size() ; n++ )
-	{
+	char property_list[65536] = "";
+
+	for (size_t n = 0; n < property_specs.size(); n++) {
 		char buffer[1024];
-		strcpy(buffer,(const char*)property_specs[n].c_str());
-		vector<string> spec = split(buffer,"[]");
-		if ( spec.size()>0 )
-		{
-			strcpy(buffer,(const char*)spec[0].c_str());
+		strcpy(buffer, (const char*) property_specs[n].c_str());
+		vector<string> spec = split(buffer, "[]");
+		if (spec.size() > 0) {
+			strcpy(buffer, (const char*) spec[0].c_str());
 			gld_property prop;
-			if ( get_parent()==NULL )
+			if (get_parent() == NULL)
 				prop = gld_property(buffer);
 			else
-				prop = gld_property(get_parent(),buffer);
-			if ( prop.get_object()==NULL )
-			{
-				if ( get_parent()==NULL )
+				prop = gld_property(get_parent(), buffer);
+			if (prop.get_object() == NULL) {
+				if (get_parent() == NULL)
 					exception("parent object is not set");
-				prop = gld_property(get_parent(),buffer);
+				prop = gld_property(get_parent(), buffer);
 			}
-			if ( !prop.is_valid() )
+			if (!prop.is_valid())
 				exception("property %s is not valid", buffer);
 
 			property_target.push_back(prop);
 			gl_debug("adding field from property '%s'", buffer);
 			double scale = 1.0;
 			gld_unit unit;
-			if ( spec.size()>1 )
-			{
+			if (spec.size() > 1) {
 				char buffer[1024];
-				strcpy(buffer,(const char*)spec[1].c_str());
+				strcpy(buffer, (const char*) spec[1].c_str());
 				unit = gld_unit(buffer);
 			}
-			else if ( prop.get_unit()!=NULL && (options&MO_USEUNITS) )
+			else if (prop.get_unit() != NULL && (options & MO_USEUNITS))
 				unit = *prop.get_unit();
 			property_unit.push_back(unit);
 			n_properties++;
-			char tmp[128];
-			if ( unit.is_valid() )
-				sprintf(tmp,"`%s[%s]` %s, ", prop.get_name(), unit.get_name(), db->get_sqltype(prop));
-			else
-				sprintf(tmp,"`%s` %s, ", prop.get_name(), db->get_sqltype(prop));
-			strcat(property_list,tmp);
+			char tmp[2][2][128];
+			sprintf(tmp[0][0], "%s", prop.get_sql_safe_name());
+			sprintf(tmp[0][1], "`%s` %s, ", prop.get_sql_safe_name(), db->get_sqltype(prop));
+			sprintf(tmp[1][0], "%s_units", prop.get_sql_safe_name());
+			sprintf(tmp[1][1], "`%s_units` %s, ", prop.get_sql_safe_name(), "CHAR(10)");
+
+			if (unit.is_valid()) {
+				rc->get_table_path()->add_table_header(new string(tmp[0][0]), new string(tmp[0][1]));
+				rc->get_table_path()->add_table_header(new string(tmp[1][0]), new string(tmp[1][1]));
+			} else {
+				rc->get_table_path()->add_table_header(new string(tmp[0][0]), new string(tmp[0][1]));
+			}
 		}
 	}
 
 	// get header fields
-	if ( strlen(header_fieldnames)>0 )
-	{
-		if ( get_parent()==NULL )
+	if (strlen(header_fieldnames) > 0) {
+		if (get_parent() == NULL)
 			exception("cannot find header fields without a parent");
 		char buffer[1024];
-		strcpy(buffer,header_fieldnames);
+		strcpy(buffer, header_fieldnames);
 		vector<string> header_specs = split(buffer, ",");
 		size_t header_pos = 0;
-		for ( size_t n = 0 ; n < header_specs.size() ; n++ )
-		{
-			if ( header_specs[n].compare("name")==0 )
-			{
-				header_pos += sprintf(header_data+header_pos,",'%s'",get_parent()->get_name());
-				strcat(property_list,"name CHAR(64), index i_name (name), ");
+		for (size_t n = 0; n < header_specs.size(); n++) {
+			if (header_specs[n].compare("name") == 0) {
+				rc->get_table_path()->add_table_header(new string("name"), new string("name CHAR(64), index i_name (name), "));
 			}
-			else if ( header_specs[n].compare("class")==0 )
-			{
-				header_pos += sprintf(header_data+header_pos,",'%s'",get_parent()->get_oclass()->get_name());
-				strcat(property_list,"class CHAR(32), index i_class (class), ");
+			else if (header_specs[n].compare("class") == 0) {
+				rc->get_table_path()->add_table_header(new string("class"), new string("class CHAR(32), index i_class (class), "));
 			}
-			else if ( header_specs[n].compare("latitude")==0 )
-			{
-				if ( isnan(get_parent()->get_latitude()) )
-					header_pos += sprintf(header_data+header_pos,",%s","NULL");
-				else
-					header_pos += sprintf(header_data+header_pos,",%.6f",get_parent()->get_latitude());
-				strcat(property_list,"latitude DOUBLE, index i_latitude (latitude), ");
+			else if (header_specs[n].compare("latitude") == 0) {
+				rc->get_table_path()->add_table_header(new string("latitude"), new string("latitude DOUBLE, index i_latitude (latitude), "));
 			}
-			else if ( header_specs[n].compare("longitude")==0 )
-			{
-				if ( isnan(get_parent()->get_longitude()) )
-					header_pos += sprintf(header_data+header_pos,",%s","NULL");
-				else
-					header_pos += sprintf(header_data+header_pos,",%.6f",get_parent()->get_oclass()->get_name());
-				strcat(property_list,"longitude DOUBLE, index i_longitude (longitude), ");
+			else if (header_specs[n].compare("longitude") == 0) {
+				rc->get_table_path()->add_table_header(new string("longitude"), new string("longitude DOUBLE, index i_longitude (longitude), "));
 			}
 			else
-				exception("header field %s does not exist",(const char*)header_specs[n].c_str());
+				exception("header field %s does not exist", (const char*) header_specs[n].c_str());
 		}
-		gl_verbose("header_fieldname=[%s]", (const char*)header_fieldnames);
-		gl_verbose("header_fielddata=[%s]", header_data);
+		gl_verbose("header_fieldname=[%s]", (const char*) header_fieldnames);
 	}
 
 	// check for table existence and create if not found
-	if ( n_properties>0 )
-	{
+	if (n_properties > 0) {
 		// drop table if exists and drop specified
-		if ( db->table_exists(get_table()) )
-		{
-			if ( get_options()&MO_DROPTABLES && !db->query("DROP TABLE IF EXISTS `%s`", get_table()) )
-				exception("unable to drop table '%s'", get_table());
+		if (db->table_exists(get_table())) {
+			if (get_options() & MO_DROPTABLES && !db->query("DROP TABLE IF EXISTS `%s`", rc->get_table().get_string()))
+				exception("unable to drop table '%s'", rc->get_table().get_string());
 		}
-		
+
 		// create table if not exists
-		if ( !db->table_exists(get_table()) )
-		{
-			if ( !(options&MO_NOCREATE) )
-			{
-				if ( !db->query("CREATE TABLE IF NOT EXISTS `%s` ("
-					"`%s` INT AUTO_INCREMENT PRIMARY KEY, "
-					"`%s` TIMESTAMP, "
-					"%s"
-					"INDEX `i_%s` (`%s`) "
-					")", 
-					get_table(),
-					(const char*)recordid_fieldname,
-					(const char*)datetime_fieldname,
-					property_list,
-					(const char*)datetime_fieldname, (const char*)datetime_fieldname))
-					exception("unable to create table '%s' in schema '%s'", get_table(), db->get_schema());
+		ostringstream query;
+		string query_string;
+		string temp = rc->get_table_path()->get_table_header_buffer().str();
+
+		query << "CREATE TABLE IF NOT EXISTS `" << rc->get_table().get_string() << "` ("
+				"`" << recordid_fieldname << "` INT AUTO_INCREMENT PRIMARY KEY, "
+				"`" << datetime_fieldname << "` DATETIME, "
+				"" << rc->get_table_path()->get_table_header_buffer().str() << ""
+				"INDEX `i_" << datetime_fieldname << "` "
+				"(`" << datetime_fieldname << "`))";
+		if (!db->table_exists(rc->get_table().get_string())) {
+			if (!(get_options() & MO_NOCREATE)) {
+				query_string = query.str();
+				const char* query_char_string = query_string.c_str();
+				if (!db->query(query_char_string))
+					exception("unable to create table '%s' in schema '%s'", rc->get_table().get_string(), db->get_schema());
 				else
-					gl_verbose("table %s created ok", get_table());
-			}
-			else
-				exception("NOCREATE option prevents creation of table '%s'", get_table());
+					gl_verbose("table %s created ok", rc->get_table().get_string());
+			} else
+				exception("NOCREATE option prevents creation of table '%s'", rc->get_table().get_string());
 		}
 
-		// check row count
-		else 
-		{
-			if ( db->select("SELECT count(*) FROM `%s`", get_table())==NULL )
-				exception("unable to get row count of table '%s'", get_table());
+// check row count
+		else {
+			if (db->select("SELECT count(*) FROM `%s`", rc->get_table().get_string()) == NULL)
+				exception("unable to get row count of table '%s'", rc->get_table().get_string());
 
-			gl_verbose("table '%s' ok", get_table());
+			gl_verbose("table '%s' ok", rc->get_table().get_string());
 		}
 	}
-	else
-	{
+	else {
 		exception("no properties specified");
 		return 0;
 	}
 
 	// set heartbeat
-	if ( interval>0 )
-	{
-		set_heartbeat((TIMESTAMP)interval);
+	if (interval > 0) {
+		set_heartbeat((TIMESTAMP) interval);
 		enabled = true;
 	}
 
 	// arm trigger, if any
-	if ( enabled && trigger[0]!='\0' )
-	{
+	if (enabled && trigger[0] != '\0') {
 		// read trigger condition
-		if ( sscanf(trigger,"%[<>=!]%s",compare_op,compare_val)==2 )
-		{
+		if (sscanf(trigger, "%[<>=!]%s", compare_op, compare_val) == 2) {
 			// enable trigger and suspend data collection
-			trigger_on=true;
-			enabled=false;
+			trigger_on = true;
+			enabled = false;
 			gl_debug("%s: trigger '%s' enabled", get_name(), get_trigger());
 		}
 	}
@@ -282,80 +258,126 @@ int recorder::init(OBJECT *parent)
 	return 1;
 }
 
-EXPORT TIMESTAMP heartbeat_recorder(OBJECT *obj)
-{
-	recorder *my = OBJECTDATA(obj,recorder);
-	if ( !my->get_trigger_on() && !my->get_enabled() ) return TS_NEVER;
+EXPORT TIMESTAMP heartbeat_recorder(OBJECT *obj) {
+	recorder *my = OBJECTDATA(obj, recorder);
+	if (!my->get_trigger_on() && !my->get_enabled())
+		return TS_NEVER;
 	obj->clock = gl_globalclock;
-	TIMESTAMP dt = (TIMESTAMP)my->get_interval();
-	
+	TIMESTAMP dt = (TIMESTAMP) my->get_interval();
+
 	// recorder is always a soft event
-	return -(obj->clock/dt+1)*dt;
+	return -(obj->clock / dt + 1) * dt;
 }
 
-TIMESTAMP recorder::commit(TIMESTAMP t0, TIMESTAMP t1)
-{
+TIMESTAMP recorder::commit(TIMESTAMP t0, TIMESTAMP t1) {
+	query_engine* rc = recorder_connection;
+
 	// check trigger
-	if ( trigger_on )
-	{
+	if (trigger_on) {
 		// trigger condition
-		if ( property_target[0].compare(compare_op,compare_val) )
-		{
+		if (property_target[0].compare(compare_op, compare_val))
+				{
 			// disable trigger and enable data collection
 			trigger_on = false;
 			enabled = true;
 		}
 	}
-	else if ( trigger[0]=='\0' )
+	else if (trigger[0] == '\0')
 		enabled = true;
 
 	// check sampling interval
 	gl_debug("%s: interval=%.0f, clock=%lld", get_name(), interval, gl_globalclock);
-	if ( interval>0 )
-	{
-		if ( gl_globalclock%((TIMESTAMP)interval)!=0 )
+	if (interval > 0) {
+		if ( gl_globalclock % ((TIMESTAMP) interval) != 0)
 			return TS_NEVER;
 		else
 			gl_verbose("%s: sampling time has arrived", get_name());
 	}
 
 	// collect data
-	if ( enabled )
-	{
-		gl_debug("header_fieldname=[%s]", (const char*)header_fieldnames);
+	if (enabled) {
+		gl_debug("header_fieldname=[%s]", (const char*) header_fieldnames);
 		gl_debug("header_fielddata=[%s]", header_data);
 		char fieldlist[65536] = "", valuelist[65536] = "";
 		size_t fieldlen = 0;
-		if ( header_fieldnames[0]!='\0' )
-			fieldlen = sprintf(fieldlist,",%s",(const char*)header_fieldnames);
-		strcpy(valuelist,header_data);
+		if (header_fieldnames[0] != '\0')
+			fieldlen = sprintf(fieldlist, ",%s", (const char*) header_fieldnames);
+		strcpy(valuelist, header_data);
 		size_t valuelen = strlen(valuelist);
-		for ( size_t n = 0 ; n < property_target.size() ; n++ )
-		{
+		for (size_t n = 0; n < property_target.size(); n++) {
+			string* name_string = new string(property_target[n].get_sql_safe_name());
 			char buffer[1024] = "NULL";
-			if ( property_unit[n].is_valid() )
-				fieldlen += sprintf(fieldlist+fieldlen,",`%s[%s]`", property_target[n].get_name(), property_unit[n].get_name());
-			else
-				fieldlen += sprintf(fieldlist+fieldlen,",`%s`", property_target[n].get_name());
-			db->get_sqldata(buffer, sizeof(buffer), property_target[n], &property_unit[n]);
-			valuelen += sprintf(valuelist+valuelen,", %s", buffer);
+
+			if (property_unit[n].is_valid()) {
+				db->get_sqldata(buffer, sizeof(buffer), property_target[n], &property_unit[n]);
+				rc->get_table_path()->add_insert_values(rc, name_string, string(buffer));
+				rc->get_table_path()->add_insert_values(rc, new string(*name_string + "_units"), string(property_unit[n].get_name()));
+			}
+			else {
+				db->get_sqldata(buffer, sizeof(buffer), property_target[n], &property_unit[n]);
+				rc->get_table_path()->add_insert_values(rc, name_string, string(buffer));
+			}
 		}
-		db->query("INSERT INTO `%s` (`%s`%s) VALUES (from_unixtime('%"FMT_INT64"d')%s)",
-			get_table(), (const char*)datetime_fieldname, fieldlist, db->convert_to_dbtime(gl_globalclock),  valuelist);
 
+		// This partially duplicates some logic used above, and I don't like it, so it may be reworked later.
+		char header_buffer[1024];
+		strcpy(header_buffer, header_fieldnames);
+		vector<string> header_specs = split(header_buffer, ",");
+		for (size_t n = 0; n < header_specs.size(); n++) {
+			if (header_specs[n].compare("name") == 0) {
+				rc->get_table_path()->add_insert_values(rc, new string("name"), string("'" + string(get_parent()->get_name()) + "'"));
+			}
+			else if (header_specs[n].compare("class") == 0) {
+				rc->get_table_path()->add_insert_values(rc, new string("class"), string("'" + string(get_parent()->get_oclass()->get_name()) + "'"));
+			}
+			else if (header_specs[n].compare("latitude") == 0) {
+				if (isnan(get_parent()->get_latitude()))
+					rc->get_table_path()->add_insert_values(rc, new string("latitude"), string("NULL"));
+				else
+					rc->get_table_path()->add_insert_values(rc, new string("latitude"), string("'" + to_string(get_parent()->get_latitude()) + "'"));
+			}
+			else if (header_specs[n].compare("longitude") == 0) {
+				if (isnan(get_parent()->get_longitude()))
+					rc->get_table_path()->add_insert_values(rc, new string("longitude"), string("NULL"));
+				else
+					rc->get_table_path()->add_insert_values(rc, new string("longitude"), string("'" + to_string(get_parent()->get_longitude()) + "'"));
+			}
+			else
+				exception("header field %s does not exist", (const char*) header_specs[n].c_str());
+		}
 
-		// check limit
-		if ( get_limit()>0 && db->get_last_index()>=get_limit() )
-		{
+// check limit
+		if (get_limit() > 0 && db->get_last_index() >= get_limit()) {
+			rc->get_table_path()->commit_state();
+
 			// shut off recorder
-			enabled=false;
-			gl_verbose("table '%s' size limit %d reached", get_table(), get_limit());
+			rc->set_tables_done();
+			enabled = false;
+			gl_verbose("table '%s' size limit %d reached", rc->get_table().get_string(), get_limit());
 		}
 	}
-	else
+	else {
 		gl_debug("%s: sampling is not enabled", get_name());
-	
+	}
+
+	rc->get_table_path()->flush_value_row(&t0);
+
+	if (gl_globalclock == gl_globalstoptime) {
+		rc->get_table_path()->flush_value_row(&t1);
+		rc->get_table_path()->commit_state();
+		rc->set_tables_done();
+	}
+
 	return TS_NEVER;
+}
+
+template<class T> std::string recorder::to_string(T t) {
+	std::string returnBuffer;
+	std::ostringstream string_conversion_buffer;
+	string_conversion_buffer.precision(15);
+	string_conversion_buffer << t;
+	returnBuffer = string_conversion_buffer.str();
+	return returnBuffer;
 }
 
 #endif // HAVE_MYSQL

--- a/mysql/recorder.h
+++ b/mysql/recorder.h
@@ -13,9 +13,13 @@
 #include <string>
 #include <vector>
 
+#include "database.h"
+#include "query_engine.h"
+
 class recorder : public gld_object {
 public:
 	GL_STRING(char1024,property);
+//	GL_STRING(char1024, group_def);
 	GL_STRING(char32,trigger);
 	GL_STRING(char1024,table);
 	GL_STRING(char32,mode);
@@ -26,9 +30,14 @@ public:
 	GL_ATOMIC(char32,datetime_fieldname);
 	GL_ATOMIC(char32,recordid_fieldname);
 	GL_ATOMIC(char1024,header_fieldnames);
+	GL_STRING(char256, complex_part);
+	GL_STRING(char256, data_type);
+	GL_ATOMIC(int32, query_buffer_limit);
+
 private:
 	bool enabled;
 	database *db;
+	query_engine* recorder_connection;
 	bool trigger_on;
 	char compare_op[16];
 	char compare_val[32];
@@ -36,6 +45,7 @@ private:
 	std::vector<gld_property> property_target;
 	std::vector<gld_unit> property_unit;
 	char header_data[1024];
+	template<class T> std::string to_string(T); // This template exists in both Recorder and Group Recorder, and could be cleaned up.
 public:
 	inline bool get_trigger_on(void) { return trigger_on; };
 	inline bool get_enabled(void) { return enabled; };

--- a/mysql/recorder.h
+++ b/mysql/recorder.h
@@ -16,26 +16,57 @@
 #include "database.h"
 #include "query_engine.h"
 
+
+class recorder_quickobjlist {
+	public:
+		recorder_quickobjlist() {
+			obj = 0;
+			next = 0;
+			memset(&prop, 0, sizeof(PROPERTYSTRUCT));
+		}
+		recorder_quickobjlist(OBJECT *o, PROPERTYSTRUCT *p) {
+			obj = o;
+			next = 0;
+			memcpy(&prop, p, sizeof(PROPERTYSTRUCT));
+		}
+		~recorder_quickobjlist() {
+			if (next != 0)
+				delete next;
+		}
+		void tack(OBJECT *o, PROPERTYSTRUCT *p) {
+			if (next) {
+				next->tack(o, p);
+			} else {
+				next = new recorder_quickobjlist(o, p);
+			}
+		}
+		OBJECT *obj;
+		PROPERTYSTRUCT prop;
+		recorder_quickobjlist *next;
+};
+
+
 class recorder : public gld_object {
 public:
 	GL_STRING(char1024,property);
-//	GL_STRING(char1024, group_def);
 	GL_STRING(char32,trigger);
 	GL_STRING(char1024,table);
+	GL_STRING(char1024,group);
 	GL_STRING(char32,mode);
 	GL_ATOMIC(int32,limit);
 	GL_ATOMIC(double,interval);
 	GL_ATOMIC(object,connection);
-	GL_ATOMIC(set,options);
+	GL_ATOMIC(set,options); // this options set is generated based on the mode.
+	GL_ATOMIC(set,sql_options); // this is the actual flag set the user can set with the 'options' input.
 	GL_ATOMIC(char32,datetime_fieldname);
 	GL_ATOMIC(char32,recordid_fieldname);
 	GL_ATOMIC(char1024,header_fieldnames);
-	GL_STRING(char256, complex_part);
 	GL_STRING(char256, data_type);
 	GL_ATOMIC(int32, query_buffer_limit);
 
 private:
 	bool enabled;
+	bool group_mode;
 	database *db;
 	query_engine* recorder_connection;
 	bool trigger_on;
@@ -44,7 +75,12 @@ private:
 	size_t n_properties;
 	std::vector<gld_property> property_target;
 	std::vector<gld_unit> property_unit;
+	std::vector<std::string> property_specs;
 	char header_data[1024];
+	recorder_quickobjlist *group_obj_list;
+	gld_objlist* group_items;
+	int group_obj_count;
+	int group_limit_counter;
 	template<class T> std::string to_string(T); // This template exists in both Recorder and Group Recorder, and could be cleaned up.
 public:
 	inline bool get_trigger_on(void) { return trigger_on; };

--- a/mysql/table_manager.cpp
+++ b/mysql/table_manager.cpp
@@ -1,0 +1,156 @@
+/*
+ * table_manager.cpp
+ *
+ *  Created on: Dec 4, 2017
+ *      Author: eber205
+ */
+
+#include <sstream>
+#include <vector>
+#include "query_engine.h"
+using namespace std;
+
+table_manager::table_manager(database* db_in, set options_in, int threshold_in, int column_in, int table_index_in, char1024* table_name_in) :
+		query_engine(db_in, options_in, threshold_in, column_in) {
+	char* table_temp_name = new char[1024];
+	sprintf(table_temp_name, "%s_%d", table_name_in->get_string(), table_index_in);
+	table_index = table_index_in;
+	table_root = table_name_in;
+	table.copy_from(table_temp_name);
+
+	insert_values_initialized = false;
+
+	prev_table = NULL;
+	next_table = NULL;
+	column_count = 0;
+	insert_count = 0;
+	done = false;
+}
+
+void table_manager::init_table(table_manager* prev_table_in, table_manager* next_table_in) {
+	prev_table = prev_table_in;
+	next_table = next_table_in;
+}
+
+void table_manager::extend_list(query_engine* parent) {
+	table_manager* new_table = new table_manager(db, options, threshold, column_limit, table_index + 1, table_root);
+	new_table->init_table(this, (next_table != NULL) ? next_table : this);
+	next_table = new_table;
+	if (prev_table == NULL) {
+		prev_table = new_table; // establishes the circular binding on first insertion.
+	}
+	parent->inc_table_count();
+}
+
+bool table_manager::query_table(string* column_name_in) {
+	for (int i = 0; i < table_headers.size(); i++) {
+		if (table_headers[i]->compare(*column_name_in) == 0) {
+			return true;
+		}
+	}
+	return false;
+}
+
+int table_manager::add_table_header(query_engine* parent, stringstream& property_list, string* property_name) {
+	if (column_count < column_limit) {
+		string* temp = new string();
+
+		table_header_buffer << property_list.str();
+		property_list.str("");
+		property_list.clear();
+
+		temp->assign(*property_name);
+		table_headers.push_back(temp);
+
+		column_count++;
+
+		return 1; // Success
+	} else {
+		this->extend_list(parent);
+		parent->next_table();
+		return next_table->add_table_header(parent, property_list, property_name);
+	}
+}
+
+int table_manager::add_insert_values(query_engine* parent, string* column_name, double value) {
+	if (query_table(column_name)) {
+		insert_values.push_back(value);
+		insert_count++;
+	} else {
+		parent->next_table();
+		return parent->get_table_path()->add_insert_values(parent, column_name, value, table_index);
+	}
+	return 1; // Success
+}
+
+int table_manager::add_insert_values(query_engine* parent, string* column_name, double value, int start_table) {
+	if (start_table == table_index)
+		return 0;
+
+	if (query_table(column_name)) {
+		insert_values.push_back(value);
+		insert_count++;
+	} else {
+		parent->next_table();
+		return parent->get_table_path()->add_insert_values(parent, column_name, value, start_table);
+	}
+	return 1; // Success
+}
+
+void table_manager::flush_value_row(TIMESTAMP* timestamp) {
+	if (!done) {
+		if (query_count == threshold) {
+			commit_values();
+			query_count = 0;
+		}
+
+		int value_count = insert_values.size();
+		if (value_count > 0) {
+			if (!insert_values_initialized) {
+				insert_values_buffer.precision(15);
+				insert_values_buffer << "VALUES(";
+				insert_values_initialized = true;
+			} else {
+				insert_values_buffer << ", (";
+			}
+			insert_values_buffer << "FROM_UNIXTIME('" << (long long) *timestamp << "'), ";
+			for (int i = 0; i < value_count - 1; i++) {
+				insert_values_buffer << insert_values[i] << ", ";
+			}
+			insert_values_buffer << insert_values[value_count - 1] << ")" << std::flush;
+
+			insert_values.clear();
+			query_count++;
+		}
+	}
+}
+
+void table_manager::clear_values_init() {
+	insert_values_initialized = false;
+	insert_values.clear();
+}
+
+void table_manager::commit_values() {
+	ostringstream query;
+	string query_string, value_buffer;
+
+	if (insert_count > 0) {
+		int column_count = table_headers.size();
+		query << "INSERT INTO `" << table.get_string() << "` (`t`, `";
+
+		for (int i = 0; i < column_count - 1; i++) {
+			query << *table_headers[i] << "`, `";
+		}
+		value_buffer = insert_values_buffer.str();
+		query << *table_headers[column_count - 1] << "`) " << value_buffer << ";" << std::flush;
+		query_string = query.str();
+		const char* temp = query_string.c_str();
+		if (value_buffer.length() > 0)
+			db->query(query_string.c_str());
+
+		insert_values_buffer.str("");
+		insert_values_buffer.clear();
+		insert_values_initialized = false;
+		insert_count = 0;
+	}
+}

--- a/mysql/table_manager.cpp
+++ b/mysql/table_manager.cpp
@@ -20,7 +20,7 @@ table_manager::table_manager(database* db_in, set options_in, int threshold_in, 
 
 	insert_values_initialized = false;
 
-	next_table = NULL;
+	next_table = this;
 	column_count = 0;
 	insert_count = 0;
 	done = false;

--- a/mysql/table_manager.cpp
+++ b/mysql/table_manager.cpp
@@ -20,25 +20,24 @@ table_manager::table_manager(database* db_in, set options_in, int threshold_in, 
 
 	insert_values_initialized = false;
 
-	prev_table = NULL;
 	next_table = NULL;
 	column_count = 0;
 	insert_count = 0;
 	done = false;
 }
 
-void table_manager::init_table(table_manager* prev_table_in, table_manager* next_table_in) {
-	prev_table = prev_table_in;
+std::vector<std::string*>* table_manager::get_table_headers(){
+	return &table_headers;
+}
+
+void table_manager::init_table(table_manager* next_table_in) {
 	next_table = next_table_in;
 }
 
 void table_manager::extend_list(query_engine* parent) {
 	table_manager* new_table = new table_manager(db, options, threshold, column_limit, table_index + 1, table_root);
-	new_table->init_table(this, (next_table != NULL) ? next_table : this);
+	new_table->init_table((next_table != NULL) ? next_table : this);
 	next_table = new_table;
-	if (prev_table == NULL) {
-		prev_table = new_table; // establishes the circular binding on first insertion.
-	}
 	parent->inc_table_count();
 }
 
@@ -123,11 +122,6 @@ void table_manager::flush_value_row(TIMESTAMP* timestamp) {
 			query_count++;
 		}
 	}
-}
-
-void table_manager::clear_values_init() {
-	insert_values_initialized = false;
-	insert_values.clear();
 }
 
 void table_manager::commit_values() {


### PR DESCRIPTION
#### What's this Pull Request do?
Supersedes Pull Request #1093.
#1060: Adds a MySQL implementation of the group_recorder class, as well as tests and support components needed to make the implementation viable. 
#1095: Adds improvements to the MySQL Recorder which allow for 'group' mode as well as making use of the query engine and buffering structures built for group_recorder. 
#1063: This bug was fixed as a necessary prerequisite for having the improvements made for #1095 work. 

#### Where should the reviewer start?
The reviewer will need to ensure gridlab-d is built and installed with MySQL support, and that the MySQL Connector C is installed and linked on their machine. 
To verify correct configuration and system compatibility, the "validate.no" file in the "mysql" directory should be removed, and gridlab-d's validation and test suite should be run. 

#### How should this be tested?
#1060: The system should be run using the MySQL module to replace the tape module for several group recorders of varying size, interval, and output count, to verify backwards compatibility with existing group recorders.
Additionally, the system should be tested with bespoke group recorders designed to test the various system functionalities and input options as listed on the [MySQL Group Recorder Wiki Page](http://gridlab-d.shoutwiki.com/wiki/Group_recorder_(mysql)).
Any test cases which might push the edge cases of the system should be run, and verified to either work, or fail in a predictable and resolvable way. 
#1095: The updated MySQL Recorder should be tested against several existing recorder examples to verify compatibility. 
#1063/#1095: New recorders should be assembled and tested making use of the new complex part attribute of the property parameter (see mysql/autotest/test_mysql_recorder_properties.glm for examples). 
#1095: New recorders should be assembled and tested making use of the new group parameter. The output should be verified to be data consistent with both the tape and mysql group recorders. 

#### What are the relevant issues?
#1060: MySQL has a hard row-size limit can cause the application to fail out during startup if the simulation produces more than 4096 columns or 65,535 bytes, whichever is smaller. This issue is generally addressed by the auto-set column_limit value, however it is possible to manually increase the value to levels where the system will fault.
Due to the overhead of initializing tables, and transferring data to MySQL, this implementation is slightly slower than the tape group recorder under most conditions, however if the simulation is small enough, and the query_buffer_limit is set low enough, the database interaction overhead can dominate the runtime, and significantly hinder use. 
#1095: There are some known risks surrounding the query_buffer_limit value and the user being able to modify it, as the property directly controls how much data is set to the database at a time. A value of 1 essentially acts in the same way as the old recorder (but with added overhead) and hinders performance. A large value (depends on the size of the MySQL cache configuration and the amount of data per query, but on the order of several thousand) in the query_buffer_limit can result in the buffered queries exceeding MySQL's cache length, resulting in MySQL halting the program until it has ingested the first section of data, before accepting the remaining data, which significantly affects performance. 

#### Questions:
- [X] Does this add new dependencies? 
No.
- [X] Is there appropriate logging included? 
Yes. 

[validate.txt](https://github.com/gridlab-d/gridlab-d/files/1856933/validate.txt)
