### PR TITLE
Added support for filter resolution and saturation

### DIFF
--- a/gldcore/autotest/test_filter_constraint.glm
+++ b/gldcore/autotest/test_filter_constraint.glm
@@ -1,0 +1,30 @@
+// Filter test simple delay
+//
+clock {
+	timezone PST+8PDT;
+	starttime '2000-01-01 00:00:00 PST';
+	stoptime '2001-01-01 00:00:00 PST';
+}
+#set debug=1
+filter delay(z,5min,10s,resolution=8,minimum=-2.5,maximum=2.5) = 1/z;
+class from {
+	randomvar value;
+}
+class to {
+	double value;
+}
+object from {
+	name from;
+	value "type:normal(0,1); min:-3.0; max:+3.0; refresh:1min";
+}
+object to {
+	name to;
+	value delay(from:value);
+}
+#set debug=0
+module tape;
+object multi_recorder {
+	file output.csv;
+	interval -1;
+	property "from:value,to:value";
+}

--- a/gldcore/exec.c
+++ b/gldcore/exec.c
@@ -1230,7 +1230,7 @@ STATUS t_sync_all(PASSCONFIG pass)
 
 	/* run all non-schedule transforms */
 	{
-		TIMESTAMP st = transform_syncall(global_clock,XS_DOUBLE|XS_COMPLEX|XS_ENDUSE);// if (abs(t)<t2) t2=t;
+		TIMESTAMP st = transform_syncall(global_clock,XS_ALL&(~(XS_SCHEDULE|XS_LOADSHAPE)));// if (abs(t)<t2) t2=t;
 		if (st<sync.step_to)
 			sync.step_to = st;
 	}
@@ -2181,7 +2181,7 @@ STATUS exec_start(void)
 
 				/* run all non-schedule transforms */
 				{
-					TIMESTAMP st = transform_syncall(global_clock,XS_DOUBLE|XS_COMPLEX|XS_ENDUSE);// if (abs(t)<t2) t2=t;
+					TIMESTAMP st = transform_syncall(global_clock,XS_ALL&(~(XS_SCHEDULE|XS_LOADSHAPE)));// if (abs(t)<t2) t2=t;
 					exec_sync_set(NULL,st);
 				}
 			}

--- a/gldcore/transform.h
+++ b/gldcore/transform.h
@@ -20,11 +20,11 @@ typedef enum {
 	XS_UNKNOWN	= 0x00, 
 	XS_DOUBLE	= 0x01, 
 	XS_COMPLEX	= 0x02, 
-	XS_LOADSHAPE= 0x04, 
+	XS_LOADSHAPE    = 0x04, 
 	XS_ENDUSE	= 0x08, 
-	XS_SCHEDULE = 0x10,
-	XS_RANDOMVAR = 0x20,
-	XS_ALL		= 0x1f,
+	XS_SCHEDULE     = 0x10,
+	XS_RANDOMVAR    = 0x20,
+	XS_ALL		= 0x3f,
 } TRANSFORMSOURCE;
 
 /* list of supported transform function types */
@@ -49,6 +49,14 @@ typedef struct s_transferfunction {
 	double *a;			///< denominator coefficients
 	unsigned int m;		///< numerator order
 	double *b;			///< numerator coefficients
+#define FC_NONE 0x0000 ///< no constraints
+#define FC_RESOLUTION  0x0001 ///< resolution limit
+#define FC_MINIMUM  0x0002 ///< lower limit
+#define FC_MAXIMUM  0x0004 ///< upper limit
+	unsigned int64 flags; ///< constraints flags
+	double resolution; ///< resolution in bits
+	double minimum; ///< lowest value
+	double maximum; ///< highest value
 	struct s_transferfunction *next;
 } TRANSFERFUNCTION;
 
@@ -109,6 +117,7 @@ UNIT *gldvar_getunits(GLDVAR *var, unsigned int n);
 
 int transform_add_filter(struct s_object_list *target_obj, struct s_property_map *target_prop, char *function, struct s_object_list *source_obj, struct s_property_map *source_prop);
 int transfer_function_add(char *tfname, char *domain, double timestep, double timeskew, unsigned int n, double *a, unsigned int m, double *b);
+int transfer_function_constrain(char *tfname, unsigned int64 flags, unsigned int64 nbits, double minimum, double maximum);
 
 int transform_saveall(FILE *fp);
 


### PR DESCRIPTION
#### What's this Pull Request do?

This addresses issues #1125 and #1126.

#### Where should the reviewer start?

http://gridlab-d.shoutwiki.com/wiki/Filter#Wanted describes to wanted features.  https://github.com/gridlab-d/gridlab-d/issues/1125 addesses quantized output.  https://github.com/gridlab-d/gridlab-d/issues/1126 addresses saturation output.

#### How should this be tested?

A test file has been added in _gldcore/autotest_ called _test_filter_constraint.glm_ that should test both saturation and quantization of filter output. The output should not exceed the min/max limits and the sampling should be quantized according the number of bits specified in the resolution field.

#### Any background context you want to provide?

This is needed by the SLAC PowerNet with Markets project for the CEC.

#### What are the relevant issues?

There are some added debug statements to aid debugging the use of filters with constraints.  

There was also a missing test for source types on transforms that caused some transforms to be ignored. This is now a warning and all transforms from unknown sources will be run.

There was also two erroneous calls to _transform_syncall_ in _gldcore/exec.c_. These have been corrected to ensure that all source types are considered when necessary.

The documentation needs to be updated.  Please advise @dchassin known when it is appropriate to do so.

As a bonus, this should also fix the intermittent validation test error in _gldcore/test_filter_second.glm_.

#### Screenshots (if appropriate)

N/A.

#### Questions:
- [ ] Does this add new dependencies?
- [ ] Is there appropriate logging included?
