### PR TITLE
(bugfix/1176) Fix to impedance_dump so non-named items don't cause segfaults

### DIFF
--- a/powerflow/autotest/test_impedance_dump_noname.glm
+++ b/powerflow/autotest/test_impedance_dump_noname.glm
@@ -1,0 +1,110 @@
+//Autotest file
+//Runs impedance dump with empty names - used to cause segfaults
+//Basically, it should just run without issues
+
+clock {
+	timezone PST+8PDT; //UTC-5
+	starttime '2018-06-30 14:00:00';
+	stoptime '2018-06-30 15:00:00';
+}
+
+module powerflow;
+
+object impedance_dump {
+	filename impedance_output.xml;
+}
+
+object overhead_line_conductor {
+	name overhead_line_conductor100;
+	geometric_mean_radius 0.0244;
+	resistance 0.306;
+}
+
+object overhead_line_conductor {
+	name overhead_line_conductor101;
+	geometric_mean_radius 0.00814;
+	resistance 0.592;
+}
+
+object line_spacing {
+	name line_spacing200;
+	distance_AB 2.5;
+	distance_BC 4.5;
+	distance_AC 7.0;
+	distance_AN 5.656854;
+	distance_BN 4.272002;
+	distance_CN 5.0;
+}
+
+object line_configuration {
+	name line_configuration300;
+	conductor_A overhead_line_conductor100;
+	conductor_B overhead_line_conductor100;
+	conductor_C overhead_line_conductor100;
+	conductor_N overhead_line_conductor101;
+	spacing line_spacing200;
+}
+
+object transformer_configuration {
+	name transformer_configuration400;
+	connect_type 1;
+	power_rating 6000;
+	powerA_rating 2000;
+	powerB_rating 2000;
+	powerC_rating 2000;
+	primary_voltage 12470;
+	secondary_voltage 4160;
+	resistance 0.01;
+	reactance 0.06;
+}
+
+object node {
+	name node1;
+	bustype SWING;
+	phases "ABCN";
+	nominal_voltage 7200;
+}
+
+object overhead_line {
+	phases "ABCN";
+	//name node12;
+	from node1;
+	to node2;
+	length 2000;
+	configuration line_configuration300;
+}
+
+object node {
+	name node2;
+	phases "ABCN";
+	nominal_voltage 7200;
+}
+
+object transformer {
+	name transformer23;
+	phases "ABCN";
+	from node2;
+	to node3;
+	configuration transformer_configuration400;
+}
+
+object node {
+	name node3;
+	phases "ABCN";
+	nominal_voltage 2400;
+}
+
+object overhead_line:34 {
+	phases "ABCN";
+	from node3;
+	name node34;
+	to node4;
+	length 2500;
+	configuration line_configuration300;
+}
+
+object node {
+	name node4;
+	phases "ABCN";
+	nominal_voltage 2400;
+}

--- a/powerflow/impedance_dump.cpp
+++ b/powerflow/impedance_dump.cpp
@@ -156,7 +156,7 @@ int impedance_dump::dump(TIMESTAMP t)
 			fprintf(fn,"\t<fuse>\n");
 
 			//write the name
-			if(obj->name[0] != 0){
+			if(obj->name != NULL){
 				fprintf(fn,"\t\t<name>%s</name>\n",obj->name);
 			} else {
 				fprintf(fn,"\t\t<name>NA</name>\n");
@@ -166,14 +166,14 @@ int impedance_dump::dump(TIMESTAMP t)
 			fprintf(fn,"\t\t<id>fuse:%d</id>\n",obj->id);
 
 			//write the from name
-			if(pFuse[index]->from->name[0] != 0){
+			if(pFuse[index]->from->name != NULL){
 				fprintf(fn,"\t\t<from_node>%s:%s</from_node>\n",pFuse[index]->from->oclass->name,pFuse[index]->from->name);
 			} else {
 				fprintf(fn,"\t\t<from_node>%s:%d</from_node>\n",pFuse[index]->from->oclass->name,pFuse[index]->from->id);
 			}
 
 			//write the to name
-			if(pFuse[index]->to->name[0] != 0){
+			if(pFuse[index]->to->name != NULL){
 				fprintf(fn,"\t\t<to_node>%s:%s</to_node>\n",pFuse[index]->to->oclass->name,pFuse[index]->to->name);
 			} else {
 				fprintf(fn,"\t\t<to_node>%s:%d</to_node>\n",pFuse[index]->to->oclass->name,pFuse[index]->to->id);
@@ -349,7 +349,7 @@ int impedance_dump::dump(TIMESTAMP t)
 			fprintf(fn,"\t<overhead_line>\n");
 
 			//write the name
-			if(obj->name[0] != 0){
+			if(obj->name != NULL){
 				fprintf(fn,"\t\t<name>%s</name>\n",obj->name);
 			} else {
 				fprintf(fn,"\t\t<name>NA</name>\n");
@@ -359,14 +359,14 @@ int impedance_dump::dump(TIMESTAMP t)
 			fprintf(fn,"\t\t<id>overhead_line:%d</id>\n",obj->id);
 
 			//write the from name
-			if(pOhLine[index]->from->name[0] != 0){
+			if(pOhLine[index]->from->name != NULL){
 				fprintf(fn,"\t\t<from_node>%s:%s</from_node>\n",pOhLine[index]->from->oclass->name,pOhLine[index]->from->name);
 			} else {
 				fprintf(fn,"\t\t<from_node>%s:%d</from_node>\n",pOhLine[index]->from->oclass->name,pOhLine[index]->from->id);
 			}
 
 			//write the to name
-			if(pOhLine[index]->to->name[0] != 0){
+			if(pOhLine[index]->to->name != NULL){
 				fprintf(fn,"\t\t<to_node>%s:%s</to_node>\n",pOhLine[index]->to->oclass->name,pOhLine[index]->to->name);
 			} else {
 				fprintf(fn,"\t\t<to_node>%s:%d</to_node>\n",pOhLine[index]->to->oclass->name,pOhLine[index]->to->id);
@@ -545,7 +545,7 @@ int impedance_dump::dump(TIMESTAMP t)
 			fprintf(fn,"\t<recloser>\n");
 
 			//write the name
-			if(obj->name[0] != 0){
+			if(obj->name != NULL){
 				fprintf(fn,"\t\t<name>%s</name>\n",obj->name);
 			} else {
 				fprintf(fn,"\t\t<name>NA</name>\n");
@@ -555,14 +555,14 @@ int impedance_dump::dump(TIMESTAMP t)
 			fprintf(fn,"\t\t<id>recloser:%d</id>\n",obj->id);
 
 			//write the from name
-			if(pRecloser[index]->from->name[0] != 0){
+			if(pRecloser[index]->from->name != NULL){
 				fprintf(fn,"\t\t<from_node>%s:%s</from_node>\n",pRecloser[index]->from->oclass->name,pRecloser[index]->from->name);
 			} else {
 				fprintf(fn,"\t\t<from_node>%s:%d</from_node>\n",pRecloser[index]->from->oclass->name,pRecloser[index]->from->id);
 			}
 
 			//write the to name
-			if(pRecloser[index]->to->name[0] != 0){
+			if(pRecloser[index]->to->name != NULL){
 				fprintf(fn,"\t\t<to_node>%s:%s</to_node>\n",pRecloser[index]->to->oclass->name,pRecloser[index]->to->name);
 			} else {
 				fprintf(fn,"\t\t<to_node>%s:%d</to_node>\n",pRecloser[index]->to->oclass->name,pRecloser[index]->to->id);
@@ -748,14 +748,14 @@ int impedance_dump::dump(TIMESTAMP t)
 			fprintf(fn,"\t\t<id>regulator:%d</id>\n",obj->id);
 
 			//write the from name
-			if(pRegulator[index]->from->name[0] != 0){
+			if(pRegulator[index]->from->name != NULL){
 				fprintf(fn,"\t\t<from_node>%s:%s</from_node>\n",pRegulator[index]->from->oclass->name,pRegulator[index]->from->name);
 			} else {
 				fprintf(fn,"\t\t<from_node>%s:%d</from_node>\n",pRegulator[index]->from->oclass->name,pRegulator[index]->from->id);
 			}
 
 			//write the to name
-			if(pRegulator[index]->to->name[0] != 0){
+			if(pRegulator[index]->to->name != NULL){
 				fprintf(fn,"\t\t<to_node>%s:%s</to_node>\n",pRegulator[index]->to->oclass->name,pRegulator[index]->to->name);
 			} else {
 				fprintf(fn,"\t\t<to_node>%s:%d</to_node>\n",pRegulator[index]->to->oclass->name,pRegulator[index]->to->id);
@@ -935,7 +935,7 @@ int impedance_dump::dump(TIMESTAMP t)
 			fprintf(fn,"\t<relay>\n");
 
 			//write the name
-			if(obj->name[0] != 0){
+			if(obj->name != NULL){
 				fprintf(fn,"\t\t<name>%s</name>\n",obj->name);
 			} else {
 				fprintf(fn,"\t\t<name>NA</name>\n");
@@ -945,14 +945,14 @@ int impedance_dump::dump(TIMESTAMP t)
 			fprintf(fn,"\t\t<id>relay:%d</id>\n",obj->id);
 
 			//write the from name
-			if(pRelay[index]->from->name[0] != 0){
+			if(pRelay[index]->from->name != NULL){
 				fprintf(fn,"\t\t<from_node>%s:%s</from_node>\n",pRelay[index]->from->oclass->name,pRelay[index]->from->name);
 			} else {
 				fprintf(fn,"\t\t<from_node>%s:%d</from_node>\n",pRelay[index]->from->oclass->name,pRelay[index]->from->id);
 			}
 
 			//write the to name
-			if(pRelay[index]->to->name[0] != 0){
+			if(pRelay[index]->to->name != NULL){
 				fprintf(fn,"\t\t<to_node>%s:%s</to_node>\n",pRelay[index]->to->oclass->name,pRelay[index]->to->name);
 			} else {
 				fprintf(fn,"\t\t<to_node>%s:%d</to_node>\n",pRelay[index]->to->oclass->name,pRelay[index]->to->id);
@@ -1128,7 +1128,7 @@ int impedance_dump::dump(TIMESTAMP t)
 			fprintf(fn,"\t<sectionalizer>\n");
 
 			//write the name
-			if(obj->name[0] != 0){
+			if(obj->name != NULL){
 				fprintf(fn,"\t\t<name>%s</name>\n",obj->name);
 			} else {
 				fprintf(fn,"\t\t<name>NA</name>\n");
@@ -1138,14 +1138,14 @@ int impedance_dump::dump(TIMESTAMP t)
 			fprintf(fn,"\t\t<id>sectionalizer:%d</id>\n",obj->id);
 
 			//write the from name
-			if(pSectionalizer[index]->from->name[0] != 0){
+			if(pSectionalizer[index]->from->name != NULL){
 				fprintf(fn,"\t\t<from_node>%s:%s</from_node>\n",pSectionalizer[index]->from->oclass->name,pSectionalizer[index]->from->name);
 			} else {
 				fprintf(fn,"\t\t<from_node>%s:%d</from_node>\n",pSectionalizer[index]->from->oclass->name,pSectionalizer[index]->from->id);
 			}
 
 			//write the to name
-			if(pSectionalizer[index]->to->name[0] != 0){
+			if(pSectionalizer[index]->to->name != NULL){
 				fprintf(fn,"\t\t<to_node>%s:%s</to_node>\n",pSectionalizer[index]->to->oclass->name,pSectionalizer[index]->to->name);
 			} else {
 				fprintf(fn,"\t\t<to_node>%s:%d</to_node>\n",pSectionalizer[index]->to->oclass->name,pSectionalizer[index]->to->id);
@@ -1321,7 +1321,7 @@ int impedance_dump::dump(TIMESTAMP t)
 			fprintf(fn,"\t<series reactor>\n");
 
 			//write the name
-			if(obj->name[0] != 0){
+			if(obj->name != NULL){
 				fprintf(fn,"\t\t<name>%s</name>\n",obj->name);
 			} else {
 				fprintf(fn,"\t\t<name>NA</name>\n");
@@ -1331,14 +1331,14 @@ int impedance_dump::dump(TIMESTAMP t)
 			fprintf(fn,"\t\t<id>series_reactor:%d</id>\n",obj->id);
 
 			//write the from name
-			if(pSeriesReactor[index]->from->name[0] != 0){
+			if(pSeriesReactor[index]->from->name != NULL){
 				fprintf(fn,"\t\t<from_node>%s:%s</from_node>\n",pSeriesReactor[index]->from->oclass->name,pSeriesReactor[index]->from->name);
 			} else {
 				fprintf(fn,"\t\t<from_node>%s:%d</from_node>\n",pSeriesReactor[index]->from->oclass->name,pSeriesReactor[index]->from->id);
 			}
 
 			//write the to name
-			if(pSeriesReactor[index]->to->name[0] != 0){
+			if(pSeriesReactor[index]->to->name != NULL){
 				fprintf(fn,"\t\t<to_node>%s:%s</to_node>\n",pSeriesReactor[index]->to->oclass->name,pSeriesReactor[index]->to->name);
 			} else {
 				fprintf(fn,"\t\t<to_node>%s:%d</to_node>\n",pSeriesReactor[index]->to->oclass->name,pSeriesReactor[index]->to->id);
@@ -1515,7 +1515,7 @@ int impedance_dump::dump(TIMESTAMP t)
 			fprintf(fn,"\t<switch>\n");
 
 			//write the name
-			if(obj->name[0] != 0){
+			if(obj->name != NULL){
 				fprintf(fn,"\t\t<name>%s</name>\n",obj->name);
 			} else {
 				fprintf(fn,"\t\t<name>NA</name>\n");
@@ -1525,14 +1525,14 @@ int impedance_dump::dump(TIMESTAMP t)
 			fprintf(fn,"\t\t<id>switch:%d</id>\n",obj->id);
 
 			//write the from name
-			if(pSwitch[index]->from->name[0] != 0){
+			if(pSwitch[index]->from->name != NULL){
 				fprintf(fn,"\t\t<from_node>%s:%s</from_node>\n",pSwitch[index]->from->oclass->name,pSwitch[index]->from->name);
 			} else {
 				fprintf(fn,"\t\t<from_node>%s:%d</from_node>\n",pSwitch[index]->from->oclass->name,pSwitch[index]->from->id);
 			}
 
 			//write the to name
-			if(pSwitch[index]->to->name[0] != 0){
+			if(pSwitch[index]->to->name != NULL){
 				fprintf(fn,"\t\t<to_node>%s:%s</to_node>\n",pSwitch[index]->to->oclass->name,pSwitch[index]->to->name);
 			} else {
 				fprintf(fn,"\t\t<to_node>%s:%d</to_node>\n",pSwitch[index]->to->oclass->name,pSwitch[index]->to->id);
@@ -1709,7 +1709,7 @@ int impedance_dump::dump(TIMESTAMP t)
 			fprintf(fn,"\t<transformer>\n");
 
 			//write the name
-			if(obj->name[0] != 0){
+			if(obj->name != NULL){
 				fprintf(fn,"\t\t<name>%s</name>\n",obj->name);
 			} else {
 				fprintf(fn,"\t\t<name>NA</name>\n");
@@ -1719,7 +1719,7 @@ int impedance_dump::dump(TIMESTAMP t)
 			fprintf(fn,"\t\t<id>transformer:%d</id>\n",obj->id);
 
 			//write the from name
-			if(pTransformer[index]->from->name[0] != 0){
+			if(pTransformer[index]->from->name != NULL){
 				fprintf(fn,"\t\t<from_node>%s:%s</from_node>\n",pTransformer[index]->from->oclass->name,pTransformer[index]->from->name);
 			} else {
 				fprintf(fn,"\t\t<from_node>%s:%d</from_node>\n",pTransformer[index]->from->oclass->name,pTransformer[index]->from->id);
@@ -1727,7 +1727,7 @@ int impedance_dump::dump(TIMESTAMP t)
 			
 
 			//write the to name
-			if(pTransformer[index]->to->name[0] != 0){
+			if(pTransformer[index]->to->name != NULL){
 				fprintf(fn,"\t\t<to_node>%s:%s</to_node>\n",pTransformer[index]->to->oclass->name,pTransformer[index]->to->name);
 			} else {
 				fprintf(fn,"\t\t<to_node>%s:%d</to_node>\n",pTransformer[index]->to->oclass->name,pTransformer[index]->to->id);
@@ -1926,7 +1926,7 @@ int impedance_dump::dump(TIMESTAMP t)
 			fprintf(fn,"\t<triplex_line>\n");
 
 			//write the name
-			if(obj->name[0] != 0){
+			if(obj->name != NULL){
 				fprintf(fn,"\t\t<name>%s</name>\n",obj->name);
 			} else {
 				fprintf(fn,"\t\t<name>NA</name>\n");
@@ -1936,14 +1936,14 @@ int impedance_dump::dump(TIMESTAMP t)
 			fprintf(fn,"\t\t<id>triplex_line:%d</id>\n",obj->id);
 
 			//write the from name
-			if(pTpLine[index]->from->name[0] != 0){
+			if(pTpLine[index]->from->name != NULL){
 				fprintf(fn,"\t\t<from_node>%s:%s</from_node>\n",pTpLine[index]->from->oclass->name,pTpLine[index]->from->name);
 			} else {
 				fprintf(fn,"\t\t<from_node>%s:%d</from_node>\n",pTpLine[index]->from->oclass->name,pTpLine[index]->from->id);
 			}
 
 			//write the to name
-			if(pTpLine[index]->to->name[0] != 0){
+			if(pTpLine[index]->to->name != NULL){
 				fprintf(fn,"\t\t<to_node>%s:%s</to_node>\n",pTpLine[index]->to->oclass->name,pTpLine[index]->to->name);
 			} else {
 				fprintf(fn,"\t\t<to_node>%s:%d</to_node>\n",pTpLine[index]->to->oclass->name,pTpLine[index]->to->id);
@@ -2096,7 +2096,7 @@ int impedance_dump::dump(TIMESTAMP t)
 			fprintf(fn,"\t<underground_line>\n");
 
 			//write the name
-			if(obj->name[0] != 0){
+			if(obj->name != NULL){
 				fprintf(fn,"\t\t<name>%s</name>\n",obj->name);
 			} else {
 				fprintf(fn,"\t\t<name>NA</name>\n");
@@ -2106,14 +2106,14 @@ int impedance_dump::dump(TIMESTAMP t)
 			fprintf(fn,"\t\t<id>underground_line:%d</id>\n",obj->id);
 
 			//write the from name
-			if(pUgLine[index]->from->name[0] != 0){
+			if(pUgLine[index]->from->name != NULL){
 				fprintf(fn,"\t\t<from_node>%s:%s</from_node>\n",pUgLine[index]->from->oclass->name,pUgLine[index]->from->name);
 			} else {
 				fprintf(fn,"\t\t<from_node>%s:%d</from_node>\n",pUgLine[index]->from->oclass->name,pUgLine[index]->from->id);
 			}
 
 			//write the to name
-			if(pUgLine[index]->to->name[0] != 0){
+			if(pUgLine[index]->to->name != NULL){
 				fprintf(fn,"\t\t<to_node>%s:%s</to_node>\n",pUgLine[index]->to->oclass->name,pUgLine[index]->to->name);
 			} else {
 				fprintf(fn,"\t\t<to_node>%s:%d</to_node>\n",pUgLine[index]->to->oclass->name,pUgLine[index]->to->id);
@@ -2292,7 +2292,7 @@ int impedance_dump::dump(TIMESTAMP t)
 			fprintf(fn,"\t<capacitor>\n");
 
 			//write the name
-			if(obj->name[0] != 0){
+			if(obj->name != NULL){
 				fprintf(fn,"\t\t<name>%s</name>\n",obj->name);
 			} else {
 				fprintf(fn,"\t\t<name>NA</name>\n");
@@ -2303,7 +2303,7 @@ int impedance_dump::dump(TIMESTAMP t)
 
 
 			//write the bus name
-			if(obj->parent->name[0] != 0){
+			if(obj->parent->name != NULL){
 				fprintf(fn,"\t\t<node>%s:%s</node>\n",pCapacitor[index]->pclass->name,obj->parent->name);
 			} else {
 				fprintf(fn,"\t\t<node>%s:%d</node>\n",pCapacitor[index]->pclass->name,obj->parent->id);


### PR DESCRIPTION
Changed all of the "name[0] != 0" lines to be null checks on name.  This fixes teh segfault for "empty name" issue.

Included an autotest that tests such a scenario.


#### What's this Pull Request do?
Fixes the segfault when an empty name is present in an object impedance_dump is trying to reference.
#### Where should the reviewer start?
Run the updated autotest, or the file in the original ticket.
#### How should this be tested?
Run impedance_dump with line objects that have no name, and make sure it doesn't fail.
#### Any background context you want to provide?
N/A
#### What are the relevant issues?
#1176 
#### Screenshots (if appropriate)
N/A
#### Questions:
- [ ] Does this add new dependencies?
Nope
- [ ] Is there appropriate logging included?
Probably not
