### PR TITLE
(#1197) Updates to link-attach-to-children routine to get to properly…

### DIFF
--- a/powerflow/autotest/test_child_line_out_of_order.glm
+++ b/powerflow/autotest/test_child_line_out_of_order.glm
@@ -1,0 +1,85 @@
+//File to make sure that lines attached to childed nodes get initialized right,
+//especially if that child is after the line in the GLM.
+// Set up so if it runs, it worked.  If it doesn't, it failed.
+
+clock {
+     timezone "UTC0";
+     starttime '2019-10-11 21:18:12';
+     stoptime '2019-10-11 21:20:12';
+}
+//#set profiler=1
+module powerflow {
+     solver_method NR;
+}
+
+object fault_check {
+	name fault_check_object;
+	check_mode ONCHANGE;
+	strictly_radial FALSE;
+	grid_association TRUE;
+}
+
+object meter {
+	name "sourcebus";
+	bustype SWING;
+	phases ABCN;
+	nominal_voltage 66395.28;
+}
+
+object node {
+	name "bus_1";
+	phases ABCN;
+	nominal_voltage 66395.28;
+}
+
+object overhead_line {
+	name "line_hvmv_sub_hsb";
+	from "sourcebus_meter";
+	to "bus_1";
+	phases ABC;
+	length 3.2809;
+	configuration "lcon_hvmv_sub_hsb_ABC";
+}
+
+object line_configuration {
+	name "lcon_hvmv_sub_hsb_ABC";
+	z11 0.00000+14.7983j;
+	c11 0.0000;
+	z12 0.00000+0.00000j;
+	c12 0.0000;
+	z13 0.00000+0.00000j;
+	c13 0.0000;
+	z21 0.00000+0.00000j;
+	c21 0.0000;
+	z22 0.00000+14.7983j;
+	c22 0.0000;
+	z23 0.00000+0.00000j;
+	c23 0.0000;
+	z31 0.00000+0.00000j;
+	c31 0.0000;
+	z32 0.00000+0.00000j;
+	c32 0.0000;
+	z33 0.00000+14.7983j;
+	c33 0.0000;
+}
+
+object switch {
+	name "swt_hvmv115b1_sw";
+	from "bus_1";
+	to "bus_2";
+	phases ABC;
+	status CLOSED;
+}
+
+object node {
+	name "bus_2";
+	phases ABCN;
+	nominal_voltage 66395.28;
+}
+
+object meter {
+	phases ABCN;
+	nominal_voltage 66395.28;
+	parent "sourcebus";
+	name "sourcebus_meter";
+}

--- a/powerflow/fuse.cpp
+++ b/powerflow/fuse.cpp
@@ -144,6 +144,10 @@ int fuse::init(OBJECT *parent)
 
 	int result = link_object::init(parent);
 
+	//Check for deferred
+	if (result == 2)
+		return 2;	//Return the deferment - no sense doing everything else!
+
 	//Check current limit
 	if (current_limit < 0.0)
 	{

--- a/powerflow/line.cpp
+++ b/powerflow/line.cpp
@@ -100,6 +100,10 @@ int line::init(OBJECT *parent)
 
 	int result = link_object::init(parent);
 
+	//Check for deferred
+	if (result == 2)
+		return 2;	//Return the deferment - no sense doing everything else!
+
 	//Map the nodes nominal_voltage values
 	fNode_nominal = new gld_property(from,"nominal_voltage");
 

--- a/powerflow/link.cpp
+++ b/powerflow/link.cpp
@@ -287,6 +287,22 @@ int link_object::init(OBJECT *parent)
 {
 	OBJECT *obj = GETOBJECT(this);
 
+	//Make sure nodes have initialized in NR - otherwise some lines get missed (if connected to children)
+	if (solver_method == SM_NR)
+	{
+		//See if the from/to nodes have parents
+		if ((from->parent != NULL) || (to->parent != NULL))
+		{
+			if	(((from->flags & OF_INIT) != OF_INIT) || ((to->flags & OF_INIT) != OF_INIT))
+			{
+				gl_verbose("link::init(): link:%d - %s - deferring initialization on from/to node", obj->id,(obj->name?obj->name : "Unnamed"));
+				return 2; // defer
+			}
+			//Default else - both have initialized already
+		}
+		//Default else - neither parented, so they can't be children - will get handled like normal
+	}
+
 	powerflow_object::init(parent);
 
 	set phase_f_test, phase_t_test, phases_test;

--- a/powerflow/node.cpp
+++ b/powerflow/node.cpp
@@ -1521,16 +1521,11 @@ TIMESTAMP node::presync(TIMESTAMP t0)
 
 			if (((SubNode == CHILD) || (SubNode == DIFF_CHILD)) && (NR_connected_links[0] > 0))
 			{
-				node *parNode = OBJECTDATA(SubNodeParent,node);
-
-				WRITELOCK_OBJECT(SubNodeParent);	//Lock
-
-				parNode->NR_connected_links[0] += NR_connected_links[0];
-
-				//Zero our accumulator, just in case (used later)
-				NR_connected_links[0] = 0;
-
-				WRITEUNLOCK_OBJECT(SubNodeParent);	//Unlock
+				GL_THROW("NR: node:%d - %s - extra links acquired outside of init routine",obj->id,(obj->name?obj->name : "Unnamed"));
+				/*  TROUBLESHOOT
+				While attempting to initialize a childed node for the NR solver, extra links that were not detected in the node::init
+				routine were discovered.  This should not have happen.  Please submit your GLM and a bug report to the issues tracker.
+				*/
 			}
 
 			//See if we need to alloc our child space

--- a/powerflow/overhead_line.cpp
+++ b/powerflow/overhead_line.cpp
@@ -70,7 +70,11 @@ int overhead_line::init(OBJECT *parent)
 	double temp_rating_emergency = 20000.0;
 	char index;
 	OBJECT *temp_obj;
-	line::init(parent);
+	int result = line::init(parent);
+
+	//Check for deferred
+	if (result == 2)
+		return 2;	//Return the deferment - no sense doing everything else!
 	
 	if (!configuration)
 		throw "no overhead line configuration specified.";

--- a/powerflow/recloser.cpp
+++ b/powerflow/recloser.cpp
@@ -84,6 +84,10 @@ int recloser::init(OBJECT *parent)
 {
 	int result = switch_object::init(parent);
 
+	//Check for deferred
+	if (result == 2)
+		return 2;	//Return the deferment - no sense doing everything else!
+
 	TIMESTAMP next_ret;
 	next_ret = gl_globalclock;
 

--- a/powerflow/regulator.cpp
+++ b/powerflow/regulator.cpp
@@ -98,6 +98,10 @@ int regulator::init(OBJECT *parent)
 	char jindex;
 	int result = link_object::init(parent);
 
+	//Check for deferred
+	if (result == 2)
+		return 2;	//Return the deferment - no sense doing everything else!
+
 	OBJECT *obj = OBJECTHDR(this);
 
 	if (!configuration)

--- a/powerflow/series_reactor.cpp
+++ b/powerflow/series_reactor.cpp
@@ -80,6 +80,10 @@ int series_reactor::init(OBJECT *parent)
 {
 	int result = link_object::init(parent);
 
+	//Check for deferred
+	if (result == 2)
+		return 2;	//Return the deferment - no sense doing everything else!
+
 	a_mat[0][0] = d_mat[0][0] = A_mat[0][0] = (has_phase(PHASE_A)) ? 1.0 : 0.0;
 	a_mat[1][1] = d_mat[1][1] = A_mat[1][1] = (has_phase(PHASE_B)) ? 1.0 : 0.0;
 	a_mat[2][2] = d_mat[2][2] = A_mat[2][2] = (has_phase(PHASE_C)) ? 1.0 : 0.0;

--- a/powerflow/switch_object.cpp
+++ b/powerflow/switch_object.cpp
@@ -123,6 +123,10 @@ int switch_object::init(OBJECT *parent)
 
 	int result = link_object::init(parent);
 
+	//Check for deferred
+	if (result == 2)
+		return 2;	//Return the deferment - no sense doing everything else!
+
 	//secondary init stuff - should have been done, but we'll be safe
 	//Basically zero everything
 	if (solver_method==SM_FBS)

--- a/powerflow/transformer.cpp
+++ b/powerflow/transformer.cpp
@@ -170,7 +170,12 @@ int transformer::init(OBJECT *parent)
 	link_rating[0][0] = config->kVA_rating;
 	link_rating[1][0] = config->kVA_rating;
 
-	link_object::init(parent);
+	int result = link_object::init(parent);
+
+	//Check for deferred
+	if (result == 2)
+		return 2;	//Return the deferment - no sense doing everything else!
+
 	OBJECT *obj = OBJECTHDR(this);
 
 	V_base = config->V_secondary;

--- a/powerflow/triplex_line.cpp
+++ b/powerflow/triplex_line.cpp
@@ -72,6 +72,10 @@ int triplex_line::init(OBJECT *parent)
 	
 	int result = line::init(parent);
 
+	//Check for deferred
+	if (result == 2)
+		return 2;	//Return the deferment - no sense doing everything else!
+
 	if (!has_phase(PHASE_S))
 		gl_warning("%s (%s:%d) is triplex but doesn't have phases S set", obj->name, obj->oclass->name, obj->id);
 		/*  TROUBLESHOOT

--- a/powerflow/underground_line.cpp
+++ b/powerflow/underground_line.cpp
@@ -75,6 +75,10 @@ int underground_line::init(OBJECT *parent)
 
 	int result = line::init(parent);
 
+	//Check for deferred
+	if (result == 2)
+		return 2;	//Return the deferment - no sense doing everything else!
+
 	if (!configuration)
 		throw "no underground line configuration specified.";
 		/*  TROUBLESHOOT

--- a/powerflow/vfd.cpp
+++ b/powerflow/vfd.cpp
@@ -153,6 +153,10 @@ int vfd::init(OBJECT *parent)
 
 	int result = link_object::init(parent);
 
+	//Check for deferred
+	if (result == 2)
+		return 2;	//Return the deferment - no sense doing everything else!
+
 	if (stableTime <= 0.0)
 	{
 		GL_THROW("VFD:%d - %s - the stableTime must be positive",obj->id,(obj->name ? obj->name : "Unnamed"));


### PR DESCRIPTION
Fixes for #1197 

#### What's this Pull Request do?
Fixes the issue in #1197.  Issue was links attached to childed nodes were not properly initializing, especially if the childed node was later in the file (and initialization sequence) than the link that attached it (e.g., childed node as last object in the GLM).

#### Where should the reviewer start?
Review the code, see if there are any major changes that aren't agreed with.  Examine the new autotest, and make sure it does what I say it does.

#### How should this be tested?
Run validation routine and make sure nothing is broke.

#### Any background context you want to provide?
See #1197 

#### What are the relevant issues?
#1197 

#### Screenshots (if appropriate)
N/A

#### Questions:
- [ ] Does this add new dependencies? - No
- [ ] Is there appropriate logging included? - There's the commit log.
