### PR TITLE
debian package update

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -285,7 +285,7 @@ dist-osx:
 
 # Build deb (binary and source) packages
 dist-deb: distdir
-	echo -e "gridlabd ($(VERSION)-1) unstable; urgency=low\n\n  * Version $(VERSION) release.\n  * View recent changes at: https://sourceforge.net/apps/mediawiki/gridlab-d/index.php?title=Special:RecentChanges\n\n -- GridLAB-D Team <gridlabd@pnl.gov> `date -R`\n" > $(distdir)/debian/changelog
+	echo -e "gridlabd ($(VERSION)-1) unstable; urgency=low\n\n  * Version $(VERSION) release.\n  * View recent changes at: https://sourceforge.net/apps/mediawiki/gridlab-d/index.php?title=Special:RecentChanges\n\n -- GridLAB-D Team <gridlabd@pnl.gov>  `date -R`\n" > $(distdir)/debian/changelog
 	ln -s $(distdir) $(distdir)-1
 	(cd $(distdir)-1 && dpkg-buildpackage -tc -us -uc $(DEBFLAGS))
 	rm -f $(distdir)-1

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: gridlabd
 Section: non-free/science
 Priority: extra
 Maintainer: GridLAB-D Team <gridlabd@pnl.gov>
-Build-Depends: debhelper (>= 7), autotools-dev, libxerces-c2-dev (>= 2.7), libc6-dev
+Build-Depends: debhelper (>= 7), autotools-dev, libxerces-c-dev (>= 2.7), libc6-dev
 Standards-Version: 3.8.3
 Homepage: http://www.gridlabd.org/
 

--- a/debian/gridlabd.install
+++ b/debian/gridlabd.install
@@ -1,2 +1,3 @@
 usr/bin
 usr/lib/gridlabd
+usr/share/gridlabd

--- a/debian/rules
+++ b/debian/rules
@@ -4,6 +4,9 @@
 # Uncomment this to turn on verbose mode.
 #export DH_VERBOSE=1
 
+override_dh_auto_configure:
+	dh_auto_configure -- --enable-silent-rules 'CFLAGS=-g -O0 -w' 'CXXFLAGS=-g -O0 -w' 'LDFLAGS=-g -O0 -w'
+
 %:
 	dh  $@
 

--- a/debian/rules
+++ b/debian/rules
@@ -13,3 +13,6 @@ override_dh_auto_configure:
 override_dh_install:
 	dh_install
 	rm -f debian/gridlabd/usr/lib/gridlabd/*.la
+
+override_dh_fixperms:
+	dh_fixperms --exclude .so


### PR DESCRIPTION
This pull request updates (slightly) the make for debian packaging.

The 85c95c008c04612cadab4e4874a54fa0f1ec333f commit simply corrects the added changelog trailer and should be safe to cherry-pick.

The eafcfbc51b7893811001b72170bef2efc330572e commit quiets down the make dist-deb quite a bit and agrees with the suggested configuration in README-LINUX. This should also be safe to cherry-pick.

The 2594665152e5a3bf1ddb18d896b38752b73c4128 commit uses the new name for libxerces, since the older library version is not available via normal update channels anymore. This may be more problematic and should probably be reviewed to see if any API changes between the two versions cause problems.

The 5cb55cf9fbf34d22df91b313d22e15b77f188748 commit adds the share directory to the package and keeps the shared object libraries executable flags.
 
Testing via:
    **make dist-deb**
now creates packages, when it didn't before, on relatively new distros.
This has no effect on the underlying codebase.
Simple .glm files are simulated correctly and show no differences in recorder output other than rounding errors near zero.
Testing with **gridlabd --validate** on Ubuntu 18.04 Bionic Beaver (4.15.0-22-generic) indicates 100% (532 models/tests) succeeded. 

Since gridlabd is only shipped as rpm files for Linux (https://sourceforge.net/projects/gridlab-d/files/gridlab-d/Candidate%20release), I was hoping to be able to generate deb files directly, rather than need to use alien to convert the rpm to a deb.

There is still the issue that debian helper compatibility mode 7 is used, while modern distros are at 10.
