### PR TITLE
Resolve return-type errors for Bugfix/1167

### DIFF
--- a/connection/init.cpp
+++ b/connection/init.cpp
@@ -210,6 +210,7 @@ EXPORT SIMULATIONMODE deltaClockUpdate(MODULE *module, double t1, unsigned long 
 		result = item->dclkupdate(item->data, t1, timestep, systemmode);
 		return result;
 	}
+	return SM_ERROR; // fall through return value resolves return-type warning. Should be unreachable.
 }
 
 EXPORT int postupdate(MODULE *module, TIMESTAMP t0, unsigned int64 dt)

--- a/gldcore/gridlabd.h
+++ b/gldcore/gridlabd.h
@@ -1,51 +1,51 @@
 /** $Id: gridlabd.h 4738 2014-07-03 00:55:39Z dchassin $
-	Copyright (C) 2008 Battelle Memorial Institute
-	@file gridlabd.h
-	@author David P. Chassin
-	@addtogroup module_api C/C++ Module API
-	@brief The GridLAB-D external C module header file
+ Copyright (C) 2008 Battelle Memorial Institute
+ @file gridlabd.h
+ @author David P. Chassin
+ @addtogroup module_api C/C++ Module API
+ @brief The GridLAB-D external C module header file
 
-	The runtime module API links the GridLAB-D core to modules that are created to
-	perform various modeling tasks.  The core interacts with each module according
-	to a set script that determines which exposed module functions are called and
-	when.  The general sequence of calls is as follows:
-	- <b>Registration</b>: A module registers the object classes it implements and
-	registers the variables that each class publishes.
-	- <b>Creation</b>: The core calls object creation functions during the model
-	load operation for each object that is created.  Basic initialization can be
-	completed at this point.
-	- <b>Definition</b>: The core sets the values of all published variables that have
-	been specified in the model being loaded.  After this is completed, all references
-	to other objects have been resolved.
-	- <b>Validation</b>: The core gives the module an opportunity to check the model
-	before initialization begins.  This gives the module an opportunity to validate
-	the model and reject it or fix it if it fails to meet module-defined criteria.
-	- <b>Initialization</b>: The core calls the final initialization procedure with
-	the object's full context now defined.  Properties that are derived based on the
-	object's context should be initialized only at this point.
-	- <b>Synchronization</b>: This operation is performed repeatedly until every object
-	reports that it no longer expects any state changes.  The return value from a
-	synchronization operation is the amount time expected to elapse before the object's
-	next state change.  The side effect of a synchronization is a change to one or
-	more properties of the object, and possible an update to the property of another
-	object.
+ The runtime module API links the GridLAB-D core to modules that are created to
+ perform various modeling tasks.  The core interacts with each module according
+ to a set script that determines which exposed module functions are called and
+ when.  The general sequence of calls is as follows:
+ - <b>Registration</b>: A module registers the object classes it implements and
+ registers the variables that each class publishes.
+ - <b>Creation</b>: The core calls object creation functions during the model
+ load operation for each object that is created.  Basic initialization can be
+ completed at this point.
+ - <b>Definition</b>: The core sets the values of all published variables that have
+ been specified in the model being loaded.  After this is completed, all references
+ to other objects have been resolved.
+ - <b>Validation</b>: The core gives the module an opportunity to check the model
+ before initialization begins.  This gives the module an opportunity to validate
+ the model and reject it or fix it if it fails to meet module-defined criteria.
+ - <b>Initialization</b>: The core calls the final initialization procedure with
+ the object's full context now defined.  Properties that are derived based on the
+ object's context should be initialized only at this point.
+ - <b>Synchronization</b>: This operation is performed repeatedly until every object
+ reports that it no longer expects any state changes.  The return value from a
+ synchronization operation is the amount time expected to elapse before the object's
+ next state change.  The side effect of a synchronization is a change to one or
+ more properties of the object, and possible an update to the property of another
+ object.
 
-	Note that object destruction is not supported at this time.
+ Note that object destruction is not supported at this time.
 
-	 GridLAB-D modules usually require a number of functions to access data and interaction
-	 with the core.  These include
-	 - memory locking,
-	 - memory exception handlers,
-	 - variable publishers,
-	 - output functions,
-	 - management routines,
-	 - module management,
-	 - class registration,
-	 - object management,
-	 - property management,
-	 - object search,
-	 - random number generators, and
-	 - time management.
+ GridLAB-D modules usually require a number of functions to access data and interaction
+ with the core.  These include
+ - memory locking,
+ - memory exception handlers,
+ - variable publishers,
+ - output functions,
+ - management routines,
+ - module management,
+ - class registration,
+ - object management,
+ - property management,
+ - object search,
+ - random number generators, and
+ - time management.
  @{
  **/
 
@@ -70,12 +70,12 @@
 #endif
 
 #ifdef __cplusplus
-	#ifndef CDECL
-		/** Defines a function as a C-type function **/
-		#define CDECL extern "C"
-	#endif
+#ifndef CDECL
+/** Defines a function as a C-type function **/
+#define CDECL extern "C"
+#endif
 #else
-	#define CDECL
+#define CDECL
 #endif
 
 #ifdef _WIN32
@@ -130,29 +130,29 @@ CDECL EXTERN CALLBACKS *callback INIT(NULL);
  */
 /**	@defgroup gridlabd_h_publishing Publishing variables
 
-	Modules must register public variables that are accessed by other modules, and the core by publishing them.
+ Modules must register public variables that are accessed by other modules, and the core by publishing them.
 
-	The typical modules will register a class, and immediately publish the variables supported by the class:
-	@code
+ The typical modules will register a class, and immediately publish the variables supported by the class:
+ @code
 
-	EXPORT CLASS *init(CALLBACKS *fntable, MODULE *module, int argc, char *argv[])
-	{
-		extern CLASS* node_class; // defined globally in the module
-		if (set_callback(fntable)==NULL)
-		{
-			errno = EINVAL;
-			return NULL;
-		}
+ EXPORT CLASS *init(CALLBACKS *fntable, MODULE *module, int argc, char *argv[])
+ {
+ extern CLASS* node_class; // defined globally in the module
+ if (set_callback(fntable)==NULL)
+ {
+ errno = EINVAL;
+ return NULL;
+ }
 
-		node_class = gl_register_class(module,"node",sizeof(node),PC_BOTTOMUP);
-		PUBLISH_CLASS(node,complex,V);
-		PUBLISH_CLASS(node,complex,S);
+ node_class = gl_register_class(module,"node",sizeof(node),PC_BOTTOMUP);
+ PUBLISH_CLASS(node,complex,V);
+ PUBLISH_CLASS(node,complex,S);
 
-		return node_class; // always return the *first* class registered
-	}
-	@endcode
+ return node_class; // always return the *first* class registered
+ }
+ @endcode
 
-	@{
+ @{
  **/
 /** The PUBLISH_STRUCT macro is used to publish a member of a structure.
  **/
@@ -165,17 +165,16 @@ CDECL EXTERN CALLBACKS *callback INIT(NULL);
 #define PUBLISH_CLASSX(C,T,N,V) {class C *_t=NULL;if (gl_publish_variable(C##_class,PT_##T,V,(char*)&(_t->N)-(char*)_t,NULL)<1) return NULL;}
 
 /** The PUBLISH_CLASS_UNT macros is used to publish a member of a class (C++ only) including a unit specification.
-**/
+ **/
 //#define PUBLISH_CLASS_UNIT(C,T,N,U) {class C _t;if (gl_publish_variable(C##_class,PT_##T,#N"["U"]",(char*)&_t.N-(char*)&_t,NULL)<1) return NULL;}
 /** The PUBLISH_DELEGATED macro is used to publish a variable that uses a delegated type.
 
-**/
+ **/
 #define PUBLISH_DELEGATED(C,T,N) {class C *_t=NULL;if (gl_publish_variable(C##_class,PT_delegated,T,#N,(char*)&(_t->N)-(char*)_t,NULL)<1) return NULL;}
 
 /** The PUBLISH_ENUM(C,N,E) macro is used to define a keyword for an enumeration variable
  **/
 //#define PUBLISH_ENUM(C,N,E) (*callback->define_enumeration_member)(C##_class,#N,#E,C::E)
-
 /** The PUBLISH_SET(C,N,E) macro is used to define a keyword for a set variable
  **/
 //#define PUBLISH_SET(C,N,E) (*callback->define_set_member)(C##_class,#N,#E,C::E)
@@ -188,62 +187,61 @@ CDECL EXTERN CALLBACKS *callback INIT(NULL);
  */
 /**	@defgroup gridlabd_h_exception Exception handling
 
-	Module exception handling is provided for modules implemented in C to perform exception handling,
-	as well to allow C++ code to throw exceptions to the core's main exception handler.
+ Module exception handling is provided for modules implemented in C to perform exception handling,
+ as well to allow C++ code to throw exceptions to the core's main exception handler.
 
-	Typical use is like this:
+ Typical use is like this:
 
-	@code
-	#include <errno.h>
-	#include <string.h>
-	GL_TRY {
+ @code
+ #include <errno.h>
+ #include <string.h>
+ GL_TRY {
 
-		// block of code
+ // block of code
 
-		// exception
-		if (errno!=0)
-			GL_THROW("Error condition %d: %s", errno, strerror(errno));
+ // exception
+ if (errno!=0)
+ GL_THROW("Error condition %d: %s", errno, strerror(errno));
 
-		// more code
+ // more code
 
-	} GL_CATCH(char *msg) {
+ } GL_CATCH(char *msg) {
 
-		// exception handler
+ // exception handler
 
-	} GL_ENDCATCH;
-	@endcode
+ } GL_ENDCATCH;
+ @endcode
 
-	Note: it is ok to use GL_THROW inside a C++ catch statement.  This behavior is defined
-	(unlike using C++ throw inside C++ catch) because GL_THROW is implemented using longjmp().
+ Note: it is ok to use GL_THROW inside a C++ catch statement.  This behavior is defined
+ (unlike using C++ throw inside C++ catch) because GL_THROW is implemented using longjmp().
 
-	See \ref exception "Exception handling" for detail on the message format conventions.
+ See \ref exception "Exception handling" for detail on the message format conventions.
 
-	@{
+ @{
  **/
 /** You may create your own #GL_TRY block and throw exception using GL_THROW(Msg,...) within
-	the block.  Declaring this block will change the behavior of GL_THROW(Msg,...) only
-	within the block.  Calls to GL_THROW(Msg,...) within this try block will be transfer
-	control to the GL_CATCH(Msg) block.
+ the block.  Declaring this block will change the behavior of GL_THROW(Msg,...) only
+ within the block.  Calls to GL_THROW(Msg,...) within this try block will be transfer
+ control to the GL_CATCH(Msg) block.
  **/
 #define GL_TRY { EXCEPTIONHANDLER *_handler = (*callback->exception.create_exception_handler)(); if (_handler==NULL) (*callback->output_error)("%s(%d): module exception handler creation failed",__FILE__,__LINE__); else if (setjmp(_handler->buf)==0) {
 /* TROUBLESHOOT
-	This error is caused when the system is unable to implement an exception handler for a module.
-	This is an internal error and should be reported to the module developer.
+ This error is caused when the system is unable to implement an exception handler for a module.
+ This is an internal error and should be reported to the module developer.
  */
 /** The behavior of GL_THROW(Msg,...) differs depending on the situation:
-	- Inside a #GL_TRY block, program flow is transfered to the GL_CATCH(Msg) block that follows.
-	- Inside a GL_CATCH(Msg) block, GL_THROW(Msg,...) behavior is undefined (read \em bad).
-	- Outside a #GL_TRY or GL_CATCH(Msg) block, control is transfered to the main core exception handler.
+ - Inside a #GL_TRY block, program flow is transfered to the GL_CATCH(Msg) block that follows.
+ - Inside a GL_CATCH(Msg) block, GL_THROW(Msg,...) behavior is undefined (read \em bad).
+ - Outside a #GL_TRY or GL_CATCH(Msg) block, control is transfered to the main core exception handler.
  **/
 #ifdef __cplusplus
-inline void GL_THROW(char *format, ...)
-{
+inline void GL_THROW(char *format, ...) {
 	static char buffer[1024];
 	va_list ptr;
-	va_start(ptr,format);
-	vsprintf(buffer,format,ptr);
+	va_start(ptr, format);
+	vsprintf(buffer, format, ptr);
 	va_end(ptr);
-	throw (const char*) buffer;
+	throw(const char*) buffer;
 }
 #else
 #define GL_THROW (*callback->exception.throw_exception)
@@ -266,37 +264,37 @@ inline void GL_THROW(char *format, ...)
  */
 /**	@defgroup gridlabd_h_output Output functions
 
-	Module may output messages to stdout, stderr, and the core test record file
-	using the output functions.
+ Module may output messages to stdout, stderr, and the core test record file
+ using the output functions.
 
-	See \ref output "Output function" for details on message format conventions.
-	@{
+ See \ref output "Output function" for details on message format conventions.
+ @{
  **/
 
 #define gl_verbose (*callback->output_verbose)
 
 /** Produces a message on stdout.
-	@see output_message(char *format, ...)
+ @see output_message(char *format, ...)
  **/
 #define gl_output (*callback->output_message)
 
 /** Produces a warning message on stderr, but only when \b --warning is provided on the command line.
-	@see output_warning(char *format, ...)
+ @see output_warning(char *format, ...)
  **/
 #define gl_warning (*callback->output_warning)
 
 /** Produces an error message on stderr, but only when \b --quiet is not provided on the command line.
- 	@see output_error(char *format, ...)
-**/
+ @see output_error(char *format, ...)
+ **/
 #define gl_error (*callback->output_error)
 
 /** Produces a debug message on stderr, but only when \b --debug is provided on the command line.
- 	@see output_debug(char *format, ...)
+ @see output_debug(char *format, ...)
  **/
 #define gl_debug (*callback->output_debug)
 
 /** Produces a test message in the test record file, but only when \b --testfile is provided on the command line.
-	@see output_testmsg(char *format, ...)
+ @see output_testmsg(char *format, ...)
  **/
 #define gl_testmsg (*callback->output_test)
 /** @} **/
@@ -306,14 +304,14 @@ inline void GL_THROW(char *format, ...)
  */
 /**	@defgroup gridlabd_h_memory Memory allocation functions
 
-	The core is responsible for managing any memory that is shared.  Use these
-	macros to manage the allocation of objects that are registered classes.
+ The core is responsible for managing any memory that is shared.  Use these
+ macros to manage the allocation of objects that are registered classes.
 
-	@{
+ @{
  **/
 /** Allocate a block of memory from the core's heap.
-	This is necessary for any memory that the core will have to manage.
-	@see malloc()
+ This is necessary for any memory that the core will have to manage.
+ @see malloc()
  **/
 #define gl_malloc (*callback->malloc)
 /** @} **/
@@ -323,24 +321,24 @@ inline void GL_THROW(char *format, ...)
  */
 /**	@defgroup gridlabd_h_corelib Core access functions
 
-	Most module function use core library functions and variables.
-	Use these macros to access the core library and other global module variables.
+ Most module function use core library functions and variables.
+ Use these macros to access the core library and other global module variables.
 
-	@{
+ @{
  **/
 /** Defines the callback table for the module.
-	Callback function provide module with direct access to important core functions.
-	@see struct s_callback
+ Callback function provide module with direct access to important core functions.
+ @see struct s_callback
  **/
 #define set_callback(CT) (callback=(CT))
 
 /** Provides access to a global module variable.
-	@see global_getvar(), global_setvar()
+ @see global_getvar(), global_setvar()
  **/
 #define gl_get_module_var (*callback->module.getvar)
 
 /** Provide file search function
-	@see find_file()
+ @see find_file()
  **/
 #define gl_findfile (*callback->file.find_file)
 
@@ -349,22 +347,21 @@ inline void GL_THROW(char *format, ...)
 #define gl_find_property (*callback->find_property)
 
 /** Declare a module dependency.  This will automatically load
-    the module if it is not already loaded.
-	@return 1 on success, 0 on failure
+ the module if it is not already loaded.
+ @return 1 on success, 0 on failure
  **/
 #ifdef __cplusplus
 inline int gl_module_depends(char *name, /**< module name */
-							 unsigned char major=0, /**< major version, if any required (module must match exactly) */
-							 unsigned char minor=0, /**< minor version, if any required (module must be greater or equal) */
-							 unsigned short build=0) /**< build number, if any required (module must be greater or equal) */
+unsigned char major = 0, /**< major version, if any required (module must match exactly) */
+unsigned char minor = 0, /**< minor version, if any required (module must be greater or equal) */
+unsigned short build = 0) /**< build number, if any required (module must be greater or equal) */
 {
-	return (*callback->module.depends)(name,major,minor,build);
+	return (*callback->module.depends)(name, major, minor, build);
 }
 #else
 #define gl_module_getfirst (*callback->module.getfirst)
 #define gl_module_depends (*callback->module.depends)
 #endif
-
 
 /** @} **/
 
@@ -373,14 +370,14 @@ inline int gl_module_depends(char *name, /**< module name */
  */
 /**	@defgroup gridlabd_h_class Class registration
 
-	Class registration is used to make sure the core knows how objects are implemented
-	in modules.  Use the class management macros to create and destroy classes.
+ Class registration is used to make sure the core knows how objects are implemented
+ in modules.  Use the class management macros to create and destroy classes.
 
-	@{
+ @{
  **/
 /** Allow an object class to be registered with the core.
-	Note that C file may publish structures, even they are not implemented as classes.
-	@see class_register()
+ Note that C file may publish structures, even they are not implemented as classes.
+ @see class_register()
  **/
 #define gl_register_class (*callback->register_class)
 #define gl_class_get_first (*callback->class_getfirst)
@@ -392,107 +389,120 @@ inline int gl_module_depends(char *name, /**< module name */
  */
 /**	@defgroup gridlabd_h_object Object management
 
-	Object management macros are create to allow modules to create, test,
-	control ranks, and reveal members of objects and registered classes.
+ Object management macros are create to allow modules to create, test,
+ control ranks, and reveal members of objects and registered classes.
 
-	@{
+ @{
  **/
 /** Creates an object by allocating on from core heap.
-	@see object_create_single()
+ @see object_create_single()
  */
 #define gl_create_object (*callback->create.single)
 
 /** Creates an array of objects on core heap.
-	@see object_create_array()
+ @see object_create_array()
  **/
 #define gl_create_array (*callback->create.array)
 
 /** Creates an array of objects on core heap.
-	@see object_create_array()
+ @see object_create_array()
  **/
 #define gl_create_foreign (*callback->create.foreign)
 
 /** Object type test
 
-	Checks the type (and supertypes) of an object.
+ Checks the type (and supertypes) of an object.
 
-	@see object_isa()
+ @see object_isa()
  **/
 #ifdef __cplusplus
 inline bool gl_object_isa(OBJECT *obj, /**< object to test */
-						  char *type,
-						  char *modname=NULL) /**< type to test */
-{	bool rv = (*callback->object_isa)(obj,type)!=0;
-	bool mv = modname ? obj->oclass->module == (*callback->module_find)(modname) : true;
-	return (rv && mv);}
+char *type, char *modname = NULL) /**< type to test */
+{
+	bool rv = (*callback->object_isa)(obj, type) != 0;
+	bool mv =
+			modname ?
+					obj->oclass->module == (*callback->module_find)(modname) :
+					true;
+	return (rv && mv);
+}
 #else
 #define gl_object_isa (*callback->object_isa)
 #endif
 
 /** Declare an object property as publicly accessible.
-	@see object_define_map()
+ @see object_define_map()
  **/
 #define gl_publish_variable (*callback->define_map)
 
 #define gl_publish_loadmethod (*callback->loadmethod)
 
 /** Publishes an object function.  This is currently unused.
-	@see object_define_function()
+ @see object_define_function()
  **/
 #ifdef __cplusplus
-inline FUNCTION *gl_publish_function(CLASS *oclass, /**< class to which function belongs */
-									 FUNCTIONNAME functionname, /**< name of function */
-									 FUNCTIONADDR call) /**< address of function entry */
-{ return (*callback->function.define)(oclass, functionname, call);}
-inline FUNCTIONADDR gl_get_function(OBJECT *obj, char *name)
-{ return obj?(*callback->function.get)(obj->oclass->name,name):NULL;}
+inline FUNCTION* gl_publish_function(CLASS *oclass, /**< class to which function belongs */
+FUNCTIONNAME functionname, /**< name of function */
+FUNCTIONADDR call) /**< address of function entry */
+{
+	return (*callback->function.define)(oclass, functionname, call);
+}
+inline FUNCTIONADDR gl_get_function(OBJECT *obj, char *name) {
+	return obj ? (*callback->function.get)(obj->oclass->name, name) : NULL;
+}
 #else
 #define gl_publish_function (*callback->function.define)
 #define gl_get_function (*callback->function.get)
 #endif
 
 /** Changes the dependency rank of an object.
-	Normally dependency rank is determined by the object parent,
-	but an object's rank may be increased using this call.
-	An object's rank may not be decreased.
-	@see object_set_rank(), object_set_parent()
+ Normally dependency rank is determined by the object parent,
+ but an object's rank may be increased using this call.
+ An object's rank may not be decreased.
+ @see object_set_rank(), object_set_parent()
  **/
 #ifdef __cplusplus
 inline int gl_set_dependent(OBJECT *obj, /**< object to set dependency */
-							OBJECT *dep) /**< object dependent on */
-{ return (*callback->object.set_dependent)(obj,dep);}
+OBJECT *dep) /**< object dependent on */
+{
+	return (*callback->object.set_dependent)(obj, dep);
+}
 #else
 #define gl_set_dependent (*callback->object.set_dependent)
 #endif
 
 /** Establishes the rank of an object relative to another object (it's parent).
-	When an object is parent to another object, it's rank is always greater.
-	Object of higher rank are processed first on top-down passes,
-	and later on bottom-up passes.
-	Objects of the same rank may be processed in parallel,
-	if system resources make it possible.
-	@see object_set_rank(), object_set_parent()
+ When an object is parent to another object, it's rank is always greater.
+ Object of higher rank are processed first on top-down passes,
+ and later on bottom-up passes.
+ Objects of the same rank may be processed in parallel,
+ if system resources make it possible.
+ @see object_set_rank(), object_set_parent()
  **/
 #ifdef __cplusplus
 inline int gl_set_parent(OBJECT *obj, /**< object to set parent of */
-						 OBJECT *parent) /**< parent object */
-{ return (*callback->object.set_parent)(obj,parent);}
+OBJECT *parent) /**< parent object */
+{
+	return (*callback->object.set_parent)(obj, parent);
+}
 #else
 #define gl_set_parent (*callback->object.set_parent)
 #endif
 
 /** Adjusts the rank of an object relative to another object (it's parent).
-	When an object is parent to another object, it's rank is always greater.
-	Object of higher rank are processed first on top-down passes,
-	and later on bottom-up passes.
-	Objects of the same rank may be processed in parallel,
-	if system resources make it possible.
-	@see object_set_rank(), object_set_parent()
+ When an object is parent to another object, it's rank is always greater.
+ Object of higher rank are processed first on top-down passes,
+ and later on bottom-up passes.
+ Objects of the same rank may be processed in parallel,
+ if system resources make it possible.
+ @see object_set_rank(), object_set_parent()
  **/
 #ifdef __cplusplus
 inline int gl_set_rank(OBJECT *obj, /**< object to change rank */
-					   int rank)	/**< new rank of object */
-{ return (*callback->object.set_rank)(obj,rank);}
+int rank) /**< new rank of object */
+{
+	return (*callback->object.set_rank)(obj, rank);
+}
 #else
 #define gl_set_rank (*callback->object.set_rank)
 #endif
@@ -506,59 +516,66 @@ inline int gl_set_rank(OBJECT *obj, /**< object to change rank */
  */
 /**	@defgroup gridlabd_h_property Property management
 
-	Use the property management functions to provide and gain access to published
-	variables from other modules.  This include getting property information
-	and unit conversion.
+ Use the property management functions to provide and gain access to published
+ variables from other modules.  This include getting property information
+ and unit conversion.
 
-	@{
+ @{
  **/
 /** Create an object
-	@see class_register()
+ @see class_register()
  **/
 #define gl_register_type (*callback->register_type)
 #define gl_class_add_extended_property (*callback->class_add_extended_property)
 
 /** Publish an delegate property type for a class
-	@note This is not supported in Version 1.
+ @note This is not supported in Version 1.
  **/
 #define gl_publish_delegate (*callback->define_type)
 
 /** Get a property of an object
-	@see object_get_property()
+ @see object_get_property()
  **/
 #ifdef __cplusplus
-inline PROPERTY *gl_get_property(OBJECT *obj, /**< a pointer to the object */
-								 PROPERTYNAME name, /**< the name of the property */
-								 PROPERTYSTRUCT *part=NULL) /**< part info */
-{ return (*callback->properties.get_property)(obj,name,part); }
+inline PROPERTY* gl_get_property(OBJECT *obj, /**< a pointer to the object */
+PROPERTYNAME name, /**< the name of the property */
+PROPERTYSTRUCT *part = NULL) /**< part info */
+{
+	return (*callback->properties.get_property)(obj, name, part);
+}
 #else
 #define gl_get_property (*callback->properties.get_property)
 #endif
 
 /** Get the value of a property in an object
-	@see object_get_value_by_addr()
+ @see object_get_value_by_addr()
  **/
 #ifdef __cplusplus
 inline int gl_get_value(OBJECT *obj, /**< the object from which to get the data */
-						void *addr, /**< the addr of the data to get */
-						char *value, /**< the buffer to which to write the result */
-						int size, /**< the size of the buffer */
-						PROPERTY *prop=NULL) /**< the property to use or NULL if unknown */
-{ return (*callback->properties.get_value_by_addr)(obj,addr,value,size,prop);}
+void *addr, /**< the addr of the data to get */
+char *value, /**< the buffer to which to write the result */
+int size, /**< the size of the buffer */
+PROPERTY *prop = NULL) /**< the property to use or NULL if unknown */
+{
+	return (*callback->properties.get_value_by_addr)(obj, addr, value, size,
+			prop);
+}
 #else
 #define gl_get_value (*callback->properties.get_value_by_addr)
 #endif
 #define gl_set_value_by_type (*callback->properties.set_value_by_type)
 
 /** Set the value of a property in an object
-	@see object_set_value_by_addr()
+ @see object_set_value_by_addr()
  **/
 #ifdef __cplusplus
 inline int gl_set_value(OBJECT *obj, /**< the object to alter */
-						void *addr, /**< the address of the property */
-						char *value, /**< the value to set */
-						PROPERTY *prop) /**< the property to use or NULL if unknown */
-{ return (*callback->properties.set_value_by_addr)(obj,addr,value,prop);}
+void *addr, /**< the address of the property */
+char *value, /**< the value to set */
+PROPERTY *prop) /**< the property to use or NULL if unknown */
+{
+	return (*callback->properties.set_value_by_addr)(obj, addr, value, prop);
+}
 #else
 #define gl_set_value (*callback->properties.set_value_by_addr)
 #endif
@@ -568,25 +585,28 @@ char* gl_name(OBJECT *my, char *buffer, size_t size);
 /* 'stolen' from rt/gridlabd.h, something dchassin squirreled in. -mhauer */
 /// Set the typed value of a property
 /// @return nothing
-template <class T> inline int gl_set_value(OBJECT *obj, ///< the object whose property value is being obtained
-											PROPERTY *prop, ///< the name of the property being obtained
-											T &value) ///< a reference to the local value where the property's value is being copied
-{
+template<class T> inline int gl_set_value(OBJECT *obj, ///< the object whose property value is being obtained
+		PROPERTY *prop, ///< the name of the property being obtained
+		T &value) ///< a reference to the local value where the property's value is being copied
+		{
 	//T *ptr = (T*)gl_get_addr(obj,propname);
 	char buffer[256];
-	T *ptr = (T *)((char *)(obj + 1) + (int64)(prop->addr)); /* warning: cast from pointer to integer of different size */
+	T *ptr = (T*) ((char*) (obj + 1) + (int64)(prop->addr)); /* warning: cast from pointer to integer of different size */
 	// @todo it would be a good idea to check the property type here
-	if (ptr==NULL)
-		GL_THROW("property %s not found in object %s", prop->name, gl_name(obj, buffer, 255));
-	if(obj->oclass->notify){
-		if(obj->oclass->notify(obj,NM_PREUPDATE,prop) == 0){
-			gl_error("preupdate notify failure on %s in %s", prop->name, obj->name ? obj->name : "an unnamed object");
+	if (ptr == NULL)
+		GL_THROW("property %s not found in object %s", prop->name,
+				gl_name(obj, buffer, 255));
+	if (obj->oclass->notify) {
+		if (obj->oclass->notify(obj, NM_PREUPDATE, prop) == 0) {
+			gl_error("preupdate notify failure on %s in %s", prop->name,
+					obj->name ? obj->name : "an unnamed object");
 		}
 	}
 	*ptr = value;
-	if(obj->oclass->notify){
-		if(obj->oclass->notify(obj,NM_POSTUPDATE,prop) == 0){
-			gl_error("postupdate notify failure on %s in %s", prop->name, obj->name ? obj->name : "an unnamed object");
+	if (obj->oclass->notify) {
+		if (obj->oclass->notify(obj, NM_POSTUPDATE, prop) == 0) {
+			gl_error("postupdate notify failure on %s in %s", prop->name,
+					obj->name ? obj->name : "an unnamed object");
 		}
 	}
 	return 1;
@@ -594,48 +614,45 @@ template <class T> inline int gl_set_value(OBJECT *obj, ///< the object whose pr
 #endif
 
 /** Get a reference to another object
-	@see object_get_reference()
+ @see object_get_reference()
  **/
 #define gl_get_reference (*callback->properties.get_reference)
 
 /** Get the value of a property in an object
-	@see object_get_value_by_name()
+ @see object_get_value_by_name()
  **/
 #ifdef __cplusplus
-inline int gl_get_value_by_name(OBJECT *obj,
-								PROPERTYNAME name,
-								char *value,
-								int size)
-{ return (*callback->properties.get_value_by_name)(obj,name,value,size);}
+inline int gl_get_value_by_name(OBJECT *obj, PROPERTYNAME name, char *value,
+		int size) {
+	return (*callback->properties.get_value_by_name)(obj, name, value, size);
+}
 #else
 #define gl_get_value_by_name (*callback->properties.get_value_by_name)
 #endif
 
 #ifdef __cplusplus
-inline char *gl_getvalue(OBJECT *obj,
-						 PROPERTYNAME name, char *buffer, int sz)
-{
-	return gl_get_value_by_name(obj,name,buffer,sz)>=0 ? buffer : NULL;
+inline char* gl_getvalue(OBJECT *obj, PROPERTYNAME name, char *buffer, int sz) {
+	return gl_get_value_by_name(obj, name, buffer, sz) >= 0 ? buffer : NULL;
 }
 #endif
 
 /** Set the value of a property in an object
-	@see object_set_value_by_name()
+ @see object_set_value_by_name()
  **/
 #define gl_set_value_by_name (*callback->properties.set_value_by_name)
 
 /** Get unit of property
-	@see object_get_unit()
+ @see object_get_unit()
  **/
 #define gl_get_unit (*callback->properties.get_unit)
 
 /** Convert the units of a property using unit name
-	@see unit_convert()
+ @see unit_convert()
  **/
 #define gl_convert (*callback->unit_convert)
 
 /** Convert the units of a property using unit data
-	@see unit_convert_ex()
+ @see unit_convert_ex()
  **/
 #define gl_convert_ex (*callback->unit_convert_ex)
 
@@ -648,36 +665,36 @@ inline char *gl_getvalue(OBJECT *obj,
 #define gl_get_object_count (*callback->object_count)
 
 #ifdef __cplusplus
-inline OBJECT **gl_get_object_prop(OBJECT *obj, PROPERTY *prop){
-    return (*callback->objvar.object_var)(obj, prop);
+inline OBJECT** gl_get_object_prop(OBJECT *obj, PROPERTY *prop) {
+	return (*callback->objvar.object_var)(obj, prop);
 }
 #else
 #define gl_get_object_prop (*callback->objvar.object_var)
 #endif
 
 #ifdef __cplusplus
-inline bool *gl_get_bool(OBJECT *obj, /**< object to set dependency */
-							PROPERTY *prop) /**< object dependent on */
+inline bool* gl_get_bool(OBJECT *obj, /**< object to set dependency */
+PROPERTY *prop) /**< object dependent on */
 {
-    return (*callback->objvar.bool_var)(obj,prop);
+	return (*callback->objvar.bool_var)(obj, prop);
 }
 #else
 #define gl_get_bool (*callback->objvar.bool_var)
 #endif
 
 #ifdef __cplusplus
-inline bool *gl_get_bool(OBJECT *obj, /**< object to set dependency */
-							char *propname) /**< object dependent on */
+inline bool* gl_get_bool(OBJECT *obj, /**< object to set dependency */
+char *propname) /**< object dependent on */
 {
-    return (*callback->objvarname.bool_var)(obj,propname);
+	return (*callback->objvarname.bool_var)(obj, propname);
 }
 #else
 #define gl_get_bool_by_name (*callback->objvarname.bool_var)
 #endif
 
 /** Retrieve the complex value associated with the property
-	@see object_get_complex()
-**/
+ @see object_get_complex()
+ **/
 #define gl_get_complex (*callback->objvar.complex_var)
 
 #define gl_get_complex_by_name (*callback->objvarname.complex_var)
@@ -721,39 +738,39 @@ inline bool *gl_get_bool(OBJECT *obj, /**< object to set dependency */
  */
 /**	@defgroup gridlabd_h_search Object search
 
-	Searches and navigates object lists.
+ Searches and navigates object lists.
 
-	@{
+ @{
  **/
 /** Find one or more object
-	@see find_objects()
+ @see find_objects()
  **/
 #define gl_find_objects (*callback->find.objects)
 
 /** Scan a list of found objects
-	@see find_first(), find_next()
+ @see find_first(), find_next()
  **/
 #define gl_find_next (*callback->find.next)
 
 /** Duplicate a list of found objects
-	@see find_copylist()
+ @see find_copylist()
  **/
 #define gl_findlist_copy (*callback->find.copy)
 #define gl_findlist_add (*callback->find.add)
 #define gl_findlist_del (*callback->find.del)
 #define gl_findlist_clear (*callback->find.clear)
 /** Release memory used by a find list
-	@see free()
+ @see free()
  **/
 #define gl_free (*callback->free)
 
 /** Create an aggregate property from a find list
-	@see aggregate_mkgroup()
+ @see aggregate_mkgroup()
  **/
 #define gl_create_aggregate (*callback->aggregate.create)
 
 /** Evaluate an aggregate property
-	@see aggregate_value()
+ @see aggregate_value()
  **/
 #define gl_run_aggregate (*callback->aggregate.refresh)
 /** @} **/
@@ -763,61 +780,61 @@ inline bool *gl_get_bool(OBJECT *obj, /**< object to set dependency */
  */
 /**	@defgroup gridlabd_h_random Random numbers
 
-	The random number library provides a variety of random number generations
-	for different distributions.
+ The random number library provides a variety of random number generations
+ for different distributions.
 
-	@{
+ @{
  **/
 
 #define RNGSTATE (&(OBJECTHDR(this))->rng_state)
 
 /** Determine the distribution type to be used from its name
-	@see RANDOMTYPE, random_type()
+ @see RANDOMTYPE, random_type()
  **/
 #define gl_randomtype (*callback->random.type)
 
 /** Obtain an arbitrary random value using RANDOMTYPE
-	@see RANDOMTYPE, random_value()
+ @see RANDOMTYPE, random_value()
  **/
 #define gl_randomvalue (*callback->random.value)
 
 /** Obtain an arbitrary random value using RANDOMTYPE
-	@see RANDOMTYPE, pseudorandom_value()
+ @see RANDOMTYPE, pseudorandom_value()
  **/
 #define gl_pseudorandomvalue (*callback->random.pseudo)
 
 /** Generate a uniformly distributed random number
-	@see random_uniform()
+ @see random_uniform()
  **/
 #define gl_random_uniform (*callback->random.uniform)
 
 /** Generate a normal distributed random number
-	@see random_normal()
+ @see random_normal()
  **/
 #define gl_random_normal (*callback->random.normal)
 
 /** Generate a log normal distributed random number
-	@see random_lognormal()
+ @see random_lognormal()
  **/
 #define gl_random_lognormal (*callback->random.lognormal)
 
 /** Generate a Bernoulli distributed random number
-	@see random_bernoulli()
+ @see random_bernoulli()
  **/
 #define gl_random_bernoulli (*callback->random.bernoulli)
 
 /** Generate a Pareto distributed random number
-	@see random_pareto()
+ @see random_pareto()
  **/
 #define gl_random_pareto (*callback->random.pareto)
 
 /** Generate a random number drawn uniformly from a sample
-	@see random_sampled()
+ @see random_sampled()
  **/
 #define gl_random_sampled (*callback->random.sampled)
 
 /** Generate an examponentially distributed random number
-	@see random_exponential()
+ @see random_exponential()
  **/
 #define gl_random_exponential (*callback->random.exponential)
 #define gl_random_triangle (*callback->random.triangle)
@@ -843,7 +860,7 @@ inline bool *gl_get_bool(OBJECT *obj, /**< object to set dependency */
 #define gl_globalstoptime (*(callback->global_stoptime))
 
 /** Convert a string to a timestamp
-	@see convert_to_timestamp()
+ @see convert_to_timestamp()
  **/
 #define gl_parsetime (*callback->time.convert_to_timestamp)
 
@@ -854,55 +871,53 @@ inline bool *gl_get_bool(OBJECT *obj, /**< object to set dependency */
 #define gl_printtimedelta (*callback->time.convert_from_deltatime_timestamp)
 
 /** Convert a timestamp to a date/time structure
-	@see mkdatetime()
+ @see mkdatetime()
  **/
 #define gl_mktime (*callback->time.mkdatetime)
 
 /** Convert a date/time structure to a string
-	@see strdatetime()
+ @see strdatetime()
  **/
 #define gl_strtime (*callback->time.strdatetime)
 
 /** Convert a timestamp to days
-	@see timestamp_to_days()
+ @see timestamp_to_days()
  **/
 #define gl_todays (*callback->time.timestamp_to_days)
 
 /** Convert a timestamp to hours
-	@see timestamp_to_hours()
+ @see timestamp_to_hours()
  **/
 #define gl_tohours (*callback->time.timestamp_to_hours)
 
 /** Convert a timestamp to minutes
-	@see timestamp_to_minutes()
+ @see timestamp_to_minutes()
  **/
 #define gl_tominutes (*callback->time.timestamp_to_minutes)
 
 /** Convert a timestamp to seconds
-	@see timestamp_to_seconds()
+ @see timestamp_to_seconds()
  **/
 #define gl_toseconds (*callback->time.timestamp_to_seconds)
 
 /** Convert a timestamp to a local date/time structure
-	@see local_datetime()
+ @see local_datetime()
  **/
 #define gl_localtime (*callback->time.local_datetime)
 
 /** Convert a timestamp to a local date/time structure
-	Use this if it is a double precision time (deltamode)
-	@see local_datetime()
+ Use this if it is a double precision time (deltamode)
+ @see local_datetime()
  **/
 #define gl_localtime_delta (*callback->time.local_datetime_delta)
 
 #ifdef __cplusplus
-inline int gl_getweekday(TIMESTAMP t)
-{
+inline int gl_getweekday(TIMESTAMP t) {
 	DATETIME dt;
 	gl_localtime(t, &dt);
 	return dt.weekday;
 }
-inline int gl_gethour(TIMESTAMP t)
-{
+inline int gl_gethour(TIMESTAMP t) {
 	DATETIME dt;
 	gl_localtime(t, &dt);
 	return dt.hour;
@@ -917,22 +932,22 @@ inline int gl_gethour(TIMESTAMP t)
  **/
 
 /** Create a new global variable
-	@see global_create()
+ @see global_create()
  **/
 #define gl_global_create (*callback->global.create)
 
 /** Set a global variable
-	@see global_setvar()
+ @see global_setvar()
  **/
 #define gl_global_setvar (*callback->global.setvar)
 
 /** Get a global variable
-	@see global_getvar()
+ @see global_getvar()
  **/
 #define gl_global_getvar (*callback->global.getvar)
 
 /** Find a global variable
-	@see global_find()
+ @see global_find()
  **/
 #define gl_global_find (*callback->global.find)
 
@@ -948,29 +963,32 @@ inline int gl_gethour(TIMESTAMP t)
  **/
 
 /** Clip a value \p x if outside the range (\p a, \p b)
-	@return the clipped value of x
-	@note \f clip() is only supported in C++
+ @return the clipped value of x
+ @note \f clip() is only supported in C++
  **/
 inline double clip(double x, /**< the value to clip **/
-				   double a, /**< the lower limit of the range **/
-				   double b) /**< the upper limit of the range **/
+double a, /**< the lower limit of the range **/
+double b) /**< the upper limit of the range **/
 {
-	if (x<a) return a;
-	else if (x>b) return b;
-	else return x;
+	if (x < a)
+		return a;
+	else if (x > b)
+		return b;
+	else
+		return x;
 }
 
 /** Determine which bit is set in a bit pattern
-	@return the bit number \e n; \p -7f is no bit found; \e -n if more than one bit found
+ @return the bit number \e n; \p -7f is no bit found; \e -n if more than one bit found
  **/
 inline char bitof(unsigned int64 x,/**< bit pattern to scan */
-						   bool use_throw=false) /**< flag to use throw when more than one bit is set */
+		bool use_throw=false) /**< flag to use throw when more than one bit is set */
 {
 	char n=0;
 	if (x==0)
 	{
 		if (use_throw)
-			throw "bitof empty bit pattern";
+		throw "bitof empty bit pattern";
 		return -0x7f;
 	}
 	while ((x&1)==0)
@@ -981,24 +999,24 @@ inline char bitof(unsigned int64 x,/**< bit pattern to scan */
 	if (x!=0)
 	{
 		if (use_throw)
-			throw "bitof found more than one bit";
+		throw "bitof found more than one bit";
 		else
-			return -n;
+		return -n;
 	}
 	return n;
 }
 /** Construct a proper object object
-    @return a pointer to the struct buffer or NULL if failed
+ @return a pointer to the struct buffer or NULL if failed
  **/
-inline char* gl_name(OBJECT *my, char *buffer, size_t size)
-{
+inline char* gl_name(OBJECT *my, char *buffer, size_t size) {
 	char temp[256];
-	if(my == NULL || buffer == NULL) return NULL;
-	if (my->name==NULL)
-		sprintf(temp,"%s:%d", my->oclass->name, my->id);
+	if (my == NULL || buffer == NULL)
+		return NULL;
+	if (my->name == NULL)
+		sprintf(temp, "%s:%d", my->oclass->name, my->id);
 	else
-		sprintf(temp,"%s", my->name);
-	if(size < strlen(temp))
+		sprintf(temp, "%s", my->name);
+	if (size < strlen(temp))
 		return NULL;
 	strcpy(buffer, temp);
 	return buffer;
@@ -1006,57 +1024,48 @@ inline char* gl_name(OBJECT *my, char *buffer, size_t size)
 
 /** Find a schedule 
  **/
-inline SCHEDULE *gl_schedule_find(char *name)
-{
+inline SCHEDULE* gl_schedule_find(char *name) {
 	return callback->schedule.find(name);
 }
 /** Create a schedule
  **/
-inline SCHEDULE *gl_schedule_create(char *name, char *definition)
-{
-	return callback->schedule.create(name,definition);
+inline SCHEDULE* gl_schedule_create(char *name, char *definition) {
+	return callback->schedule.create(name, definition);
 }
 /** Find the time index in a schedule
  **/
-inline SCHEDULEINDEX gl_schedule_index(SCHEDULE *sch, TIMESTAMP ts)
-{
-	return callback->schedule.index(sch,ts);
+inline SCHEDULEINDEX gl_schedule_index(SCHEDULE *sch, TIMESTAMP ts) {
+	return callback->schedule.index(sch, ts);
 }
 /** Find the value at a time index in a schedule
  **/
-inline double gl_schedule_value(SCHEDULE *sch, SCHEDULEINDEX index)
-{
-	return callback->schedule.value(sch,index);
+inline double gl_schedule_value(SCHEDULE *sch, SCHEDULEINDEX index) {
+	return callback->schedule.value(sch, index);
 }
 /** Find the elapsed time until the value at an index changes
  **/
-inline int32 gl_schedule_dtnext(SCHEDULE *sch, SCHEDULEINDEX index)
-{
-	return callback->schedule.dtnext(sch,index);
+inline int32 gl_schedule_dtnext(SCHEDULE *sch, SCHEDULEINDEX index) {
+	return callback->schedule.dtnext(sch, index);
 }
-inline SCHEDULE *gl_schedule_getfirst(void)
-{
+inline SCHEDULE* gl_schedule_getfirst(void) {
 	return callback->schedule.getfirst();
 }
 /** Create an enduse
  **/
-inline int gl_enduse_create(enduse *e)
-{
+inline int gl_enduse_create(enduse *e) {
 	return callback->enduse.create(e);
 }
 /** Synchronize an enduse
  **/
-inline TIMESTAMP gl_enduse_sync(enduse *e, TIMESTAMP t1)
-{
-	return callback->enduse.sync(e,PC_BOTTOMUP,t1);
+inline TIMESTAMP gl_enduse_sync(enduse *e, TIMESTAMP t1) {
+	return callback->enduse.sync(e, PC_BOTTOMUP, t1);
 }
 /** Create a loadshape 
  **/
-inline loadshape *gl_loadshape_create(SCHEDULE *s)
-{
-	loadshape *ls = (loadshape*)malloc(sizeof(loadshape));
-	memset(ls,0,sizeof(loadshape));
-	if (0 == callback->loadshape.create(ls)){
+inline loadshape* gl_loadshape_create(SCHEDULE *s) {
+	loadshape *ls = (loadshape*) malloc(sizeof(loadshape));
+	memset(ls, 0, sizeof(loadshape));
+	if (0 == callback->loadshape.create(ls)) {
 		return NULL;
 	}
 	ls->schedule = s;
@@ -1064,8 +1073,7 @@ inline loadshape *gl_loadshape_create(SCHEDULE *s)
 }
 /** Get the current value of a loadshape
  **/
-inline double gl_get_loadshape_value(loadshape *shape)
-{
+inline double gl_get_loadshape_value(loadshape *shape) {
 	if (shape)
 		return shape->load;
 	else
@@ -1073,46 +1081,47 @@ inline double gl_get_loadshape_value(loadshape *shape)
 }
 /** Format a DATETIME into a string buffer
  **/
-inline char *gl_strftime(DATETIME *dt, char *buffer, int size) { return callback->time.strdatetime(dt,buffer,size)?buffer:NULL;};
+inline char* gl_strftime(DATETIME *dt, char *buffer, int size) {
+	return callback->time.strdatetime(dt, buffer, size) ? buffer : NULL;
+}
+;
 /** Format a TIMESTAMP into a string buffer
  **/
-inline char *gl_strftime(TIMESTAMP ts, char *buffer, int size)
-{
+inline char* gl_strftime(TIMESTAMP ts, char *buffer, int size) {
 	//static char buffer[64];
 	DATETIME dt;
-	if(buffer == 0){
+	if (buffer == 0) {
 		gl_error("gl_strftime: buffer is a null pointer");
 		return 0;
 	}
-	if(size < 15){
+	if (size < 15) {
 		gl_error("gl_strftime: buffer size is too small");
 		return 0;
 	}
-	if(gl_localtime(ts,&dt)){
-		return gl_strftime(&dt,buffer,size);
+	if (gl_localtime(ts, &dt)) {
+		return gl_strftime(&dt, buffer, size);
 	} else {
-		strncpy(buffer,"(invalid time)", size);
+		strncpy(buffer, "(invalid time)", size);
 	}
 	return buffer;
 }
 /** Calculate the next power of 2 greater than a number
  **/
-inline size_t nextpow2(register size_t x)
-{
-	if (x<0) return 0;
+inline size_t nextpow2(register size_t x) {
+	if (x < 0)
+		return 0;
 	x--;
-	x|=x>>1;
-	x|=x>>2;
-	x|=x>>4;
-	x|=x>>8;
-	x|=x>>16;
+	x |= x >> 1;
+	x |= x >> 2;
+	x |= x >> 4;
+	x |= x >> 8;
+	x |= x >> 16;
 	// won't work for anything over 2^30
-	return x+1;
+	return x + 1;
 }
 
 /**@}*/
 #endif //__cplusplus
-
 
 /******************************************************************************
  * Interpolation routines
@@ -1156,7 +1165,6 @@ inline size_t nextpow2(register size_t x)
 #define gl_forecast_save (*callback->forecast.save)
 /**@}*/
 
-
 /******************************************************************************
  * Init/Sync/Create catchall macros
  */
@@ -1186,11 +1194,32 @@ inline size_t nextpow2(register size_t x)
  * @{
  */
 #ifdef __cplusplus
-inline TRANSFORM *gl_transform_getfirst(void) { return callback->transform.getnext(NULL); };
-inline TRANSFORM *gl_transform_getnext(TRANSFORM *xform) { return callback->transform.getnext(xform); };
-inline int gl_transform_add_linear(TRANSFORMSOURCE stype,double *source,void *target,double scale,double bias,OBJECT *obj,PROPERTY *prop,SCHEDULE *sched) { return callback->transform.add_linear(stype,source,target,scale,bias,obj,prop,sched); };
-inline int gl_transform_add_external(OBJECT *target_obj, PROPERTY *target_prop,char *function,OBJECT *source_obj, PROPERTY* source_prop) { return callback->transform.add_external(target_obj,target_prop,function,source_obj,source_prop); };
-inline const char *gl_module_find_transform_function(TRANSFORMFUNCTION function) { return callback->module.find_transform_function(function); };
+inline TRANSFORM* gl_transform_getfirst(void) {
+	return callback->transform.getnext(NULL);
+}
+;
+inline TRANSFORM* gl_transform_getnext(TRANSFORM *xform) {
+	return callback->transform.getnext(xform);
+}
+;
+inline int gl_transform_add_linear(TRANSFORMSOURCE stype, double *source,
+		void *target, double scale, double bias, OBJECT *obj, PROPERTY *prop,
+		SCHEDULE *sched) {
+	return callback->transform.add_linear(stype, source, target, scale, bias,
+			obj, prop, sched);
+}
+;
+inline int gl_transform_add_external(OBJECT *target_obj, PROPERTY *target_prop,
+		char *function, OBJECT *source_obj, PROPERTY *source_prop) {
+	return callback->transform.add_external(target_obj, target_prop, function,
+			source_obj, source_prop);
+}
+;
+inline const char* gl_module_find_transform_function(
+		TRANSFORMFUNCTION function) {
+	return callback->module.find_transform_function(function);
+}
+;
 #else
 #define gl_transform_getnext (*callback->transform.getnext) /* TRANSFORM *(*transform.getnext)(TRANSFORM*); */
 #define gl_transform_add_linear (*callback->transfor.add_linear) /* int transform_add_linear(TRANSFORMSOURCE stype,double *source,void *target,double scale,double bias,OBJECT *obj,PROPERTY *prop,SCHEDULE *sched) */
@@ -1200,9 +1229,19 @@ inline const char *gl_module_find_transform_function(TRANSFORMFUNCTION function)
 /**@}*/
 
 #ifdef __cplusplus
-inline randomvar *gl_randomvar_getfirst(void) { return callback->randomvar.getnext(NULL); };
-inline randomvar *gl_randomvar_getnext(randomvar *var) { return callback->randomvar.getnext(var); };
-inline size_t gl_randomvar_getspec(char *str, size_t size, const randomvar *var) { return callback->randomvar.getspec(str,size,var); };
+inline randomvar* gl_randomvar_getfirst(void) {
+	return callback->randomvar.getnext(NULL);
+}
+;
+inline randomvar* gl_randomvar_getnext(randomvar *var) {
+	return callback->randomvar.getnext(var);
+}
+;
+inline size_t gl_randomvar_getspec(char *str, size_t size,
+		const randomvar *var) {
+	return callback->randomvar.getspec(str, size, var);
+}
+;
 #else
 #define gl_randomvar_getnext (*callback->randomvar.getnext) /* randomvar *(*randomvar.getnext)(randomvar*) */
 #define gl_randomvar_getspec (*callback->randomvar.getspec) /* size_t (*randomvar.getspec(char*,size_t,randomvar*) */
@@ -1217,33 +1256,33 @@ inline size_t gl_randomvar_getspec(char *str, size_t size, const randomvar *var)
 
 #ifdef __cplusplus
 /** read remote object data **/
-inline void *gl_read(void *local, /**< local memory for data (must be correct size for property) */
-					 OBJECT *obj, /**< object from which to get data */
-					 PROPERTY *prop) /**< property from which to get data */
+inline void* gl_read(void *local, /**< local memory for data (must be correct size for property) */
+OBJECT *obj, /**< object from which to get data */
+PROPERTY *prop) /**< property from which to get data */
 {
-	return callback->remote.readobj(local,obj,prop);
+	return callback->remote.readobj(local, obj, prop);
 }
 /** write remote object data **/
 inline void gl_write(void *local, /** local memory for data */
-					 OBJECT *obj, /** object to which data is written */
-					 PROPERTY *prop) /**< property to which data is written */
+OBJECT *obj, /** object to which data is written */
+PROPERTY *prop) /**< property to which data is written */
 {
 	/* @todo */
-	return callback->remote.writeobj(local,obj,prop);
+	return callback->remote.writeobj(local, obj, prop);
 }
 /** read remote global data **/
-inline void *gl_read(void *local, /** local memory for data (must be correct size for global */
-					 GLOBALVAR *var) /** global variable from which to get data */
+inline void* gl_read(void *local, /** local memory for data (must be correct size for global */
+GLOBALVAR *var) /** global variable from which to get data */
 {
 	/* @todo */
-	return callback->remote.readvar(local,var);
+	return callback->remote.readvar(local, var);
 }
 /** write remote global data **/
 inline void gl_write(void *local, /** local memory for data */
-					 GLOBALVAR *var) /** global variable to which data is written */
+GLOBALVAR *var) /** global variable to which data is written */
 {
 	/* @todo */
-	return callback->remote.writevar(local,var);
+	return callback->remote.writevar(local, var);
 }
 #endif
 /**@}*/
@@ -1255,10 +1294,18 @@ inline void gl_write(void *local, /** local memory for data */
 #define READUNLOCK(X) ::runlock(X); /**< Unlocks an read lock */
 #define WRITEUNLOCK(X) ::wunlock(X); /**< Unlocks a write lock */
 
-inline void rlock(unsigned int* lock) { callback->lock.read(lock); }
-inline void wlock(unsigned int* lock) { callback->lock.write(lock); }
-inline void runlock(unsigned int* lock) { callback->unlock.read(lock); }
-inline void wunlock(unsigned int* lock) { callback->unlock.write(lock); }
+inline void rlock(unsigned int *lock) {
+	callback->lock.read(lock);
+}
+inline void wlock(unsigned int *lock) {
+	callback->lock.write(lock);
+}
+inline void runlock(unsigned int *lock) {
+	callback->unlock.read(lock);
+}
+inline void wunlock(unsigned int *lock) {
+	callback->unlock.write(lock);
+}
 
 #else
 #define READLOCK(X) rlock(X); /**< Locks an item for reading (allows other reads but blocks write) */
@@ -1286,7 +1333,6 @@ static unsigned long _nan[] = { 0xffffffff, 0x7fffffff, };
 #define NaN NAN
 #endif
 
-
 #ifdef __cplusplus
 
 /**************************************************************************************
@@ -1312,109 +1358,278 @@ private: // data
 	STRBUF *buf;
 public: // construction/destructor
 	/// construct an empty string
-	inline gld_string(void) : buf(NULL) { init(); };
+	inline gld_string(void) :
+			buf(NULL) {
+		init();
+	}
+	;
 	/// construct a linked string
-	inline gld_string(gld_string&s) : buf(NULL) { init(); link(s); };
+	inline gld_string(gld_string &s) :
+			buf(NULL) {
+		init();
+		link(s);
+	}
+	;
 	/// construct a new string
-	inline gld_string(const char *s) : buf(NULL) { init(); copy(s); };
+	inline gld_string(const char *s) :
+			buf(NULL) {
+		init();
+		copy(s);
+	}
+	;
 	/// construct a new string of a particular length
-	inline gld_string(const char *s, size_t n) : buf(NULL) { init(); copy(s,n); };
+	inline gld_string(const char *s, size_t n) :
+			buf(NULL) {
+		init();
+		copy(s, n);
+	}
+	;
 	/// destroy a string (or unlink from one)
-	inline ~gld_string(void) { unlink(); };
+	inline ~gld_string(void) {
+		unlink();
+	}
+	;
 public: // copy
 	/// copy a string
-	inline gld_string &operator=(const char *s) { copy(s); return *this; };
+	inline gld_string& operator=(const char *s) {
+		copy(s);
+		return *this;
+	}
+	;
 	/// link to a string
-	inline gld_string &operator=(gld_string&s) { link(s); return *this; };
+	inline gld_string& operator=(gld_string &s) {
+		link(s);
+		return *this;
+	}
+	;
 public: // casts
 	/// cast to a pointer to the string buffer
-	inline operator const char*(void) { return buf->str; };
+	inline operator const char*(void) {
+		return buf->str;
+	}
+	;
 	/// cast to the size of the string
-	inline operator size_t(void) { return buf->len; };
+	inline operator size_t(void) {
+		return buf->len;
+	}
+	;
 	/// cast to a pointer to the string data
-	inline operator STRBUF *(void) { return buf; };
+	inline operator STRBUF *(void) {
+		return buf;
+	}
+	;
 private: // internals
-	inline void init(void) { buf=(STRBUF*)malloc(sizeof(STRBUF)); memset(buf,0,sizeof(STRBUF)); }; 
-	inline void lock(void) { if ( buf ) ::wlock(&buf->lock); };
-	inline void unlock(void) { if ( buf ) ::wunlock(&buf->lock); };
-	inline void fit(size_t n) { if ( buf==NULL || n>buf->len) alloc(n); };
-	inline void alloc(size_t n) 
-	{
+	inline void init(void) {
+		buf = (STRBUF*) malloc(sizeof(STRBUF));
+		memset(buf, 0, sizeof(STRBUF));
+	}
+	;
+	inline void lock(void) {
+		if (buf)
+			::wlock(&buf->lock);
+	}
+	;
+	inline void unlock(void) {
+		if (buf)
+			::wunlock(&buf->lock);
+	}
+	;
+	inline void fit(size_t n) {
+		if (buf == NULL || n > buf->len)
+			alloc(n);
+	}
+	;
+	inline void alloc(size_t n) {
 		size_t len = nextpow2(n);
-		if ( len<sizeof(NATIVE) ) 
-			len=sizeof(NATIVE); 
-		char *newstr=(char*)malloc(len);
-		if ( buf->str!=NULL )
-		{
-			strcpy(newstr,buf->str);
+		if (len < sizeof(NATIVE))
+			len = sizeof(NATIVE);
+		char *newstr = (char*) malloc(len);
+		if (buf->str != NULL) {
+			strcpy(newstr, buf->str);
 			free(buf->str);
-		}
-		else
-			buf->nrefs=1;
+		} else
+			buf->nrefs = 1;
 		buf->str = newstr;
 		buf->len = len;
-	};
-	inline void copy(const char *s) { fit(strlen(s)+1); strcpy(buf->str,s); };
-	inline void copy(const char *s, size_t n) { fit(n+1); strncpy(buf->str,s,n); };
-	inline void link(gld_string&s) { unlink(); buf=(STRBUF*)s; buf->nrefs++;};
-	inline void unlink() { if ( buf->nrefs<=1 ) {free(buf->str); free(buf);} else buf->nrefs--; };
+	}
+	;
+	inline void copy(const char *s) {
+		fit(strlen(s) + 1);
+		strcpy(buf->str, s);
+	}
+	;
+	inline void copy(const char *s, size_t n) {
+		fit(n + 1);
+		strncpy(buf->str, s, n);
+	}
+	;
+	inline void link(gld_string &s) {
+		unlink();
+		buf = (STRBUF*) s;
+		buf->nrefs++;
+	}
+	;
+	inline void unlink() {
+		if (buf->nrefs <= 1) {
+			free(buf->str);
+			free(buf);
+		} else
+			buf->nrefs--;
+	}
+	;
 public: // status accessors
 	/// determine whether a string is valid
-	inline bool is_valid(void) { return buf!=NULL; };
+	inline bool is_valid(void) {
+		return buf != NULL;
+	}
+	;
 	/// determine whether a string is null
-	inline bool is_null(void) { return is_valid() && buf->str==NULL; };
+	inline bool is_null(void) {
+		return is_valid() && buf->str == NULL;
+	}
+	;
 public: // read accessors
 	/// get a pointer to the string buffer
-	inline const char* get_buffer(void) { return buf ? buf->str : NULL; };
+	inline const char* get_buffer(void) {
+		return buf ? buf->str : NULL;
+	}
+	;
 	/// get the size of the string buffer (as allocated)
-	inline size_t get_size(void) { return buf ? buf->len : -1; };
+	inline size_t get_size(void) {
+		return buf ? buf->len : -1;
+	}
+	;
 	/// get the length of the string (up to the null termination)
-	inline size_t get_length(void) { return buf && buf->str ? strlen(buf->str) : -1; };
+	inline size_t get_length(void) {
+		return buf && buf->str ? strlen(buf->str) : -1;
+	}
+	;
 public: // write accessors
 	/// set the string
-	inline void set_string(const char *s) { copy(s); };
+	inline void set_string(const char *s) {
+		copy(s);
+	}
+	;
 	/// set the string buffer size
-	inline void set_size(size_t n) { fit(n); };
+	inline void set_size(size_t n) {
+		fit(n);
+	}
+	;
 	/// format the string (a la printf)
-	inline size_t format(const char *fmt,...) { va_list ptr; va_start(ptr,fmt); int len=vsnprintf(buf->str,buf->len,fmt,ptr); va_end(ptr); return len;};
+	inline size_t format(const char *fmt, ...) {
+		va_list ptr;
+		va_start(ptr, fmt);
+		int len = vsnprintf(buf->str, buf->len, fmt, ptr);
+		va_end(ptr);
+		return len;
+	}
+	;
 	/// format the string with a specific buffer size
-	inline size_t format(size_t len,const char *fmt,...) { fit(len); va_list ptr; va_start(ptr,fmt); int rv=vsnprintf(buf->str,buf->len,fmt,ptr); va_end(ptr); return rv;};
+	inline size_t format(size_t len, const char *fmt, ...) {
+		fit(len);
+		va_list ptr;
+		va_start(ptr, fmt);
+		int rv = vsnprintf(buf->str, buf->len, fmt, ptr);
+		va_end(ptr);
+		return rv;
+	}
+	;
 public: // compare ops
 	/// alphabetic before comparison
-	inline bool operator<(const char*s) { return strcmp(buf->str,s)<0; };
+	inline bool operator<(const char *s) {
+		return strcmp(buf->str, s) < 0;
+	}
+	;
 	/// alphabetic before or same comparison
-	inline bool operator<=(const char*s) { return strcmp(buf->str,s)<=0; };
+	inline bool operator<=(const char *s) {
+		return strcmp(buf->str, s) <= 0;
+	}
+	;
 	/// alphabetic same comparison
-	inline bool operator==(const char*s) { return strcmp(buf->str,s)==0; };
+	inline bool operator==(const char *s) {
+		return strcmp(buf->str, s) == 0;
+	}
+	;
 	/// alphabetic after or same comparison
-	inline bool operator>=(const char*s) { return strcmp(buf->str,s)>=0; };
+	inline bool operator>=(const char *s) {
+		return strcmp(buf->str, s) >= 0;
+	}
+	;
 	/// alphabetic after comparison
-	inline bool operator>(const char*s) { return strcmp(buf->str,s)>0; };
+	inline bool operator>(const char *s) {
+		return strcmp(buf->str, s) > 0;
+	}
+	;
 	/// alphabetic differs comparison
-	inline bool operator!=(const char*s) { return strcmp(buf->str,s)!=0; };
+	inline bool operator!=(const char *s) {
+		return strcmp(buf->str, s) != 0;
+	}
+	;
 public: // manipulation
 	/// trim left whitespace
-	inline void trimleft(void) { if ( is_null() ) return; size_t n=0; while (buf->str[n]!='\0'&&isspace(*buf->str)) n++; strcpy(buf->str,buf->str+n); };
+	inline void trimleft(void) {
+		if (is_null())
+			return;
+		size_t n = 0;
+		while (buf->str[n] != '\0' && isspace(*buf->str))
+			n++;
+		strcpy(buf->str, buf->str + n);
+	}
+	;
 	/// trim right whitespace
-	inline void trimright(void) { if ( is_null() ) return; size_t n=strlen(buf->str); while (n>0&&isspace(buf->str[n-1])) buf->str[--n]='\0'; };
+	inline void trimright(void) {
+		if (is_null())
+			return;
+		size_t n = strlen(buf->str);
+		while (n > 0 && isspace(buf->str[n - 1]))
+			buf->str[--n] = '\0';
+	}
+	;
 	/// extract left string
-	inline gld_string left(size_t n) { if ( is_null() ) return gld_string(); return gld_string(buf->str,n); };
+	inline gld_string left(size_t n) {
+		if (is_null())
+			return gld_string();
+		return gld_string(buf->str, n);
+	}
+	;
 	/// extract right string
-	inline gld_string right(size_t n) { if ( is_null() ) return gld_string(); return gld_string(buf->str+buf->len-n); };
+	inline gld_string right(size_t n) {
+		if (is_null())
+			return gld_string();
+		return gld_string(buf->str + buf->len - n);
+	}
+	;
 	/// extract mid string
-	inline gld_string mid(size_t n, size_t m) { if ( is_null() ) return gld_string(); return gld_string(buf->str+buf->len-n,m); };
+	inline gld_string mid(size_t n, size_t m) {
+		if (is_null())
+			return gld_string();
+		return gld_string(buf->str + buf->len - n, m);
+	}
+	;
 	/// locate substring
-	inline size_t findstr(const char *s) { if ( is_null() ) return -1; char *p=strstr(buf->str,s); return p==NULL ? -1 : (p-buf->str); };
+	inline size_t findstr(const char *s) {
+		if (is_null())
+			return -1;
+		char *p = strstr(buf->str, s);
+		return p == NULL ? -1 : (p - buf->str);
+	}
+	;
 	/// find character
-	inline size_t findchr(char c) { if ( is_null() ) return -1; char *p=strchr(buf->str,c); return p==NULL ? -1 : (p-buf->str); };
-	inline size_t split(gld_string *&list, const char *delim=" ") 
-	{
+	inline size_t findchr(char c) {
+		if (is_null())
+			return -1;
+		char *p = strchr(buf->str, c);
+		return p == NULL ? -1 : (p - buf->str);
+	}
+	;
+	inline size_t split(gld_string *&list, const char *delim = " ") {
 		// TODO
-		if ( is_null() ) return 0;
+		if (is_null())
+			return 0;
 		return 0;
 	}
-	inline gld_string merge(gld_string *&list, size_t n, const char *delim=" ")
-	{
+	inline gld_string merge(gld_string *&list, size_t n,
+			const char *delim = " ") {
 		// TODO
 		return gld_string();
 	}
@@ -1426,140 +1641,353 @@ private: // data
 	DATETIME dt;
 public: // constructors
 	/// Clock constructor for current global clock
-	gld_clock(void) { callback->time.local_datetime(*(callback->global_clock),&dt); }; 
+	gld_clock(void) {
+		callback->time.local_datetime(*(callback->global_clock), &dt);
+	}
+	;
 	/// Clock constructor for an arbitrary TIMESTAMP
-	gld_clock(TIMESTAMP ts) { if ( !callback->time.local_datetime(ts,&dt)) memset(&dt,0,sizeof(dt)); };
+	gld_clock(TIMESTAMP ts) {
+		if (!callback->time.local_datetime(ts, &dt))
+			memset(&dt, 0, sizeof(dt));
+	}
+	;
 	/// Clock constructor for a time string
-	gld_clock(char *str) { from_string(str); };
+	gld_clock(char *str) {
+		from_string(str);
+	}
+	;
 	/// Clock constructor for year, month, day, hour, minute, second, nanosecond values
-	gld_clock(unsigned short y, unsigned short m=0, unsigned short d=0, unsigned short H=0, unsigned short M=0, unsigned short S=0, unsigned short int ms=0, char *tz=NULL, int dst=-1)
-	{
-		dt.year = y; dt.month=m; dt.day=d; dt.hour=H; dt.minute=M; dt.second=S; dt.nanosecond=ms;
-		if ( dst>=0 ) dt.is_dst=dst;
-		if ( tz!=NULL ) set_tz(tz); else callback->time.mkdatetime(&dt);
+	gld_clock(unsigned short y, unsigned short m = 0, unsigned short d = 0,
+			unsigned short H = 0, unsigned short M = 0, unsigned short S = 0,
+			unsigned short int ms = 0, char *tz = NULL, int dst = -1) {
+		dt.year = y;
+		dt.month = m;
+		dt.day = d;
+		dt.hour = H;
+		dt.minute = M;
+		dt.second = S;
+		dt.nanosecond = ms;
+		if (dst >= 0)
+			dt.is_dst = dst;
+		if (tz != NULL)
+			set_tz(tz);
+		else
+			callback->time.mkdatetime(&dt);
 	}
 public: // cast operators
 	/// Cast to TIMESTAMP
-	inline operator TIMESTAMP (void) { return dt.timestamp; };
+	inline operator TIMESTAMP(void) {
+		return dt.timestamp;
+	}
+	;
 public: // comparison operators
 	/// Compare after TIMESTAMP
-	inline bool operator > (TIMESTAMP t) { return dt.timestamp>t; };
+	inline bool operator >(TIMESTAMP t) {
+		return dt.timestamp > t;
+	}
+	;
 	/// Compare after or same TIMESTAMP
-	inline bool operator >= (TIMESTAMP t) { return dt.timestamp>=t; };
+	inline bool operator >=(TIMESTAMP t) {
+		return dt.timestamp >= t;
+	}
+	;
 	/// Compare before TIMESTAMP
-	inline bool operator < (TIMESTAMP t) { return dt.timestamp<t; };
+	inline bool operator <(TIMESTAMP t) {
+		return dt.timestamp < t;
+	}
+	;
 	/// Compare before or same TIMESTAMP
-	inline bool operator <= (TIMESTAMP t) { return dt.timestamp<=t; };
+	inline bool operator <=(TIMESTAMP t) {
+		return dt.timestamp <= t;
+	}
+	;
 	/// Compare same TIMESTAMP
-	inline bool operator == (TIMESTAMP t) { return dt.timestamp==t; };
+	inline bool operator ==(TIMESTAMP t) {
+		return dt.timestamp == t;
+	}
+	;
 	/// Compare different TIMESTAMP
-	inline bool operator != (TIMESTAMP t) { return dt.timestamp!=t; };
+	inline bool operator !=(TIMESTAMP t) {
+		return dt.timestamp != t;
+	}
+	;
 	/// Check if valid TIMESTAMP
-	inline bool is_valid(void) { return dt.timestamp>0; };
+	inline bool is_valid(void) {
+		return dt.timestamp > 0;
+	}
+	;
 	/// Check if NEVER
-	inline bool is_never(void) { return dt.timestamp==TS_NEVER; };
+	inline bool is_never(void) {
+		return dt.timestamp == TS_NEVER;
+	}
+	;
 public: // read accessors
 	/// Get the year
-	inline unsigned short get_year(void) { return dt.year; };
+	inline unsigned short get_year(void) {
+		return dt.year;
+	}
+	;
 	/// Get the month (0-11)
-	inline unsigned short get_month(void) { return dt.month; };
+	inline unsigned short get_month(void) {
+		return dt.month;
+	}
+	;
 	/// Get the day (1-31)
-	inline unsigned short get_day(void) { return dt.day; };
+	inline unsigned short get_day(void) {
+		return dt.day;
+	}
+	;
 	/// Get the hour (0-23)
-	inline unsigned short get_hour(void) { return dt.hour; };
+	inline unsigned short get_hour(void) {
+		return dt.hour;
+	}
+	;
 	/// Get the minute (0-59)
-	inline unsigned short get_minute(void) { return dt.minute; };
+	inline unsigned short get_minute(void) {
+		return dt.minute;
+	}
+	;
 	/// Get the second (0-59)
-	inline unsigned short get_second(void) { return dt.second; };
+	inline unsigned short get_second(void) {
+		return dt.second;
+	}
+	;
 	/// Get the nanosecond (0-999999)
-	inline unsigned int get_nanosecond(void) { return dt.nanosecond; };
+	inline unsigned int get_nanosecond(void) {
+		return dt.nanosecond;
+	}
+	;
 	/// Get the Unix Day Number (full days since the Unix Epoch)
-	inline unsigned int get_uday(void) { return dt.timestamp / 86400; };
+	inline unsigned int get_uday(void) {
+		return dt.timestamp / 86400;
+	}
+	;
 	/// Get the Julian Day Number
-	inline unsigned int get_jday(void) { return (dt.timestamp / 86400) + 2440587.5; };
+	inline unsigned int get_jday(void) {
+		return (dt.timestamp / 86400) + 2440587.5;
+	}
+	;
 	/// Get the timezone spec
-	inline char* get_tz(void) { return dt.tz; };
+	inline char* get_tz(void) {
+		return dt.tz;
+	}
+	;
 	/// Get the summer/daylight time flag
-	inline bool get_is_dst(void) { return dt.is_dst?true:false; };
+	inline bool get_is_dst(void) {
+		return dt.is_dst ? true : false;
+	}
+	;
 	/// Get the weekday (Sunday=0)
-	inline unsigned short get_weekday(void) { return dt.weekday; };
+	inline unsigned short get_weekday(void) {
+		return dt.weekday;
+	}
+	;
 	/// Get the day of the year (Jan 1=0)
-	inline unsigned short get_yearday(void) { return dt.yearday; };
+	inline unsigned short get_yearday(void) {
+		return dt.yearday;
+	}
+	;
 	/// Get the timezone offer (in seconds)
-	inline int get_tzoffset(void) { return dt.tzoffset; };
+	inline int get_tzoffset(void) {
+		return dt.tzoffset;
+	}
+	;
 	/// Get the TIMESTAMP value (UTC)
-	inline TIMESTAMP get_timestamp(void) { return dt.timestamp; };
+	inline TIMESTAMP get_timestamp(void) {
+		return dt.timestamp;
+	}
+	;
 	/// Get the local TIMESTAMP value (ignoring DST)
-	inline TIMESTAMP get_localtimestamp(void) { return dt.timestamp - dt.tzoffset; };
+	inline TIMESTAMP get_localtimestamp(void) {
+		return dt.timestamp - dt.tzoffset;
+	}
+	;
 	/// Get the local TIMESTAMP value (including DST)
-	inline TIMESTAMP get_localtimestamp_dst(bool force_dst=false) { return dt.timestamp - dt.tzoffset + (dt.is_dst||force_dst?3600:0); };
+	inline TIMESTAMP get_localtimestamp_dst(bool force_dst = false) {
+		return dt.timestamp - dt.tzoffset + (dt.is_dst || force_dst ? 3600 : 0);
+	}
+	;
 public: // write accessors
 	/// Set the date
-	inline TIMESTAMP set_date(unsigned short y, unsigned short m, unsigned short d) { dt.year=y; dt.month=m; dt.day=d; return callback->time.mkdatetime(&dt); };
+	inline TIMESTAMP set_date(unsigned short y, unsigned short m,
+			unsigned short d) {
+		dt.year = y;
+		dt.month = m;
+		dt.day = d;
+		return callback->time.mkdatetime(&dt);
+	}
+	;
 	/// Set the time
-	inline TIMESTAMP set_time(unsigned short H, unsigned short M, unsigned short S, unsigned long u=0, char *t=NULL, bool force_dst=false) { dt.hour=H; dt.minute=M; dt.second=S; dt.nanosecond=u; strncpy(dt.tz,t,sizeof(dt.tz)); if (force_dst) dt.is_dst=true; return callback->time.mkdatetime(&dt); };
+	inline TIMESTAMP set_time(unsigned short H, unsigned short M,
+			unsigned short S, unsigned long u = 0, char *t = NULL,
+			bool force_dst = false) {
+		dt.hour = H;
+		dt.minute = M;
+		dt.second = S;
+		dt.nanosecond = u;
+		strncpy(dt.tz, t, sizeof(dt.tz));
+		if (force_dst)
+			dt.is_dst = true;
+		return callback->time.mkdatetime(&dt);
+	}
+	;
 	/// Set the date and time
-	inline TIMESTAMP set_datetime(unsigned short y, unsigned short m, unsigned short d, unsigned short H, unsigned short M, unsigned short S, unsigned long u=0, char *t=NULL, bool force_dst=false) { dt.year=y; dt.month=m; dt.day=d; dt.hour=H; dt.minute=M; dt.second=S; dt.nanosecond=u; strncpy(dt.tz,t,sizeof(dt.tz)); if (force_dst) dt.is_dst=true; return callback->time.mkdatetime(&dt); };
+	inline TIMESTAMP set_datetime(unsigned short y, unsigned short m,
+			unsigned short d, unsigned short H, unsigned short M,
+			unsigned short S, unsigned long u = 0, char *t = NULL,
+			bool force_dst = false) {
+		dt.year = y;
+		dt.month = m;
+		dt.day = d;
+		dt.hour = H;
+		dt.minute = M;
+		dt.second = S;
+		dt.nanosecond = u;
+		strncpy(dt.tz, t, sizeof(dt.tz));
+		if (force_dst)
+			dt.is_dst = true;
+		return callback->time.mkdatetime(&dt);
+	}
+	;
 	/// Set the year
-	inline TIMESTAMP set_year(unsigned short y) { dt.year=y; return callback->time.mkdatetime(&dt); };
+	inline TIMESTAMP set_year(unsigned short y) {
+		dt.year = y;
+		return callback->time.mkdatetime(&dt);
+	}
+	;
 	/// Set the month (Jan=0)
-	inline TIMESTAMP set_month(unsigned short m) { dt.month=m; return callback->time.mkdatetime(&dt); };
+	inline TIMESTAMP set_month(unsigned short m) {
+		dt.month = m;
+		return callback->time.mkdatetime(&dt);
+	}
+	;
 	/// Set the day (1-31)
-	inline TIMESTAMP set_day(unsigned short d) { dt.day=d; return callback->time.mkdatetime(&dt); };
+	inline TIMESTAMP set_day(unsigned short d) {
+		dt.day = d;
+		return callback->time.mkdatetime(&dt);
+	}
+	;
 	/// Set the hour (0-23)
-	inline TIMESTAMP set_hour(unsigned short h) { dt.hour=h; return callback->time.mkdatetime(&dt); };
+	inline TIMESTAMP set_hour(unsigned short h) {
+		dt.hour = h;
+		return callback->time.mkdatetime(&dt);
+	}
+	;
 	/// Set the minute (0-59)
-	inline TIMESTAMP set_minute(unsigned short m) { dt.minute=m; return callback->time.mkdatetime(&dt); };
+	inline TIMESTAMP set_minute(unsigned short m) {
+		dt.minute = m;
+		return callback->time.mkdatetime(&dt);
+	}
+	;
 	/// Set the second (0-59)
-	inline TIMESTAMP set_second(unsigned short s) { dt.second=s; return callback->time.mkdatetime(&dt); };
+	inline TIMESTAMP set_second(unsigned short s) {
+		dt.second = s;
+		return callback->time.mkdatetime(&dt);
+	}
+	;
 	/// Set the nanosecond (0-999999)
-	inline TIMESTAMP set_nanosecond(unsigned int u) { dt.nanosecond=u; return callback->time.mkdatetime(&dt); };
+	inline TIMESTAMP set_nanosecond(unsigned int u) {
+		dt.nanosecond = u;
+		return callback->time.mkdatetime(&dt);
+	}
+	;
 	/// Set the timezone (see tzinfo.txt)
-	inline TIMESTAMP set_tz(char* t) { strncpy(dt.tz,t,sizeof(dt.tz)); return callback->time.mkdatetime(&dt); };
+	inline TIMESTAMP set_tz(char *t) {
+		strncpy(dt.tz, t, sizeof(dt.tz));
+		return callback->time.mkdatetime(&dt);
+	}
+	;
 	/// Set the DST flag
-	inline TIMESTAMP set_is_dst(bool i) { dt.is_dst=i; return callback->time.mkdatetime(&dt); };
+	inline TIMESTAMP set_is_dst(bool i) {
+		dt.is_dst = i;
+		return callback->time.mkdatetime(&dt);
+	}
+	;
 public: // special functions
 	/// Convert from string
-	inline bool from_string(char *str) { return callback->time.local_datetime(callback->time.convert_to_timestamp(str),&dt)?true:false; };
+	inline bool from_string(char *str) {
+		return callback->time.local_datetime(
+				callback->time.convert_to_timestamp(str), &dt) ? true : false;
+	}
+	;
 	/// Convert to string
-	inline unsigned int to_string(char *str, int size) {return callback->time.convert_from_timestamp(dt.timestamp,str,size); };
+	inline unsigned int to_string(char *str, int size) {
+		return callback->time.convert_from_timestamp(dt.timestamp, str, size);
+	}
+	;
 	/// Extract the total number of days since 1/1/1970 0:00:00 UTC
-	inline double to_days(TIMESTAMP ts=0) { return (dt.timestamp-ts)/86400.0 + dt.nanosecond*1e-9; };
+	inline double to_days(TIMESTAMP ts = 0) {
+		return (dt.timestamp - ts) / 86400.0 + dt.nanosecond * 1e-9;
+	}
+	;
 	/// Extract the total number of hours since 1/1/1970 0:00:00 UTC
-	inline double to_hours(TIMESTAMP ts=0) { return (dt.timestamp-ts)/3600.0 + dt.nanosecond*1e-9; };
+	inline double to_hours(TIMESTAMP ts = 0) {
+		return (dt.timestamp - ts) / 3600.0 + dt.nanosecond * 1e-9;
+	}
+	;
 	/// Extract the total number of minutes since 1/1/1970 0:00:00 UTC
-	inline double to_minutes(TIMESTAMP ts=0) { return (dt.timestamp-ts)/60.0 + dt.nanosecond*1e-9; };
+	inline double to_minutes(TIMESTAMP ts = 0) {
+		return (dt.timestamp - ts) / 60.0 + dt.nanosecond * 1e-9;
+	}
+	;
 	/// Extract the total number of seconds since 1/1/1970 0:00:00 UTC
-	inline double to_seconds(TIMESTAMP ts=0) { return dt.timestamp-ts + dt.nanosecond*1e-9; };
+	inline double to_seconds(TIMESTAMP ts = 0) {
+		return dt.timestamp - ts + dt.nanosecond * 1e-9;
+	}
+	;
 	/// Extract the total number of nanoseconds since 1/1/1970 0:00:00 UTC
-	inline double to_nanoseconds(TIMESTAMP ts=0) { return (dt.timestamp-ts)*1e9 + dt.nanosecond; };
+	inline double to_nanoseconds(TIMESTAMP ts = 0) {
+		return (dt.timestamp - ts) * 1e9 + dt.nanosecond;
+	}
+	;
 	/// Get the timestamp as a string
-	inline gld_string get_string(const size_t sz=1024) 
-	{
+	inline gld_string get_string(const size_t sz = 1024) {
 		gld_string res;
 		char buf[1024];
-		if ( sizeof(buf)<sz ) throw "get_string() over size limit";
-		if ( to_string(buf,(int)sz)>=0 )
+		if (sizeof(buf) < sz)
+			throw "get_string() over size limit";
+		if (to_string(buf, (int) sz) >= 0)
 			res = buf;
 		return res;
-	};
+	}
+	;
 };
 
 /// Read lock container
 class gld_rlock {
-private: OBJECT *my;
+private:
+	OBJECT *my;
 	/// Constructor
-public: inline gld_rlock(OBJECT *obj) : my(obj) {::rlock(&my->lock);}; 
+public:
+	inline gld_rlock(OBJECT *obj) :
+			my(obj) {
+		::rlock(&my->lock);
+	}
+	;
 	/// Destructor
-public: inline ~gld_rlock(void) {::runlock(&my->lock);};
+public:
+	inline ~gld_rlock(void) {
+		::runlock(&my->lock);
+	}
+	;
 };
 /// Write lock container
 class gld_wlock {
-private: OBJECT *my;
-		 /// Constructor
-public: inline gld_wlock(OBJECT *obj) : my(obj) {::wlock(&my->lock);}; 
-		/// Destructor
-public: inline ~gld_wlock(void) {::wunlock(&my->lock);};
+private:
+	OBJECT *my;
+	/// Constructor
+public:
+	inline gld_wlock(OBJECT *obj) :
+			my(obj) {
+		::wlock(&my->lock);
+	}
+	;
+	/// Destructor
+public:
+	inline ~gld_wlock(void) {
+		::wunlock(&my->lock);
+	}
+	;
 };
 
 class gld_class;
@@ -1571,27 +1999,55 @@ private: // data
 
 public: // constructors/casts
 	/// Constructor
-	inline gld_module(void) { MODULE *m = callback->module.getfirst(); if (m) core=*m; else throw "no modules loaded";};
+	inline gld_module(void) {
+		MODULE *m = callback->module.getfirst();
+		if (m)
+			core = *m;
+		else
+			throw "no modules loaded";
+	}
+	;
 	/// Cast to MODULE
-	inline operator MODULE*(void) { return &core; };
+	inline operator MODULE*(void) {
+		return &core;
+	}
+	;
 
 public: // read accessors
 	/// Get module name
-	inline char* get_name(void) { return core.name; };
+	inline char* get_name(void) {
+		return core.name;
+	}
+	;
 	/// Get module major version number
-	inline unsigned short get_major(void) { return core.major; };
+	inline unsigned short get_major(void) {
+		return core.major;
+	}
+	;
 	/// Get module minor version number
-	inline unsigned short get_minor(void) { return core.minor; };
+	inline unsigned short get_minor(void) {
+		return core.minor;
+	}
+	;
 	/// Get first class in module
-	inline gld_class* get_first_class(void) { return (gld_class*)core.oclass; };
+	inline gld_class* get_first_class(void) {
+		return (gld_class*) core.oclass;
+	}
+	;
 
 public: // write accessors
 
 public: // iterators
 	/// Check if last module loaded
-	inline bool is_last(void) { return core.next==NULL; };
+	inline bool is_last(void) {
+		return core.next == NULL;
+	}
+	;
 	/// Get next module loaded
-	inline void get_next(void) { core = *(core.next); };
+	inline void get_next(void) {
+		core = *(core.next);
+	}
+	;
 };
 
 class gld_property;
@@ -1604,45 +2060,94 @@ private: // data
 
 public: // constructors
 	/// Constructor (blocker implementation)
-	inline gld_class(void) { throw "gld_class constructor not permitted"; };
+	inline gld_class(void) {
+		throw "gld_class constructor not permitted";
+	}
+	;
 	/// Cast to CLASS
-	inline operator CLASS*(void) { return &core; };
+	inline operator CLASS*(void) {
+		return &core;
+	}
+	;
 
 public: // read accessors
 	/// Get class name
-	inline char* get_name(void) { return core.name; };
+	inline char* get_name(void) {
+		return core.name;
+	}
+	;
 	/// Get class size
-	inline size_t get_size(void) { return core.size; };
+	inline size_t get_size(void) {
+		return core.size;
+	}
+	;
 	/// Get class parent
-	inline gld_class* get_parent(void) { return (gld_class*)core.parent; };
+	inline gld_class* get_parent(void) {
+		return (gld_class*) core.parent;
+	}
+	;
 	/// Get module that implements the class
-	inline gld_module* get_module(void) { return (gld_module*)core.module; };
+	inline gld_module* get_module(void) {
+		return (gld_module*) core.module;
+	}
+	;
 	/// Get the first property in the class
-	inline gld_property* get_first_property(void) { return (gld_property*)core.pmap; };
+	inline gld_property* get_first_property(void) {
+		return (gld_property*) core.pmap;
+	}
+	;
 	/// Get the next property in the class
-	inline gld_property* get_next_property(PROPERTY*p) { PROPERTY *prop=(PROPERTY*)p->next; return ( prop && prop->oclass==&core ) ? (gld_property*)prop : NULL; };
+	inline gld_property* get_next_property(PROPERTY *p) {
+		PROPERTY *prop = (PROPERTY*) p->next;
+		return (prop && prop->oclass == &core) ? (gld_property*) prop : NULL;
+	}
+	;
 	/// Get the first function in the class
-	inline gld_function* get_first_function(void) { return (gld_function*)core.fmap; };
+	inline gld_function* get_first_function(void) {
+		return (gld_function*) core.fmap;
+	}
+	;
 	/// Get the next function in the class
-	inline gld_function* get_next_function(FUNCTION*f) { return (gld_function*)f->next; };
+	inline gld_function* get_next_function(FUNCTION *f) {
+		return (gld_function*) f->next;
+	}
+	;
 	/// Get TRL 
-	inline TECHNOLOGYREADINESSLEVEL get_trl(void) { return core.trl; };
+	inline TECHNOLOGYREADINESSLEVEL get_trl(void) {
+		return core.trl;
+	}
+	;
 
 public: // write accessors
 	/// Set TRL
-	inline void set_trl(TECHNOLOGYREADINESSLEVEL t) { core.trl=t; };
+	inline void set_trl(TECHNOLOGYREADINESSLEVEL t) {
+		core.trl = t;
+	}
+	;
 
 public: // special functions
 	/// Register a class	
-	static inline CLASS *create(MODULE *m, char *n, size_t s, unsigned int f) { return callback->register_class(m,n,(unsigned int)s,f); };
-	
+	static inline CLASS* create(MODULE *m, char *n, size_t s, unsigned int f) {
+		return callback->register_class(m, n, (unsigned int) s, f);
+	}
+	;
+
 public: // iterators
 	/// Check if last class registered
-	inline bool is_last(void) { return core.next==NULL; };
+	inline bool is_last(void) {
+		return core.next == NULL;
+	}
+	;
 	/// Check if last class defined by this class' module
-	inline bool is_module_last(void) { return core.next==NULL || core.module!=core.next->module; };
+	inline bool is_module_last(void) {
+		return core.next == NULL || core.module != core.next->module;
+	}
+	;
 	/// Get the next class
-	inline gld_class* get_next(void) { return (gld_class*)core.next; };
+	inline gld_class* get_next(void) {
+		return (gld_class*) core.next;
+	}
+	;
 };
 
 /// Function container
@@ -1653,25 +2158,46 @@ private: // data
 
 public: // constructors
 	/// Construct a function (blocker implementation)
-	inline gld_function(void) { throw "gld_function constructor not permitted"; };
+	inline gld_function(void) {
+		throw "gld_function constructor not permitted";
+	}
+	;
 	/// Cast to a FUNCTION pointer
-	inline operator FUNCTION*(void) { return &core; };
+	inline operator FUNCTION*(void) {
+		return &core;
+	}
+	;
 
 public: // read accessors
 	/// Get function name
-	inline char *get_name(void) { return core.name; };
+	inline char* get_name(void) {
+		return core.name;
+	}
+	;
 	/// Get function class
-	inline gld_class* get_class(void) { return (gld_class*)core.oclass; };
+	inline gld_class* get_class(void) {
+		return (gld_class*) core.oclass;
+	}
+	;
 	/// Get function address
-	inline FUNCTIONADDR get_addr(void) { return core.addr; };
+	inline FUNCTIONADDR get_addr(void) {
+		return core.addr;
+	}
+	;
 
 public: // write accessors
 
 public: // iterators
 	/// Check whether this is the last function defined
-	inline bool is_last(void) { return core.next==NULL; };
+	inline bool is_last(void) {
+		return core.next == NULL;
+	}
+	;
 	/// Get the next function in the list
-	inline gld_function* get_next(void) { return (gld_function*)core.next; };
+	inline gld_function* get_next(void) {
+		return (gld_function*) core.next;
+	}
+	;
 };
 
 /// Built-in type container
@@ -1682,23 +2208,41 @@ private: // data
 
 public: // constructors/casts
 	/// Constructor
-	inline gld_type(PROPERTYTYPE t) : type(t) {};
+	inline gld_type(PROPERTYTYPE t) :
+			type(t) {
+	}
+	;
 	/// Cast to PROPERTYTYPE
-	inline operator PROPERTYTYPE(void) { return type; };
+	inline operator PROPERTYTYPE(void) {
+		return type;
+	}
+	;
 
 public: // read accessors
 	// TODO size,conversions,etc...
-	PROPERTYSPEC *get_spec(void) { return callback->properties.get_spec(type);};
+	PROPERTYSPEC* get_spec(void) {
+		return callback->properties.get_spec(type);
+	}
+	;
 
 public: // write accessors
 
 public: // iterators
 	/// Get the first property type
-	static inline PROPERTYTYPE get_first(void) { return PT_double; };
+	static inline PROPERTYTYPE get_first(void) {
+		return PT_double;
+	}
+	;
 	/// Get the next property type
-	inline PROPERTYTYPE get_next(void) { return (PROPERTYTYPE)(((int)type)+1); };
+	inline PROPERTYTYPE get_next(void) {
+		return (PROPERTYTYPE)(((int) type) + 1);
+	}
+	;
 	/// Check whether this is the last property type
-	inline bool is_last(void) { return (PROPERTYTYPE)(((int)type)+1)==_PT_LAST; }; 
+	inline bool is_last(void) {
+		return (PROPERTYTYPE)(((int) type) + 1) == _PT_LAST;
+	}
+	;
 };
 
 /// Unit container
@@ -1709,53 +2253,124 @@ private: // data
 
 public: // constructors/casts
 	/// Construct empty unit container
-	inline gld_unit(void) { memset(&core,0,sizeof(core)); };
+	inline gld_unit(void) {
+		memset(&core, 0, sizeof(core));
+	}
+	;
 	/// Construct a container for a named or derived unit
-	inline gld_unit(char *name) { UNIT *unit=callback->unit_find(name); if (unit) memcpy(&core,unit,sizeof(UNIT)); else memset(&core,0,sizeof(UNIT)); };
+	inline gld_unit(char *name) {
+		UNIT *unit = callback->unit_find(name);
+		if (unit)
+			memcpy(&core, unit, sizeof(UNIT));
+		else
+			memset(&core, 0, sizeof(UNIT));
+	}
+	;
 	/// Cast to a UNIT structure
-	inline operator UNIT*(void) { return &core; };
+	inline operator UNIT*(void) {
+		return &core;
+	}
+	;
 
 public: // read accessors
 	/// Get the name or derivation of the unit
-	inline char* get_name(void) { return core.name; };
+	inline char* get_name(void) {
+		return core.name;
+	}
+	;
 	/// Get the C exponent
-	inline double get_c(void) { return core.c; };
+	inline double get_c(void) {
+		return core.c;
+	}
+	;
 	/// Get the E exponent
-	inline double get_e(void) { return core.e; };
+	inline double get_e(void) {
+		return core.e;
+	}
+	;
 	/// Get the H exponent
-	inline double get_h(void) { return core.h; };
+	inline double get_h(void) {
+		return core.h;
+	}
+	;
 	/// Get the K exponent
-	inline double get_k(void) { return core.k; };
+	inline double get_k(void) {
+		return core.k;
+	}
+	;
 	/// Get the M exponent
-	inline double get_m(void) { return core.m; };
+	inline double get_m(void) {
+		return core.m;
+	}
+	;
 	/// Get the S exponent
-	inline double get_s(void) { return core.s; };
+	inline double get_s(void) {
+		return core.s;
+	}
+	;
 	/// Get the A constant
-	inline double get_a(void) { return core.a; };
+	inline double get_a(void) {
+		return core.a;
+	}
+	;
 	/// Get the B constant
-	inline double get_b(void) { return core.b; };
+	inline double get_b(void) {
+		return core.b;
+	}
+	;
 	/// Get the unit precision
-	inline int get_prec(void) { return core.prec; };
+	inline int get_prec(void) {
+		return core.prec;
+	}
+	;
 	/// Check whether the unit is valid
-	inline bool is_valid(void) { return core.name[0]!='\0'; };
+	inline bool is_valid(void) {
+		return core.name[0] != '\0';
+	}
+	;
 
 public: // write accessors
 	/// Change the unit
-	inline bool set_unit(char *name){ UNIT *unit=callback->unit_find(name); if (unit) {memcpy(&core,unit,sizeof(UNIT));return true;} else {memset(&core,0,sizeof(UNIT));return false;} };
+	inline bool set_unit(char *name) {
+		UNIT *unit = callback->unit_find(name);
+		if (unit) {
+			memcpy(&core, unit, sizeof(UNIT));
+			return true;
+		} else {
+			memset(&core, 0, sizeof(UNIT));
+			return false;
+		}
+	}
+	;
 
 public: // special functions
 	/// Convert a value to another named or derived unit
-	inline bool convert(char *name, double &value) { UNIT *unit=callback->unit_find(name); return unit&&(callback->unit_convert_ex(&core,unit,&value))?true:false; }
+	inline bool convert(char *name, double &value) {
+		UNIT *unit = callback->unit_find(name);
+		return unit && (callback->unit_convert_ex(&core, unit, &value)) ?
+				true : false;
+	}
 	/// Convert a value to another UNIT
-	inline bool convert(UNIT *unit, double &value) { return callback->unit_convert_ex(&core,unit,&value)?true:false; }
+	inline bool convert(UNIT *unit, double &value) {
+		return callback->unit_convert_ex(&core, unit, &value) ? true : false;
+	}
 	/// Convert a value to another gld_unit
-	inline bool convert(gld_unit &unit, double &value) { return callback->unit_convert_ex(&core,(UNIT*)unit,&value)?true:false; }
+	inline bool convert(gld_unit &unit, double &value) {
+		return callback->unit_convert_ex(&core, (UNIT*) unit, &value) ?
+				true : false;
+	}
 
 public: // iterators
 	/// Check whether this is the last defined unit
-	inline bool is_last(void) { return core.next==NULL?true:false; };
+	inline bool is_last(void) {
+		return core.next == NULL ? true : false;
+	}
+	;
 	/// Get the next unit
-	inline gld_unit* get_next(void) { return (gld_unit*)core.next; };
+	inline gld_unit* get_next(void) {
+		return (gld_unit*) core.next;
+	}
+	;
 };
 
 /// Keyword container
@@ -1766,47 +2381,118 @@ private: // data
 
 public: // constructors/casts
 	/// Construct a key word
-	inline gld_keyword(KEYWORD &key) { core=key; };
+	inline gld_keyword(KEYWORD &key) {
+		core = key;
+	}
+	;
 	/// Cast to a keyword pointer
-	inline operator KEYWORD* (void) { return &core; };
-	inline operator const char* (void) { return core.name; };
-	inline operator long unsigned int (void) { return core.value;};
+	inline operator KEYWORD*(void) {
+		return &core;
+	}
+	;
+	inline operator const char*(void) {
+		return core.name;
+	}
+	;
+	inline operator long unsigned int(void) {
+		return core.value;
+	}
+	;
 
 public: // read accessors
 	/// Get the name of a keyword
-	inline const char* get_name(void) { return core.name; };
+	inline const char* get_name(void) {
+		return core.name;
+	}
+	;
 	/// Get the bit pattern for the keyword
-	inline long unsigned int get_value(void) { return core.value; };
-	inline enumeration get_enumeration_value(void) { return (enumeration)get_value(); };
-	inline set get_set_value(void) { return (set)get_value(); };
+	inline long unsigned int get_value(void) {
+		return core.value;
+	}
+	;
+	inline enumeration get_enumeration_value(void) {
+		return (enumeration) get_value();
+	}
+	;
+	inline set get_set_value(void) {
+		return (set) get_value();
+	}
+	;
 
 public: // write accessors
-	inline int compare(const char *name) { return strcmp(name,core.name); };
-	inline bool operator == (const char *name) { return compare(name)==0; };
-	inline bool operator <= (const char *name) { return compare(name)<=0; };
-	inline bool operator >= (const char *name) { return compare(name)>=0; };
-	inline bool operator < (const char *name) { return compare(name)<0; };
-	inline bool operator > (const char *name) { return compare(name)>0; };
-	inline bool operator != (const char *name) { return compare(name)!=0; };
-	inline int compare(long unsigned int value) { return value<(long unsigned int)core.value ? -1 : ( value>core.value ? +1 : 0 ); };
-	inline bool operator == (long unsigned int value) { return compare(value)==0; };
-	inline bool operator <= (long unsigned int value) { return compare(value)<=0; };
-	inline bool operator >= (long unsigned int value) { return compare(value)>=0; };
-	inline bool operator < (long unsigned int value) { return compare(value)<0; };
-	inline bool operator > (long unsigned int value) { return compare(value)>0; };
-	inline bool operator != (long unsigned int value) { return compare(value)!=0; };
+	inline int compare(const char *name) {
+		return strcmp(name, core.name);
+	}
+	;
+	inline bool operator ==(const char *name) {
+		return compare(name) == 0;
+	}
+	;
+	inline bool operator <=(const char *name) {
+		return compare(name) <= 0;
+	}
+	;
+	inline bool operator >=(const char *name) {
+		return compare(name) >= 0;
+	}
+	;
+	inline bool operator <(const char *name) {
+		return compare(name) < 0;
+	}
+	;
+	inline bool operator >(const char *name) {
+		return compare(name) > 0;
+	}
+	;
+	inline bool operator !=(const char *name) {
+		return compare(name) != 0;
+	}
+	;
+	inline int compare(long unsigned int value) {
+		return value < (long unsigned int) core.value ?
+				-1 : (value > core.value ? +1 : 0);
+	}
+	;
+	inline bool operator ==(long unsigned int value) {
+		return compare(value) == 0;
+	}
+	;
+	inline bool operator <=(long unsigned int value) {
+		return compare(value) <= 0;
+	}
+	;
+	inline bool operator >=(long unsigned int value) {
+		return compare(value) >= 0;
+	}
+	;
+	inline bool operator <(long unsigned int value) {
+		return compare(value) < 0;
+	}
+	;
+	inline bool operator >(long unsigned int value) {
+		return compare(value) > 0;
+	}
+	;
+	inline bool operator !=(long unsigned int value) {
+		return compare(value) != 0;
+	}
+	;
 
 public: // iterators
 	/// Get the next keyword (NULL if last)
-	inline gld_keyword* get_next(void) { return (gld_keyword*)core.next; };
-	template <class T> inline gld_keyword* find(T value)
-	{
-		if ( compare(value)==0 ) return this;
-		if ( get_next()==NULL ) return NULL;
+	inline gld_keyword* get_next(void) {
+		return (gld_keyword*) core.next;
+	}
+	;
+	template<class T> inline gld_keyword* find(T value) {
+		if (compare(value) == 0)
+			return this;
+		if (get_next() == NULL)
+			return NULL;
 		return get_next()->find(value);
-	};
+	}
+	;
 };
-
 
 // object data declaration/accessors
 /// Define an atomic property
@@ -1878,118 +2564,324 @@ public: // iterators
 	inline void set_##X(char *str) { get_##X##_property().from_string(str); }; \
 
 /// Set bits of a bitflag property
-inline void setbits(unsigned long &flags, unsigned int bits) { flags|=bits; }; 
+inline void setbits(unsigned long &flags, unsigned int bits) {
+	flags |= bits;
+}
+;
 /// Clear bits of a bitflag property
-inline void clearbits(unsigned long &flags, unsigned int bits) { flags&=~bits; }; 
+inline void clearbits(unsigned long &flags, unsigned int bits) {
+	flags &= ~bits;
+}
+;
 /// Test bits of a bitflag property
-inline bool hasbits(unsigned long flags, unsigned int bits) { return (flags&bits) ? true : false; };
+inline bool hasbits(unsigned long flags, unsigned int bits) {
+	return (flags & bits) ? true : false;
+}
+;
 
 /// Object container
 class gld_object {
 public:
-	inline OBJECT *my() { return this?(((OBJECT*)this)-1):NULL; }
+	inline OBJECT* my() {
+		return this ? (((OBJECT*) this) - 1) : NULL;
+	}
 private:
 	// Make gld_object not copy-constructable.
 	gld_object& operator=(const gld_object&) = delete;
 
 public: // constructors
-	inline static gld_object *find_object(char *n) { OBJECT *obj = callback->get_object(n); if (obj) return (gld_object*)(obj+1); else return NULL; };
+	inline static gld_object* find_object(char *n) {
+		OBJECT *obj = callback->get_object(n);
+		if (obj)
+			return (gld_object*) (obj + 1);
+		else
+			return NULL;
+	}
+	;
 
 public: // header read accessors (no locking)
-	inline OBJECTNUM get_id(void) { return my()->id; };
-	inline char* get_groupid(void) { return my()->groupid.get_string(); };
-	inline gld_class* get_oclass(void) { return (gld_class*)my()->oclass; };
-	inline gld_object* get_parent(void) { return my()->parent?OBJECTDATA(my()->parent,gld_object):NULL; };
-	inline OBJECTRANK get_rank(void) { return my()->rank; };
-	inline TIMESTAMP get_clock(void) { return my()->clock; };
-	inline TIMESTAMP get_valid_to(void) { return my()->valid_to; };
-	inline TIMESTAMP get_schedule_skew(void) { return my()->schedule_skew; };
-	inline FORECAST* get_forecast(void) { return my()->forecast; };
-	inline double get_latitude(void) { return my()->latitude; };
-	inline double get_longitude(void) { return my()->longitude; };
-	inline TIMESTAMP get_in_svc(void) { return my()->in_svc; };
-	inline TIMESTAMP get_out_svc(void) { return my()->out_svc; };
+	inline OBJECTNUM get_id(void) {
+		return my()->id;
+	}
+	;
+	inline char* get_groupid(void) {
+		return my()->groupid.get_string();
+	}
+	;
+	inline gld_class* get_oclass(void) {
+		return (gld_class*) my()->oclass;
+	}
+	;
+	inline gld_object* get_parent(void) {
+		return my()->parent ? OBJECTDATA(my()->parent, gld_object) : NULL;
+	}
+	;
+	inline OBJECTRANK get_rank(void) {
+		return my()->rank;
+	}
+	;
+	inline TIMESTAMP get_clock(void) {
+		return my()->clock;
+	}
+	;
+	inline TIMESTAMP get_valid_to(void) {
+		return my()->valid_to;
+	}
+	;
+	inline TIMESTAMP get_schedule_skew(void) {
+		return my()->schedule_skew;
+	}
+	;
+	inline FORECAST* get_forecast(void) {
+		return my()->forecast;
+	}
+	;
+	inline double get_latitude(void) {
+		return my()->latitude;
+	}
+	;
+	inline double get_longitude(void) {
+		return my()->longitude;
+	}
+	;
+	inline TIMESTAMP get_in_svc(void) {
+		return my()->in_svc;
+	}
+	;
+	inline TIMESTAMP get_out_svc(void) {
+		return my()->out_svc;
+	}
+	;
 	inline const char* get_name(void) {
 		static char _name[sizeof(CLASS) + 16];
-		if(my()->name){
-				return my()->name;
-		} else if(my()->oclass){
-			snprintf(_name, sizeof(CLASS) + 16, "%s:%d",
-					my()->oclass->name, my()->id);
+		if (my()->name) {
+			return my()->name;
+		} else if (my()->oclass) {
+			snprintf(_name, sizeof(CLASS) + 16, "%s:%d", my()->oclass->name,
+					my()->id);
 		} else {
 			snprintf(_name, sizeof(CLASS) + 16, "Unknown");
 		}
 		return _name;
 	}
 	;
-	inline NAMESPACE* get_space(void) { return my()->space; };
-	inline unsigned int get_lock(void) { return my()->lock; };
-	inline unsigned int get_rng_state(void) { return my()->rng_state; };
-	inline TIMESTAMP get_heartbeat(void) { return my()->heartbeat; };
-	inline unsigned long get_flags(unsigned long mask=0xffffffff) { return (my()->flags)&mask; };
+	inline NAMESPACE* get_space(void) {
+		return my()->space;
+	}
+	;
+	inline unsigned int get_lock(void) {
+		return my()->lock;
+	}
+	;
+	inline unsigned int get_rng_state(void) {
+		return my()->rng_state;
+	}
+	;
+	inline TIMESTAMP get_heartbeat(void) {
+		return my()->heartbeat;
+	}
+	;
+	inline unsigned long get_flags(unsigned long mask = 0xffffffff) {
+		return (my()->flags) & mask;
+	}
+	;
 
 protected: // header write accessors (no locking)
-	inline void set_clock(TIMESTAMP ts=0) { my()->clock=(ts?ts:gl_globalclock); };
-	inline void set_heartbeat(TIMESTAMP dt) { my()->heartbeat=dt; };
-	inline void set_forecast(FORECAST *fs) { my()->forecast=fs; };
-	inline void set_latitude(double x) { my()->latitude=x; };
-	inline void set_longitude(double x) { my()->longitude=x; };
-	inline void set_flags(unsigned long flags) { my()->flags=flags; };
-	inline void set_flags_bits(unsigned long bits) { my()->flags|=bits; };
-	inline void unset_flags_bits(unsigned long bits) { my()->flags&=~bits; };
+	inline void set_clock(TIMESTAMP ts = 0) {
+		my()->clock = (ts ? ts : gl_globalclock);
+	}
+	;
+	inline void set_heartbeat(TIMESTAMP dt) {
+		my()->heartbeat = dt;
+	}
+	;
+	inline void set_forecast(FORECAST *fs) {
+		my()->forecast = fs;
+	}
+	;
+	inline void set_latitude(double x) {
+		my()->latitude = x;
+	}
+	;
+	inline void set_longitude(double x) {
+		my()->longitude = x;
+	}
+	;
+	inline void set_flags(unsigned long flags) {
+		my()->flags = flags;
+	}
+	;
+	inline void set_flags_bits(unsigned long bits) {
+		my()->flags |= bits;
+	}
+	;
+	inline void unset_flags_bits(unsigned long bits) {
+		my()->flags &= ~bits;
+	}
+	;
 
 protected: // locking (self)
-	inline void rlock(void) { ::rlock(&my()->lock); };
-	inline void runlock(void) { ::runlock(&my()->lock); };
-	inline void wlock(void) { ::wlock(&my()->lock); };
-	inline void wunlock(void) { ::wunlock(&my()->lock); };
+	inline void rlock(void) {
+		::rlock(&my()->lock);
+	}
+	;
+	inline void runlock(void) {
+		::runlock(&my()->lock);
+	}
+	;
+	inline void wlock(void) {
+		::wlock(&my()->lock);
+	}
+	;
+	inline void wunlock(void) {
+		::wunlock(&my()->lock);
+	}
+	;
 protected: // locking (others)
-	inline void rlock(OBJECT *obj) { ::rlock(&obj->lock); };
-	inline void runlock(OBJECT *obj) { ::runlock(&obj->lock); };
-	inline void wlock(OBJECT *obj) { ::wlock(&obj->lock); };
-	inline void wunlock(OBJECT *obj) { ::wunlock(&obj->lock); };
+	inline void rlock(OBJECT *obj) {
+		::rlock(&obj->lock);
+	}
+	;
+	inline void runlock(OBJECT *obj) {
+		::runlock(&obj->lock);
+	}
+	;
+	inline void wlock(OBJECT *obj) {
+		::wlock(&obj->lock);
+	}
+	;
+	inline void wunlock(OBJECT *obj) {
+		::wunlock(&obj->lock);
+	}
+	;
 
 protected: // special functions
-	inline bool operator == (gld_object *o) { return o!=NULL && my()==o->my(); };
-	inline bool operator == (OBJECT *o) { return o!=NULL && my()==o; };
+	inline bool operator ==(gld_object *o) {
+		return o != NULL && my() == o->my();
+	}
+	;
+	inline bool operator ==(OBJECT *o) {
+		return o != NULL && my() == o;
+	}
+	;
 
 public: // member lookup functions
-	inline PROPERTY* get_property(char *name, PROPERTYSTRUCT *pstruct=NULL) { return callback->properties.get_property(my(),name,pstruct); };
-	inline FUNCTIONADDR get_function(char *name) { return (*callback->function.get)(my()->oclass->name,name); };
+	inline PROPERTY* get_property(char *name, PROPERTYSTRUCT *pstruct = NULL) {
+		return callback->properties.get_property(my(), name, pstruct);
+	}
+	;
+	inline FUNCTIONADDR get_function(char *name) {
+		return (*callback->function.get)(my()->oclass->name, name);
+	}
+	;
 
 public: // external accessors
-	template <class T> inline void getp(PROPERTY &prop, T &value) { rlock(); value=*(T*)(GETADDR(my(),&prop)); wunlock(); };
-	template <class T> inline void setp(PROPERTY &prop, T &value) { wlock(); *(T*)(GETADDR(my(),&prop))=value; wunlock(); };
-	template <class T> inline void getp(PROPERTY &prop, T &value, gld_rlock&) { value=*(T*)(GETADDR(my(),&prop)); };
-	template <class T> inline void getp(PROPERTY &prop, T &value, gld_wlock&) { value=*(T*)(GETADDR(my(),&prop)); };
-	template <class T> inline void setp(PROPERTY &prop, T &value, gld_wlock&) { *(T*)(GETADDR(my(),&prop))=value; };
+	template<class T> inline void getp(PROPERTY &prop, T &value) {
+		rlock();
+		value = *(T*) (GETADDR(my(), &prop));
+		wunlock();
+	}
+	;
+	template<class T> inline void setp(PROPERTY &prop, T &value) {
+		wlock();
+		*(T*) (GETADDR(my(), &prop)) = value;
+		wunlock();
+	}
+	;
+	template<class T> inline void getp(PROPERTY &prop, T &value, gld_rlock&) {
+		value = *(T*) (GETADDR(my(), &prop));
+	}
+	;
+	template<class T> inline void getp(PROPERTY &prop, T &value, gld_wlock&) {
+		value = *(T*) (GETADDR(my(), &prop));
+	}
+	;
+	template<class T> inline void setp(PROPERTY &prop, T &value, gld_wlock&) {
+		*(T*) (GETADDR(my(), &prop)) = value;
+	}
+	;
 
 public: // core interface
-	inline int set_dependent(OBJECT *obj) { return callback->object.set_dependent(my(),obj); };
-	inline int set_parent(OBJECT *obj) { return callback->object.set_parent(my(),obj); };
-	inline int set_rank(unsigned int r) { return callback->object.set_rank(my(),r); };
-	inline bool isa(char *type) { return callback->object_isa(my(),type) ? true : false; };
-	inline bool is_valid(void) { return my()!=NULL && my()==OBJECTHDR(this); };
+	inline int set_dependent(OBJECT *obj) {
+		return callback->object.set_dependent(my(), obj);
+	}
+	;
+	inline int set_parent(OBJECT *obj) {
+		return callback->object.set_parent(my(), obj);
+	}
+	;
+	inline int set_rank(unsigned int r) {
+		return callback->object.set_rank(my(), r);
+	}
+	;
+	inline bool isa(char *type) {
+		return callback->object_isa(my(), type) ? true : false;
+	}
+	;
+	inline bool is_valid(void) {
+		return my() != NULL && my() == OBJECTHDR(this);
+	}
+	;
 
 public: // iterators
-	inline bool is_last(void) { return my()->next==NULL; };
-	inline static gld_object *get_first(void) { OBJECT *o=callback->object.get_first(); return OBJECTDATA(o,gld_object);};
-	inline gld_object* get_next(void) { return OBJECTDATA(my()->next,gld_object); };
+	inline bool is_last(void) {
+		return my()->next == NULL;
+	}
+	;
+	inline static gld_object* get_first(void) {
+		OBJECT *o = callback->object.get_first();
+		return OBJECTDATA(o, gld_object);
+	}
+	;
+	inline gld_object* get_next(void) {
+		return OBJECTDATA(my()->next, gld_object);
+	}
+	;
 
 public: // exceptions
-	inline void exception(const char *msg, ...) { static char buf[1024]; va_list ptr; va_start(ptr,msg); vsprintf(buf+sprintf(buf,"%s: ",get_name()),msg,ptr); va_end(ptr); throw (const char*)buf;};
-	inline void error(const char *msg, ...) { static char buf[1024]; va_list ptr; va_start(ptr,msg); vsprintf(buf+sprintf(buf,"%s: ",get_name()),msg,ptr); va_end(ptr); gl_error("%s",buf);};
-	inline void warning(const char *msg, ...) { static char buf[1024]; va_list ptr; va_start(ptr,msg); vsprintf(buf+sprintf(buf,"%s: ",get_name()),msg,ptr); va_end(ptr); gl_warning("%s",buf);};
-	inline void debug(const char *msg, ...) { static char buf[1024]; va_list ptr; va_start(ptr,msg); vsprintf(buf+sprintf(buf,"%s: ",get_name()),msg,ptr); va_end(ptr); gl_debug("%s",buf);};
+	inline void exception(const char *msg, ...) {
+		static char buf[1024];
+		va_list ptr;
+		va_start(ptr, msg);
+		vsprintf(buf + sprintf(buf, "%s: ", get_name()), msg, ptr);
+		va_end(ptr);
+		throw(const char*) buf;
+	}
+	;
+	inline void error(const char *msg, ...) {
+		static char buf[1024];
+		va_list ptr;
+		va_start(ptr, msg);
+		vsprintf(buf + sprintf(buf, "%s: ", get_name()), msg, ptr);
+		va_end(ptr);
+		gl_error("%s", buf);
+	}
+	;
+	inline void warning(const char *msg, ...) {
+		static char buf[1024];
+		va_list ptr;
+		va_start(ptr, msg);
+		vsprintf(buf + sprintf(buf, "%s: ", get_name()), msg, ptr);
+		va_end(ptr);
+		gl_warning("%s", buf);
+	}
+	;
+	inline void debug(const char *msg, ...) {
+		static char buf[1024];
+		va_list ptr;
+		va_start(ptr, msg);
+		vsprintf(buf + sprintf(buf, "%s: ", get_name()), msg, ptr);
+		va_end(ptr);
+		gl_debug("%s", buf);
+	}
+	;
 };
 /// Create a gld_object from an OBJECT
-static inline gld_object* get_object(OBJECT*obj)
-{
-	return obj ? (gld_object*)(obj+1) : NULL;
+static inline gld_object* get_object(OBJECT *obj) {
+	return obj ? (gld_object*) (obj + 1) : NULL;
 }
 /// Find a gld_object from an object name
-static inline gld_object* get_object(char *n)
-{
+static inline gld_object* get_object(char *n) {
 	OBJECT *obj = callback->get_object(n);
 	return get_object(obj);
 }
@@ -2003,195 +2895,518 @@ private: // data
 	OBJECT *obj;
 
 public: // constructors/casts
-	inline gld_property(void) : obj(NULL), pstruct(nullpstruct) {};
-	inline gld_property(gld_object *o, char *n) : obj(o->my()), pstruct(nullpstruct)  
-	{ 
-		if (o) 
-			callback->properties.get_property(o->my(),n,&pstruct); 
-		else 
-		{
-			GLOBALVAR *v=callback->global.find(n); 
-			pstruct.prop= (v?v->prop:NULL);
-		} 
-	};
-	inline gld_property(OBJECT *o, char *n) : obj(o), pstruct(nullpstruct)  
-	{ 
-		if (o) 
-			callback->properties.get_property(o,n,&pstruct); 
-		else 
-		{
-			GLOBALVAR *v=callback->global.find(n); 
-			pstruct.prop= (v?v->prop:NULL);
-		} 
-	};
-	inline gld_property(OBJECT *o) : obj(o), pstruct(nullpstruct) { pstruct.prop=o->oclass->pmap; };
-	inline gld_property(OBJECT *o, PROPERTY *p) : obj(o), pstruct(nullpstruct) { pstruct.prop=p; };
-	inline gld_property(OBJECT *o, PROPERTYSTRUCT *p) : obj(o), pstruct(nullpstruct) { pstruct=*p; };
-	inline gld_property(GLOBALVAR *v) : obj(NULL), pstruct(nullpstruct) { pstruct.prop=v->prop; };
-	inline gld_property(char *n) : obj(NULL), pstruct(nullpstruct)
-	{
+	inline gld_property(void) :
+			obj(NULL), pstruct(nullpstruct) {
+	}
+	;
+	inline gld_property(gld_object *o, char *n) :
+			obj(o->my()), pstruct(nullpstruct) {
+		if (o)
+			callback->properties.get_property(o->my(), n, &pstruct);
+		else {
+			GLOBALVAR *v = callback->global.find(n);
+			pstruct.prop = (v ? v->prop : NULL);
+		}
+	}
+	;
+	inline gld_property(OBJECT *o, char *n) :
+			obj(o), pstruct(nullpstruct) {
+		if (o)
+			callback->properties.get_property(o, n, &pstruct);
+		else {
+			GLOBALVAR *v = callback->global.find(n);
+			pstruct.prop = (v ? v->prop : NULL);
+		}
+	}
+	;
+	inline gld_property(OBJECT *o) :
+			obj(o), pstruct(nullpstruct) {
+		pstruct.prop = o->oclass->pmap;
+	}
+	;
+	inline gld_property(OBJECT *o, PROPERTY *p) :
+			obj(o), pstruct(nullpstruct) {
+		pstruct.prop = p;
+	}
+	;
+	inline gld_property(OBJECT *o, PROPERTYSTRUCT *p) :
+			obj(o), pstruct(nullpstruct) {
+		pstruct = *p;
+	}
+	;
+	inline gld_property(GLOBALVAR *v) :
+			obj(NULL), pstruct(nullpstruct) {
+		pstruct.prop = v->prop;
+	}
+	;
+	inline gld_property(char *n) :
+			obj(NULL), pstruct(nullpstruct) {
 		char oname[256], vname[256];
-		if ( sscanf(n,"%[A-Za-z0-9_].%[A-Za-z0-9_.]",oname,vname)==2 )
-		{
+		if (sscanf(n, "%[A-Za-z0-9_].%[A-Za-z0-9_.]", oname, vname) == 2) {
 			obj = callback->get_object(oname);
-			if ( obj )
-			{
-				callback->properties.get_property(obj,vname,&pstruct);
+			if (obj) {
+				callback->properties.get_property(obj, vname, &pstruct);
 				return;
 			}
 		}
-		GLOBALVAR *v=callback->global.find(n); 
-		pstruct.prop = (v?v->prop:NULL);  
-	};
-	inline gld_property(char *m, char *n) : obj(NULL), pstruct(nullpstruct) 
-	{
+		GLOBALVAR *v = callback->global.find(n);
+		pstruct.prop = (v ? v->prop : NULL);
+	}
+	;
+	inline gld_property(char *m, char *n) :
+			obj(NULL), pstruct(nullpstruct) {
 		obj = callback->get_object(m);
-		if ( obj != NULL ) {
+		if (obj != NULL) {
 			callback->properties.get_property(obj, n, &pstruct);
 			return;
-		} 
-		char1024 vn; 
-		sprintf(vn,"%s::%s",m,n); 
-		GLOBALVAR *v=callback->global.find(vn); 
-		pstruct.prop= (v?v->prop:NULL);  
-	};
-	inline operator PROPERTY*(void) { return pstruct.prop; };
-	inline operator OBJECT*(void) { return obj; };
+		}
+		char1024 vn;
+		sprintf(vn, "%s::%s", m, n);
+		GLOBALVAR *v = callback->global.find(vn);
+		pstruct.prop = (v ? v->prop : NULL);
+	}
+	;
+	inline operator PROPERTY*(void) {
+		return pstruct.prop;
+	}
+	;
+	inline operator OBJECT*(void) {
+		return obj;
+	}
+	;
 
 public: // read accessors
-	inline OBJECT *get_object(void) { return obj; };
-	inline PROPERTY *get_property(void) { return pstruct.prop; };
-	inline PROPERTYSTRUCT *get_property_struct(void) { return &pstruct; };
-	inline gld_class* get_class(void) { return (gld_class*)pstruct.prop->oclass; };
-	inline char *get_name(void) { return pstruct.prop->name; };
-	inline char *get_sql_safe_name(char* return_val) {
+	inline OBJECT* get_object(void) {
+		return obj;
+	}
+	;
+	inline PROPERTY* get_property(void) {
+		return pstruct.prop;
+	}
+	;
+	inline PROPERTYSTRUCT* get_property_struct(void) {
+		return &pstruct;
+	}
+	;
+	inline gld_class* get_class(void) {
+		return (gld_class*) pstruct.prop->oclass;
+	}
+	;
+	inline char* get_name(void) {
+		return pstruct.prop->name;
+	}
+	;
+	inline char* get_sql_safe_name(char *return_val) {
 		if (pstruct.part[0] != '\0') {
 			sprintf(return_val, "%s_%s", pstruct.prop->name, pstruct.part);
 		} else {
 			sprintf(return_val, "%s", pstruct.prop->name);
 		}
 		return return_val;
-	};
-	inline gld_type get_type(void) { return gld_type(pstruct.prop->ptype); };
-	inline size_t get_size(void) { return (size_t)(pstruct.prop->size); };
-	inline size_t get_width(void) { return (size_t)(pstruct.prop->width); };
-	inline PROPERTYACCESS get_access(void) { return pstruct.prop->access; };
-	inline bool get_access(unsigned int bits, unsigned int mask=0xffff) {  return ((pstruct.prop->access&mask)|bits); };
-	inline gld_unit* get_unit(void) { return (gld_unit*)pstruct.prop->unit; };
-	inline void* get_addr(void) { return obj?((void*)((char*)(obj+1)+(unsigned int64)(pstruct.prop->addr))):pstruct.prop->addr; };
-	inline gld_keyword* get_first_keyword(void) { return (gld_keyword*)pstruct.prop->keywords; };
-	inline char* get_description(void) { return pstruct.prop->description; };
-	inline PROPERTYFLAGS get_flags(void) { return pstruct.prop->flags; };
-	inline int to_string(char *buffer, int size) { return callback->convert.property_to_string(pstruct.prop,get_addr(),buffer,size); };
-	inline gld_string get_string(const size_t sz=1024)
-	{
-		gld_string res;
-		char buf[1024];
-		if ( sizeof(buf)<sz ) throw "get_string() over size limit";
-		if ( to_string(buf,(int)sz)>=0 )
-			res = buf;
-		return res;
-	};
-	inline int from_string(char *string) { return callback->convert.string_to_property(pstruct.prop,get_addr(),string); };
-	inline char *get_partname(void) { return pstruct.part; };
-	inline double get_part(char *part=NULL) { return callback->properties.get_part(obj,pstruct.prop,part?part:pstruct.part); };
+	}
+	;
+	inline gld_type get_type(void) {
+		return gld_type(pstruct.prop->ptype);
+	}
+	;
+	inline size_t get_size(void) {
+		return (size_t)(pstruct.prop->size);
+	}
+	;
+	inline size_t get_width(void) {
+		return (size_t)(pstruct.prop->width);
+	}
+	;
+	inline PROPERTYACCESS get_access(void) {
+		return pstruct.prop->access;
+	}
+	;
+	inline bool get_access(unsigned int bits, unsigned int mask = 0xffff) {
+		return ((pstruct.prop->access & mask) | bits);
+	}
+	;
+	inline gld_unit* get_unit(void) {
+		return (gld_unit*) pstruct.prop->unit;
+	}
+	;
+	inline void* get_addr(void) {
+	return obj?((void*)((char*)(obj+1)+(unsigned int64)(pstruct.prop->addr))):pstruct.prop->addr;}
+;
+inline gld_keyword* get_first_keyword(void) {
+	return (gld_keyword*) pstruct.prop->keywords;
+}
+;
+inline char* get_description(void) {
+	return pstruct.prop->description;
+}
+;
+inline PROPERTYFLAGS get_flags(void) {
+	return pstruct.prop->flags;
+}
+;
+inline int to_string(char *buffer, int size) {
+	return callback->convert.property_to_string(pstruct.prop, get_addr(),
+			buffer, size);
+}
+;
+inline gld_string get_string(const size_t sz = 1024) {
+	gld_string res;
+	char buf[1024];
+	if (sizeof(buf) < sz)
+		throw "get_string() over size limit";
+	if (to_string(buf, (int) sz) >= 0)
+		res = buf;
+	return res;
+}
+;
+inline int from_string(char *string) {
+	return callback->convert.string_to_property(pstruct.prop, get_addr(),
+			string);
+}
+;
+inline char* get_partname(void) {
+	return pstruct.part;
+}
+;
+inline double get_part(char *part = NULL) {
+	return callback->properties.get_part(obj, pstruct.prop,
+			part ? part : pstruct.part);
+}
+;
 
 public: // write accessors
-	inline void set_object(OBJECT *o) { obj=o; };
-	inline void set_object(gld_object *o) { obj=o->my(); };
-	inline void set_property(char *n) { callback->properties.get_property(obj,n,&pstruct); };
-	inline void set_property(PROPERTY *p) { pstruct.prop=p; };
+inline void set_object(OBJECT *o) {
+	obj = o;
+}
+;
+inline void set_object(gld_object *o) {
+	obj = o->my();
+}
+;
+inline void set_property(char *n) {
+	callback->properties.get_property(obj, n, &pstruct);
+}
+;
+inline void set_property(PROPERTY *p) {
+	pstruct.prop = p;
+}
+;
 
 public: // special operations
-	inline bool is_valid(void) { return pstruct.prop!=NULL; }
-	inline bool has_part(void) { return pstruct.part[0]!='\0'; };
-	inline bool is_complex(void) { if(pstruct.prop->ptype == PT_complex) return true; return false;}
-	inline bool is_double(void) { switch(pstruct.prop->ptype) { case PT_double: case PT_random: case PT_enduse: case PT_loadshape: return true; default: return false;} };
-	inline bool is_integer(void) { switch(pstruct.prop->ptype) { case PT_int16: case PT_int32: case PT_int64: return true; default: return false;} };
-	inline bool is_enumeration(void) { return pstruct.prop->ptype==PT_enumeration; };
-	inline bool is_set(void) { return pstruct.prop->ptype==PT_set; };
-	inline bool is_character(void) { switch(pstruct.prop->ptype) { case PT_char8: case PT_char32: case PT_char256: case PT_char1024: return true; default: return false;} };
-	inline bool is_random(void) { return pstruct.prop->ptype==PT_random; };
-	inline bool is_enduse(void) { return pstruct.prop->ptype==PT_enduse; };
-	inline bool is_loadshape(void) { return pstruct.prop->ptype==PT_loadshape; };
-	inline bool is_double_array(void) { return pstruct.prop->ptype==PT_double_array; };
-	inline bool is_complex_array(void) { return pstruct.prop->ptype==PT_complex_array; };
-	inline bool is_objectref(void) { return pstruct.prop->ptype==PT_object; };
-	inline bool is_bool(void) { return pstruct.prop->ptype==PT_bool; };
-	inline bool is_timestamp(void) { return pstruct.prop->ptype==PT_timestamp; };
+inline bool is_valid(void) {
+	return pstruct.prop != NULL;
+}
+inline bool has_part(void) {
+	return pstruct.part[0] != '\0';
+}
+;
+inline bool is_complex(void) {
+	if (pstruct.prop->ptype == PT_complex)
+		return true;
+	return false;
+}
+inline bool is_double(void) {
+	switch (pstruct.prop->ptype) {
+	case PT_double:
+	case PT_random:
+	case PT_enduse:
+	case PT_loadshape:
+		return true;
+	default:
+		return false;
+	}
+}
+;
+inline bool is_integer(void) {
+	switch (pstruct.prop->ptype) {
+	case PT_int16:
+	case PT_int32:
+	case PT_int64:
+		return true;
+	default:
+		return false;
+	}
+}
+;
+inline bool is_enumeration(void) {
+	return pstruct.prop->ptype == PT_enumeration;
+}
+;
+inline bool is_set(void) {
+	return pstruct.prop->ptype == PT_set;
+}
+;
+inline bool is_character(void) {
+	switch (pstruct.prop->ptype) {
+	case PT_char8:
+	case PT_char32:
+	case PT_char256:
+	case PT_char1024:
+		return true;
+	default:
+		return false;
+	}
+}
+;
+inline bool is_random(void) {
+	return pstruct.prop->ptype == PT_random;
+}
+;
+inline bool is_enduse(void) {
+	return pstruct.prop->ptype == PT_enduse;
+}
+;
+inline bool is_loadshape(void) {
+	return pstruct.prop->ptype == PT_loadshape;
+}
+;
+inline bool is_double_array(void) {
+	return pstruct.prop->ptype == PT_double_array;
+}
+;
+inline bool is_complex_array(void) {
+	return pstruct.prop->ptype == PT_complex_array;
+}
+;
+inline bool is_objectref(void) {
+	return pstruct.prop->ptype == PT_object;
+}
+;
+inline bool is_bool(void) {
+	return pstruct.prop->ptype == PT_bool;
+}
+;
+inline bool is_timestamp(void) {
+	return pstruct.prop->ptype == PT_timestamp;
+}
+;
 
-	// TODO these need to use throw instead of returning overloaded values
-	inline double get_double(void) { errno=0; switch(pstruct.prop->ptype) { case PT_double: case PT_random: case PT_enduse: case PT_loadshape: return has_part() ? get_part() : *(double*)get_addr(); default: errno=EINVAL; return NaN;} };
-	inline double get_double(UNIT*to) { double rv = get_double(); return get_unit()->convert(to,rv) ? rv : QNAN; };
-	inline double get_double(gld_unit&to) { double rv = get_double(); return get_unit()->convert(to,rv) ? rv : QNAN; };
-	inline double get_double(char*to) { double rv = get_double(); return get_unit()->convert(to,rv) ? rv : QNAN; };
-	inline complex get_complex(void) { errno=0; if ( pstruct.prop->ptype==PT_complex ) return *(complex*)get_addr(); else return complex(QNAN,QNAN); };
-	inline int64 get_integer(void) { errno=0; switch(pstruct.prop->ptype) { case PT_int16: return (int64)*(int16*)get_addr(); case PT_int32: return (int64)*(int32*)get_addr(); case PT_int64: return *(int64*)get_addr(); default: errno=EINVAL; return 0;} };
+// TODO these need to use throw instead of returning overloaded values
+inline double get_double(void) {
+	errno = 0;
+	switch (pstruct.prop->ptype) {
+	case PT_double:
+	case PT_random:
+	case PT_enduse:
+	case PT_loadshape:
+		return has_part() ? get_part() : *(double*) get_addr();
+	default:
+		errno = EINVAL;
+		return NaN;
+	}
+}
+;
+inline double get_double(UNIT *to) {
+	double rv = get_double();
+	return get_unit()->convert(to, rv) ? rv : QNAN;
+}
+;
+inline double get_double(gld_unit &to) {
+	double rv = get_double();
+	return get_unit()->convert(to, rv) ? rv : QNAN;
+}
+;
+inline double get_double(char *to) {
+	double rv = get_double();
+	return get_unit()->convert(to, rv) ? rv : QNAN;
+}
+;
+inline complex get_complex(void) {
+	errno = 0;
+	if (pstruct.prop->ptype == PT_complex)
+		return *(complex*) get_addr();
+	else
+		return complex(QNAN, QNAN);
+}
+;
+inline int64 get_integer(void) {
+	errno = 0;
+	switch (pstruct.prop->ptype) {
+	case PT_int16:
+		return (int64) * (int16*) get_addr();
+	case PT_int32:
+		return (int64) * (int32*) get_addr();
+	case PT_int64:
+		return *(int64*) get_addr();
+	default:
+		errno = EINVAL;
+		return 0;
+	}
+}
+;
 //	inline TIMESTAMP get_timestamp(void) { if (pstruct.prop->ptype == PT_timestamp) return *(TIMESTAMP*)get_addr(); exception("get_timestamp() called on a property that is not a timestamp"); };
-	inline TIMESTAMP get_timestamp(void) { if (pstruct.prop->ptype != PT_timestamp) exception("get_timestamp() called on a property that is not a timestamp");return *(TIMESTAMP*) get_addr();};
+inline TIMESTAMP get_timestamp(void) {
+	if (pstruct.prop->ptype != PT_timestamp)
+		exception(
+				"get_timestamp() called on a property that is not a timestamp");
+	return *(TIMESTAMP*) get_addr();
+}
+;
 //	inline enumeration get_enumeration(void) { if ( pstruct.prop->ptype == PT_enumeration ) return *(enumeration*)get_addr(); exception("get_enumeration() called on a property that is not an enumeration"); };
-	inline enumeration get_enumeration(void) { if ( pstruct.prop->ptype != PT_enumeration ) exception("get_enumeration() called on a property that is not an enumeration"); return *(enumeration*)get_addr(); };
+inline enumeration get_enumeration(void) {
+	if (pstruct.prop->ptype != PT_enumeration)
+		exception(
+				"get_enumeration() called on a property that is not an enumeration");
+	return *(enumeration*) get_addr();
+}
+;
 //	inline set get_set(void) { if ( pstruct.prop->ptype == PT_set ) return *(set*)get_addr(); exception("get_set() called on a property that is not a set"); };
-	inline set get_set(void) { if ( pstruct.prop->ptype != PT_set ) exception("get_set() called on a property that is not a set"); return *(set*)get_addr(); };
-	inline gld_object* get_objectref(void) { if ( is_objectref() ) return ::get_object(*(OBJECT**)get_addr()); else return NULL; };
-	template <class T> inline void getp(T &value) { ::rlock(&obj->lock); value = *(T*)get_addr(); ::runlock(&obj->lock); };
-	template <class T> inline void setp(T &value) { ::wlock(&obj->lock); *(T*)get_addr()=value; ::wunlock(&obj->lock); };
-	template <class T> inline void getp(T &value, gld_rlock&) { value = *(T*)get_addr(); };
-	template <class T> inline void getp(T &value, gld_wlock&) { value = *(T*)get_addr(); };
-	template <class T> inline void setp(T &value, gld_wlock&) { *(T*)get_addr()=value; };
-	inline void setp(enumeration value) { ::wlock(&obj->lock); *(enumeration*)get_addr()=value; ::wunlock(&obj->lock); };
-	inline void setp(set value) { ::wlock(&obj->lock); *(set*)get_addr()=value; ::wunlock(&obj->lock); };
-	inline gld_keyword* find_keyword(unsigned long value) { return get_first_keyword()->find(value); };
-	inline gld_keyword* find_keyword(const char *name) { return get_first_keyword()->find(name); };
-	inline bool compare(char *op, char *a, char *b=NULL, char *p=NULL) 
-	{ 
-		PROPERTYCOMPAREOP n = callback->properties.get_compare_op(pstruct.prop->ptype,op); 
-		if (n==TCOP_ERR) throw "invalid property compare operation"; 
-		return compare((enumeration)n,a,b,p); 
-	};
-	inline bool compare(enumeration op, char *a, char *b=NULL) 
-	{ 
-		char v1[1024], v2[1024]; 
-		return callback->convert.string_to_property(pstruct.prop,(void*)v1,a)>0 && callback->properties.compare_basic(pstruct.prop->ptype,(PROPERTYCOMPAREOP)op,get_addr(),(void*)v1,(b&&callback->convert.string_to_property(pstruct.prop,(void*)v2,b)>0)?(void*)v2:NULL, NULL);
-	};
-	inline bool compare(enumeration op, char *a, char *b, char *p) 
-	{
-		double v1, v2; v1=atof(a); v2=b?atof(b):0;
-		return callback->properties.compare_basic(pstruct.prop->ptype,(PROPERTYCOMPAREOP)op,get_addr(),(void*)&v1,b?(void*)&v2:NULL, p);
-	};
-	inline bool compare(enumeration op, double *a, double *b=NULL, char *p=NULL) 
-	{ 
-		return callback->properties.compare_basic(pstruct.prop->ptype,(PROPERTYCOMPAREOP)op,get_addr(),a,b,p);
-	};
-	inline bool compare(enumeration op, void *a, void *b=NULL) 
-	{ 
-		return callback->properties.compare_basic(pstruct.prop->ptype,(PROPERTYCOMPAREOP)op,get_addr(),a,b,NULL);
-	};
+inline set get_set(void) {
+	if (pstruct.prop->ptype != PT_set)
+		exception("get_set() called on a property that is not a set");
+	return *(set*) get_addr();
+}
+;
+inline gld_object* get_objectref(void) {
+	if (is_objectref())
+		return ::get_object(*(OBJECT**) get_addr());
+	else
+		return NULL;
+}
+;
+template<class T> inline void getp(T &value) {
+	::rlock(&obj->lock);
+	value = *(T*) get_addr();
+	::runlock(&obj->lock);
+}
+;
+template<class T> inline void setp(T &value) {
+	::wlock(&obj->lock);
+	*(T*) get_addr() = value;
+	::wunlock(&obj->lock);
+}
+;
+template<class T> inline void getp(T &value, gld_rlock&) {
+	value = *(T*) get_addr();
+}
+;
+template<class T> inline void getp(T &value, gld_wlock&) {
+	value = *(T*) get_addr();
+}
+;
+template<class T> inline void setp(T &value, gld_wlock&) {
+	*(T*) get_addr() = value;
+}
+;
+inline void setp(enumeration value) {
+	::wlock(&obj->lock);
+	*(enumeration*) get_addr() = value;
+	::wunlock(&obj->lock);
+}
+;
+inline void setp(set value) {
+	::wlock(&obj->lock);
+	*(set*) get_addr() = value;
+	::wunlock(&obj->lock);
+}
+;
+inline gld_keyword* find_keyword(unsigned long value) {
+	return get_first_keyword()->find(value);
+}
+;
+inline gld_keyword* find_keyword(const char *name) {
+	return get_first_keyword()->find(name);
+}
+;
+inline bool compare(char *op, char *a, char *b = NULL, char *p = NULL) {
+	PROPERTYCOMPAREOP n = callback->properties.get_compare_op(
+			pstruct.prop->ptype, op);
+	if (n == TCOP_ERR)
+		throw "invalid property compare operation";
+	return compare((enumeration) n, a, b, p);
+}
+;
+inline bool compare(enumeration op, char *a, char *b = NULL) {
+	char v1[1024], v2[1024];
+	return callback->convert.string_to_property(pstruct.prop, (void*) v1, a) > 0
+			&& callback->properties.compare_basic(pstruct.prop->ptype,
+					(PROPERTYCOMPAREOP) op, get_addr(), (void*) v1,
+					(b
+							&& callback->convert.string_to_property(
+									pstruct.prop, (void*) v2, b) > 0) ?
+							(void*) v2 : NULL, NULL);
+}
+;
+inline bool compare(enumeration op, char *a, char *b, char *p) {
+	double v1, v2;
+	v1 = atof(a);
+	v2 = b ? atof(b) : 0;
+	return callback->properties.compare_basic(pstruct.prop->ptype,
+			(PROPERTYCOMPAREOP) op, get_addr(), (void*) &v1,
+			b ? (void*) &v2 : NULL, p);
+}
+;
+inline bool compare(enumeration op, double *a, double *b = NULL,
+		char *p = NULL) {
+	return callback->properties.compare_basic(pstruct.prop->ptype,
+			(PROPERTYCOMPAREOP) op, get_addr(), a, b, p);
+}
+;
+inline bool compare(enumeration op, void *a, void *b = NULL) {
+	return callback->properties.compare_basic(pstruct.prop->ptype,
+			(PROPERTYCOMPAREOP) op, get_addr(), a, b, NULL);
+}
+;
 
 public: // iterators
-	inline bool is_last(void) { return pstruct.prop==NULL || pstruct.prop->next==NULL || pstruct.prop->oclass!=pstruct.prop->next->oclass; };
-	inline PROPERTY* get_next(void) { return is_last() ? NULL : pstruct.prop->next; };
+inline bool is_last(void) {
+	return pstruct.prop == NULL || pstruct.prop->next == NULL
+			|| pstruct.prop->oclass != pstruct.prop->next->oclass;
+}
+;
+inline PROPERTY* get_next(void) {
+	return is_last() ? NULL : pstruct.prop->next;
+}
+;
 
 public: // comparators
-	inline bool operator == (char* a) { return compare(TCOP_EQ,a,NULL); };
-	inline bool operator <= (char* a) { return compare(TCOP_LE,a,NULL); };
-	inline bool operator >= (char* a) { return compare(TCOP_GE,a,NULL); };
-	inline bool operator != (char* a) { return compare(TCOP_NE,a,NULL); };
-	inline bool operator < (char* a) { return compare(TCOP_LT,a,NULL); };
-	inline bool operator > (char* a) { return compare(TCOP_GT,a,NULL); };
-	inline bool inside(char* a, char* b) { return compare(TCOP_IN,a,b); };
-	inline bool outside(char* a, char* b) { return compare(TCOP_NI,a,b); };
+inline bool operator ==(char *a) {
+	return compare(TCOP_EQ, a, NULL);
+}
+;
+inline bool operator <=(char *a) {
+	return compare(TCOP_LE, a, NULL);
+}
+;
+inline bool operator >=(char *a) {
+	return compare(TCOP_GE, a, NULL);
+}
+;
+inline bool operator !=(char *a) {
+	return compare(TCOP_NE, a, NULL);
+}
+;
+inline bool operator <(char *a) {
+	return compare(TCOP_LT, a, NULL);
+}
+;
+inline bool operator >(char *a) {
+	return compare(TCOP_GT, a, NULL);
+}
+;
+inline bool inside(char *a, char *b) {
+	return compare(TCOP_IN, a, b);
+}
+;
+inline bool outside(char *a, char *b) {
+	return compare(TCOP_NI, a, b);
+}
+;
 
 private: // exceptions
-	inline void exception(const char *msg, ...)
-	{ 
-		static char buf[1024]; 
-		va_list ptr; 
-		va_start(ptr,msg); 
-		vsprintf(buf+sprintf(buf,"%s.%s: ",OBJECTDATA(obj,gld_object)->get_name(),pstruct.prop->name),msg,ptr); 
-		va_end(ptr); 
-		throw (const char*)buf;
-	};
+inline void exception(const char *msg, ...) {
+	static char buf[1024];
+	va_list ptr;
+	va_start(ptr, msg);
+	vsprintf(
+			buf
+					+ sprintf(buf, "%s.%s: ",
+							OBJECTDATA(obj, gld_object)->get_name(),
+							pstruct.prop->name), msg, ptr);
+	va_end(ptr);
+	throw(const char*) buf;
+}
+;
 };
 
 /// Global variable container
@@ -2201,46 +3416,131 @@ private: // data
 	GLOBALVAR *var;
 
 public: // constructors
-	inline gld_global(void) { var=callback->global.find(NULL); };
-	inline gld_global(GLOBALVAR *v) : var(v) {};
-	inline gld_global(char *n) { var=callback->global.find(n); };
-	inline gld_global(char *n, PROPERTYTYPE t, void *p) { var=callback->global.create(n,t,p,NULL); };
+	inline gld_global(void) {
+		var = callback->global.find(NULL);
+	}
+	;
+	inline gld_global(GLOBALVAR *v) :
+			var(v) {
+	}
+	;
+	inline gld_global(char *n) {
+		var = callback->global.find(n);
+	}
+	;
+	inline gld_global(char *n, PROPERTYTYPE t, void *p) {
+		var = callback->global.create(n, t, p, NULL);
+	}
+	;
 
 public: // read accessors
-	inline operator GLOBALVAR*(void) { return var; };
-	inline bool is_valid(void) { return var!=NULL; };
-	inline PROPERTY* get_property(void) { if (!var) return NULL; return var->prop; };
-	inline unsigned long get_flags(void) { if (!var) return -1; return var->flags; };
-	inline size_t to_string(char *bp, size_t sz) { if (!var) return -1; gld_property p(var); return p.to_string(bp,(int)sz); };
-	inline gld_string get_string(const size_t sz=1024)
-	{
+	inline operator GLOBALVAR*(void) {
+		return var;
+	}
+	;
+	inline bool is_valid(void) {
+		return var != NULL;
+	}
+	;
+	inline PROPERTY* get_property(void) {
+		if (!var)
+			return NULL;
+		return var->prop;
+	}
+	;
+	inline unsigned long get_flags(void) {
+		if (!var)
+			return -1;
+		return var->flags;
+	}
+	;
+	inline size_t to_string(char *bp, size_t sz) {
+		if (!var)
+			return -1;
+		gld_property p(var);
+		return p.to_string(bp, (int) sz);
+	}
+	;
+	inline gld_string get_string(const size_t sz = 1024) {
 		gld_string res;
 		char buf[1024];
-		if ( sizeof(buf)<sz ) throw "get_string() over size limit";
-		if ( to_string(buf,(int)sz)>=0 )
+		if (sizeof(buf) < sz)
+			throw "get_string() over size limit";
+		if (to_string(buf, (int) sz) >= 0)
 			res = buf;
 		return res;
-	};
-	inline bool get_bool(void) { return *(bool*)(var->prop->addr); };
-	inline int16 get_int16(void) { return *(int16*)(var->prop->addr); };
-	inline int32 get_int32(void) { return *(int32*)(var->prop->addr); };
-	inline int64 get_int64(void) { return *(int64*)(var->prop->addr); };
-	inline double get_double(void) { return *(double*)(var->prop->addr); };
-	inline complex get_complex(void) { return *(complex*)(var->prop->addr); };
-	inline TIMESTAMP get_timestamp(void) { return *(TIMESTAMP*)(var->prop->addr); };
+	}
+	;
+	inline bool get_bool(void) {
+		return *(bool*) (var->prop->addr);
+	}
+	;
+	inline int16 get_int16(void) {
+		return *(int16*) (var->prop->addr);
+	}
+	;
+	inline int32 get_int32(void) {
+		return *(int32*) (var->prop->addr);
+	}
+	;
+	inline int64 get_int64(void) {
+		return *(int64*) (var->prop->addr);
+	}
+	;
+	inline double get_double(void) {
+		return *(double*) (var->prop->addr);
+	}
+	;
+	inline complex get_complex(void) {
+		return *(complex*) (var->prop->addr);
+	}
+	;
+	inline TIMESTAMP get_timestamp(void) {
+		return *(TIMESTAMP*) (var->prop->addr);
+	}
+	;
 
 public: // write accessors
-	inline size_t from_string(char *bp) { if (!var) return -1; gld_property p(var); return p.from_string(bp); };
-	inline bool get(char *n) { var=callback->global.find(n); return var!=NULL; };
-	inline bool create(char *n, PROPERTYTYPE t, void *p) { var=callback->global.create(n,t,p,NULL); return var!=NULL; };
+	inline size_t from_string(char *bp) {
+		if (!var)
+			return -1;
+		gld_property p(var);
+		return p.from_string(bp);
+	}
+	;
+	inline bool get(char *n) {
+		var = callback->global.find(n);
+		return var != NULL;
+	}
+	;
+	inline bool create(char *n, PROPERTYTYPE t, void *p) {
+		var = callback->global.create(n, t, p, NULL);
+		return var != NULL;
+	}
+	;
 
 public: // external accessors
 	// TODO
 
 public: // iterators
-	inline GLOBALVAR* get_first(void) { return callback->global.find(NULL); };
-	inline bool is_last(void) { if (!var) return false; else return (var->next==NULL); };
-	inline GLOBALVAR* get_next(void) { if (!var) return NULL; else return var->next; };
+	inline GLOBALVAR* get_first(void) {
+		return callback->global.find(NULL);
+	}
+	;
+	inline bool is_last(void) {
+		if (!var)
+			return false;
+		else
+			return (var->next == NULL);
+	}
+	;
+	inline GLOBALVAR* get_next(void) {
+		if (!var)
+			return NULL;
+		else
+			return var->next;
+	}
+	;
 };
 
 /// Aggregation container
@@ -2248,12 +3548,30 @@ class gld_aggregate {
 private:
 	AGGREGATION *aggr;
 public:
-	inline gld_aggregate(void) { aggr=NULL; };
-	inline gld_aggregate(char *spec, char *group) { set_aggregate(spec,group); };
+	inline gld_aggregate(void) {
+		aggr = NULL;
+	}
+	;
+	inline gld_aggregate(char *spec, char *group) {
+		set_aggregate(spec, group);
+	}
+	;
 public:
-	inline bool set_aggregate(char *spec, char *group) { aggr=callback->aggregate.create(spec,group); return aggr!=NULL; };
-	inline bool is_valid(void) { return aggr!=NULL; };
-	inline double get_value(void) { if (!aggr) throw "null aggregate"; return callback->aggregate.refresh(aggr); };
+	inline bool set_aggregate(char *spec, char *group) {
+		aggr = callback->aggregate.create(spec, group);
+		return aggr != NULL;
+	}
+	;
+	inline bool is_valid(void) {
+		return aggr != NULL;
+	}
+	;
+	inline double get_value(void) {
+		if (!aggr)
+			throw "null aggregate";
+		return callback->aggregate.refresh(aggr);
+	}
+	;
 };
 
 /// Object list container
@@ -2261,40 +3579,106 @@ class gld_objlist {
 private:
 	struct s_objlist *list;
 public:
-	inline operator OBJLIST*() { return list; };
+	inline operator OBJLIST*() {
+		return list;
+	}
+	;
 public:
-	inline gld_objlist(void) : list(NULL) {};
-	inline gld_objlist(char *group) { list=callback->objlist.search(group); };
-	inline gld_objlist(CLASS *c, PROPERTY *m, char *p, char *o, void *a, void *b=NULL) { list=callback->objlist.create(c,m,p,o,a,b); };
-	inline gld_objlist(char *cn, char *mn, char *p, char *o, void *a, void *b=NULL) 
-	{ 
-		CLASS *c=callback->class_getname(cn); if (!c) exception("gld_objlist(): class '%s' is not found",cn); 
-		PROPERTY *m=callback->find_property(c,mn); if (!m) exception("gld_objlist(): property '%s' is not found in class '%s'",mn,cn);
-		list=callback->objlist.create(c,m,p,o,a,b); 
-	};
-	inline ~gld_objlist(void) { callback->objlist.destroy(list); };
+	inline gld_objlist(void) :
+			list(NULL) {
+	}
+	;
+	inline gld_objlist(char *group) {
+		list = callback->objlist.search(group);
+	}
+	;
+	inline gld_objlist(CLASS *c, PROPERTY *m, char *p, char *o, void *a,
+			void *b = NULL) {
+		list = callback->objlist.create(c, m, p, o, a, b);
+	}
+	;
+	inline gld_objlist(char *cn, char *mn, char *p, char *o, void *a, void *b =
+			NULL) {
+		CLASS *c = callback->class_getname(cn);
+		if (!c)
+			exception("gld_objlist(): class '%s' is not found", cn);
+		PROPERTY *m = callback->find_property(c, mn);
+		if (!m)
+			exception("gld_objlist(): property '%s' is not found in class '%s'",
+					mn, cn);
+		list = callback->objlist.create(c, m, p, o, a, b);
+	}
+	;
+	inline ~gld_objlist(void) {
+		callback->objlist.destroy(list);
+	}
+	;
 public:
-	inline size_t set(char *group) { if ( list ) callback->objlist.destroy(list); list=callback->objlist.search(group); return list?list->size:-1; };
-	inline size_t add(PROPERTY *m, char *p, char *o, void *a, void *b=NULL) { return callback->objlist.add(list,m,p,o,a,b); };
-	inline size_t del(PROPERTY *m, char *p, char *o, void *a, void *b=NULL) { return callback->objlist.add(list,m,p,o,a,b); };
-	inline size_t add(char *cn, char *mn, char *p, char *o, void *a, void *b=NULL) 
-	{
-		CLASS *c=callback->class_getname(cn); if (!c) exception("gld_objlist(): class '%s' is not found",cn); 
-		PROPERTY *m=callback->find_property(c,mn); if (!m) exception("gld_objlist(): property '%s' is not found in class '%s'",mn,cn);
-		return callback->objlist.add(list,m,p,o,a,b); 
-	};
-	inline size_t del(char *cn, char *mn, char *p, char *o, void *a, void *b=NULL) 
-	{ 
-		CLASS *c=callback->class_getname(cn); if (!c) exception("gld_objlist(): class '%s' is not found",cn); 
-		PROPERTY *m=callback->find_property(c,mn); if (!m) exception("gld_objlist(): property '%s' is not found in class '%s'",mn,cn);
-		return callback->objlist.add(list,m,p,o,a,b); 
-	};
+	inline size_t set(char *group) {
+		if (list)
+			callback->objlist.destroy(list);
+		list = callback->objlist.search(group);
+		return list ? list->size : -1;
+	}
+	;
+	inline size_t add(PROPERTY *m, char *p, char *o, void *a, void *b = NULL) {
+		return callback->objlist.add(list, m, p, o, a, b);
+	}
+	;
+	inline size_t del(PROPERTY *m, char *p, char *o, void *a, void *b = NULL) {
+		return callback->objlist.add(list, m, p, o, a, b);
+	}
+	;
+	inline size_t add(char *cn, char *mn, char *p, char *o, void *a, void *b =
+			NULL) {
+		CLASS *c = callback->class_getname(cn);
+		if (!c)
+			exception("gld_objlist(): class '%s' is not found", cn);
+		PROPERTY *m = callback->find_property(c, mn);
+		if (!m)
+			exception("gld_objlist(): property '%s' is not found in class '%s'",
+					mn, cn);
+		return callback->objlist.add(list, m, p, o, a, b);
+	}
+	;
+	inline size_t del(char *cn, char *mn, char *p, char *o, void *a, void *b =
+			NULL) {
+		CLASS *c = callback->class_getname(cn);
+		if (!c)
+			exception("gld_objlist(): class '%s' is not found", cn);
+		PROPERTY *m = callback->find_property(c, mn);
+		if (!m)
+			exception("gld_objlist(): property '%s' is not found in class '%s'",
+					mn, cn);
+		return callback->objlist.add(list, m, p, o, a, b);
+	}
+	;
 public:
-	inline bool is_valid(void) { return list!=NULL; };
-	inline size_t get_size(void) { return list->size; };
-	inline OBJECT *get(size_t n) { return list->objlist[n]; };
-	inline int apply(void *arg, int (*function)(OBJECT *,void*,int)) { return callback->objlist.apply(list,arg,function);};
-	inline void exception(const char *msg, ...) { static char buf[1024]; va_list ptr; va_start(ptr,msg); vsprintf(buf,msg,ptr); va_end(ptr); throw (const char*)buf;};
+	inline bool is_valid(void) {
+		return list != NULL;
+	}
+	;
+	inline size_t get_size(void) {
+		return list->size;
+	}
+	;
+	inline OBJECT* get(size_t n) {
+		return list->objlist[n];
+	}
+	;
+	inline int apply(void *arg, int (*function)(OBJECT*, void*, int)) {
+		return callback->objlist.apply(list, arg, function);
+	}
+	;
+	inline void exception(const char *msg, ...) {
+		static char buf[1024];
+		va_list ptr;
+		va_start(ptr, msg);
+		vsprintf(buf, msg, ptr);
+		va_end(ptr);
+		throw(const char*) buf;
+	}
+	;
 };
 
 /// Web data container
@@ -2308,18 +3692,51 @@ private:
 		int status;
 	} *result;
 public:
-	inline gld_webdata(void) {result=NULL;};
-	inline gld_webdata(char *url, size_t maxlen=4096) {open(url,maxlen);};
-	inline ~gld_webdata(void) {};
+	inline gld_webdata(void) {
+		result = NULL;
+	}
+	;
+	inline gld_webdata(char *url, size_t maxlen = 4096) {
+		open(url, maxlen);
+	}
+	;
+	inline ~gld_webdata(void) {
+	}
+	;
 public:
-	inline bool open(char *url, size_t maxlen=4096) { result = (struct s_http*)callback->http.read(url,(int)maxlen); return is_valid();};
-	inline void close(void) { callback->http.free((void*)result);};
-	inline bool is_valid(void) { return result!=NULL; };
-	inline char *get_header(void) { return result->header.data;};
-	inline size_t get_header_size(void) { return result->header.size; };
-	inline char *get_body(void) { return result->body.data; };
-	inline size_t get_body_size(void) { return result->body.size; };
-	inline int get_status(void) { return result->status; };
+	inline bool open(char *url, size_t maxlen = 4096) {
+		result = (struct s_http*) callback->http.read(url, (int) maxlen);
+		return is_valid();
+	}
+	;
+	inline void close(void) {
+		callback->http.free((void*) result);
+	}
+	;
+	inline bool is_valid(void) {
+		return result != NULL;
+	}
+	;
+	inline char* get_header(void) {
+		return result->header.data;
+	}
+	;
+	inline size_t get_header_size(void) {
+		return result->header.size;
+	}
+	;
+	inline char* get_body(void) {
+		return result->body.data;
+	}
+	;
+	inline size_t get_body_size(void) {
+		return result->body.size;
+	}
+	;
+	inline int get_status(void) {
+		return result->status;
+	}
+	;
 };
 ////////////////////////////////////////////////////////////////////////////////////
 // Module-Core Linkage Export Macros
@@ -2337,7 +3754,7 @@ CDECL int gld_major=MAJOR, gld_minor=MINOR;
 CDECL int dllinit() __attribute__((constructor));
 CDECL int dllkill() __attribute__((destructor));
 CDECL int dllinit() { return 0; }
-CDECL int dllkill() { do_kill(NULL); }
+CDECL int dllkill() { return do_kill(NULL); }
 #endif // !WIN32
 #elif defined CONSOLE
 #ifdef _WIN32

--- a/gldcore/gridlabd.h
+++ b/gldcore/gridlabd.h
@@ -1888,8 +1888,9 @@ inline bool hasbits(unsigned long flags, unsigned int bits) { return (flags&bits
 class gld_object {
 public:
 	inline OBJECT *my() { return this?(((OBJECT*)this)-1):NULL; }
-public:
-	inline gld_object &operator=(gld_object&o) { exception("copy constructor is forbidden on gld_object"); };
+private:
+	// Make gld_object not copy-constructable.
+	gld_object& operator=(const gld_object&) = delete;
 
 public: // constructors
 	inline static gld_object *find_object(char *n) { OBJECT *obj = callback->get_object(n); if (obj) return (gld_object*)(obj+1); else return NULL; };
@@ -2126,9 +2127,12 @@ public: // special operations
 	inline double get_double(char*to) { double rv = get_double(); return get_unit()->convert(to,rv) ? rv : QNAN; };
 	inline complex get_complex(void) { errno=0; if ( pstruct.prop->ptype==PT_complex ) return *(complex*)get_addr(); else return complex(QNAN,QNAN); };
 	inline int64 get_integer(void) { errno=0; switch(pstruct.prop->ptype) { case PT_int16: return (int64)*(int16*)get_addr(); case PT_int32: return (int64)*(int32*)get_addr(); case PT_int64: return *(int64*)get_addr(); default: errno=EINVAL; return 0;} };
-	inline TIMESTAMP get_timestamp(void) { if (pstruct.prop->ptype == PT_timestamp) return *(TIMESTAMP*)get_addr(); exception("get_timestamp() called on a property that is not a timestamp"); };
-	inline enumeration get_enumeration(void) { if ( pstruct.prop->ptype == PT_enumeration ) return *(enumeration*)get_addr(); exception("get_enumeration() called on a property that is not an enumeration"); };
-	inline set get_set(void) { if ( pstruct.prop->ptype == PT_set ) return *(set*)get_addr(); exception("get_set() called on a property that is not a set"); };
+//	inline TIMESTAMP get_timestamp(void) { if (pstruct.prop->ptype == PT_timestamp) return *(TIMESTAMP*)get_addr(); exception("get_timestamp() called on a property that is not a timestamp"); };
+	inline TIMESTAMP get_timestamp(void) { if (pstruct.prop->ptype != PT_timestamp) exception("get_timestamp() called on a property that is not a timestamp");return *(TIMESTAMP*) get_addr();};
+//	inline enumeration get_enumeration(void) { if ( pstruct.prop->ptype == PT_enumeration ) return *(enumeration*)get_addr(); exception("get_enumeration() called on a property that is not an enumeration"); };
+	inline enumeration get_enumeration(void) { if ( pstruct.prop->ptype != PT_enumeration ) exception("get_enumeration() called on a property that is not an enumeration"); return *(enumeration*)get_addr(); };
+//	inline set get_set(void) { if ( pstruct.prop->ptype == PT_set ) return *(set*)get_addr(); exception("get_set() called on a property that is not a set"); };
+	inline set get_set(void) { if ( pstruct.prop->ptype != PT_set ) exception("get_set() called on a property that is not a set"); return *(set*)get_addr(); };
 	inline gld_object* get_objectref(void) { if ( is_objectref() ) return ::get_object(*(OBJECT**)get_addr()); else return NULL; };
 	template <class T> inline void getp(T &value) { ::rlock(&obj->lock); value = *(T*)get_addr(); ::runlock(&obj->lock); };
 	template <class T> inline void setp(T &value) { ::wlock(&obj->lock); *(T*)get_addr()=value; ::wunlock(&obj->lock); };

--- a/gldcore/gridlabd.h
+++ b/gldcore/gridlabd.h
@@ -1,51 +1,51 @@
 /** $Id: gridlabd.h 4738 2014-07-03 00:55:39Z dchassin $
- Copyright (C) 2008 Battelle Memorial Institute
- @file gridlabd.h
- @author David P. Chassin
- @addtogroup module_api C/C++ Module API
- @brief The GridLAB-D external C module header file
+	Copyright (C) 2008 Battelle Memorial Institute
+	@file gridlabd.h
+	@author David P. Chassin
+	@addtogroup module_api C/C++ Module API
+	@brief The GridLAB-D external C module header file
 
- The runtime module API links the GridLAB-D core to modules that are created to
- perform various modeling tasks.  The core interacts with each module according
- to a set script that determines which exposed module functions are called and
- when.  The general sequence of calls is as follows:
- - <b>Registration</b>: A module registers the object classes it implements and
- registers the variables that each class publishes.
- - <b>Creation</b>: The core calls object creation functions during the model
- load operation for each object that is created.  Basic initialization can be
- completed at this point.
- - <b>Definition</b>: The core sets the values of all published variables that have
- been specified in the model being loaded.  After this is completed, all references
- to other objects have been resolved.
- - <b>Validation</b>: The core gives the module an opportunity to check the model
- before initialization begins.  This gives the module an opportunity to validate
- the model and reject it or fix it if it fails to meet module-defined criteria.
- - <b>Initialization</b>: The core calls the final initialization procedure with
- the object's full context now defined.  Properties that are derived based on the
- object's context should be initialized only at this point.
- - <b>Synchronization</b>: This operation is performed repeatedly until every object
- reports that it no longer expects any state changes.  The return value from a
- synchronization operation is the amount time expected to elapse before the object's
- next state change.  The side effect of a synchronization is a change to one or
- more properties of the object, and possible an update to the property of another
- object.
+	The runtime module API links the GridLAB-D core to modules that are created to
+	perform various modeling tasks.  The core interacts with each module according
+	to a set script that determines which exposed module functions are called and
+	when.  The general sequence of calls is as follows:
+	- <b>Registration</b>: A module registers the object classes it implements and
+	registers the variables that each class publishes.
+	- <b>Creation</b>: The core calls object creation functions during the model
+	load operation for each object that is created.  Basic initialization can be
+	completed at this point.
+	- <b>Definition</b>: The core sets the values of all published variables that have
+	been specified in the model being loaded.  After this is completed, all references
+	to other objects have been resolved.
+	- <b>Validation</b>: The core gives the module an opportunity to check the model
+	before initialization begins.  This gives the module an opportunity to validate
+	the model and reject it or fix it if it fails to meet module-defined criteria.
+	- <b>Initialization</b>: The core calls the final initialization procedure with
+	the object's full context now defined.  Properties that are derived based on the
+	object's context should be initialized only at this point.
+	- <b>Synchronization</b>: This operation is performed repeatedly until every object
+	reports that it no longer expects any state changes.  The return value from a
+	synchronization operation is the amount time expected to elapse before the object's
+	next state change.  The side effect of a synchronization is a change to one or
+	more properties of the object, and possible an update to the property of another
+	object.
 
- Note that object destruction is not supported at this time.
+	Note that object destruction is not supported at this time.
 
- GridLAB-D modules usually require a number of functions to access data and interaction
- with the core.  These include
- - memory locking,
- - memory exception handlers,
- - variable publishers,
- - output functions,
- - management routines,
- - module management,
- - class registration,
- - object management,
- - property management,
- - object search,
- - random number generators, and
- - time management.
+	 GridLAB-D modules usually require a number of functions to access data and interaction
+	 with the core.  These include
+	 - memory locking,
+	 - memory exception handlers,
+	 - variable publishers,
+	 - output functions,
+	 - management routines,
+	 - module management,
+	 - class registration,
+	 - object management,
+	 - property management,
+	 - object search,
+	 - random number generators, and
+	 - time management.
  @{
  **/
 
@@ -70,12 +70,12 @@
 #endif
 
 #ifdef __cplusplus
-#ifndef CDECL
-/** Defines a function as a C-type function **/
-#define CDECL extern "C"
-#endif
+	#ifndef CDECL
+		/** Defines a function as a C-type function **/
+		#define CDECL extern "C"
+	#endif
 #else
-#define CDECL
+	#define CDECL
 #endif
 
 #ifdef _WIN32
@@ -130,29 +130,29 @@ CDECL EXTERN CALLBACKS *callback INIT(NULL);
  */
 /**	@defgroup gridlabd_h_publishing Publishing variables
 
- Modules must register public variables that are accessed by other modules, and the core by publishing them.
+	Modules must register public variables that are accessed by other modules, and the core by publishing them.
 
- The typical modules will register a class, and immediately publish the variables supported by the class:
- @code
+	The typical modules will register a class, and immediately publish the variables supported by the class:
+	@code
 
- EXPORT CLASS *init(CALLBACKS *fntable, MODULE *module, int argc, char *argv[])
- {
- extern CLASS* node_class; // defined globally in the module
- if (set_callback(fntable)==NULL)
- {
- errno = EINVAL;
- return NULL;
- }
+	EXPORT CLASS *init(CALLBACKS *fntable, MODULE *module, int argc, char *argv[])
+	{
+		extern CLASS* node_class; // defined globally in the module
+		if (set_callback(fntable)==NULL)
+		{
+			errno = EINVAL;
+			return NULL;
+		}
 
- node_class = gl_register_class(module,"node",sizeof(node),PC_BOTTOMUP);
- PUBLISH_CLASS(node,complex,V);
- PUBLISH_CLASS(node,complex,S);
+		node_class = gl_register_class(module,"node",sizeof(node),PC_BOTTOMUP);
+		PUBLISH_CLASS(node,complex,V);
+		PUBLISH_CLASS(node,complex,S);
 
- return node_class; // always return the *first* class registered
- }
- @endcode
+		return node_class; // always return the *first* class registered
+	}
+	@endcode
 
- @{
+	@{
  **/
 /** The PUBLISH_STRUCT macro is used to publish a member of a structure.
  **/
@@ -165,16 +165,17 @@ CDECL EXTERN CALLBACKS *callback INIT(NULL);
 #define PUBLISH_CLASSX(C,T,N,V) {class C *_t=NULL;if (gl_publish_variable(C##_class,PT_##T,V,(char*)&(_t->N)-(char*)_t,NULL)<1) return NULL;}
 
 /** The PUBLISH_CLASS_UNT macros is used to publish a member of a class (C++ only) including a unit specification.
- **/
+**/
 //#define PUBLISH_CLASS_UNIT(C,T,N,U) {class C _t;if (gl_publish_variable(C##_class,PT_##T,#N"["U"]",(char*)&_t.N-(char*)&_t,NULL)<1) return NULL;}
 /** The PUBLISH_DELEGATED macro is used to publish a variable that uses a delegated type.
 
- **/
+**/
 #define PUBLISH_DELEGATED(C,T,N) {class C *_t=NULL;if (gl_publish_variable(C##_class,PT_delegated,T,#N,(char*)&(_t->N)-(char*)_t,NULL)<1) return NULL;}
 
 /** The PUBLISH_ENUM(C,N,E) macro is used to define a keyword for an enumeration variable
  **/
 //#define PUBLISH_ENUM(C,N,E) (*callback->define_enumeration_member)(C##_class,#N,#E,C::E)
+
 /** The PUBLISH_SET(C,N,E) macro is used to define a keyword for a set variable
  **/
 //#define PUBLISH_SET(C,N,E) (*callback->define_set_member)(C##_class,#N,#E,C::E)
@@ -187,61 +188,62 @@ CDECL EXTERN CALLBACKS *callback INIT(NULL);
  */
 /**	@defgroup gridlabd_h_exception Exception handling
 
- Module exception handling is provided for modules implemented in C to perform exception handling,
- as well to allow C++ code to throw exceptions to the core's main exception handler.
+	Module exception handling is provided for modules implemented in C to perform exception handling,
+	as well to allow C++ code to throw exceptions to the core's main exception handler.
 
- Typical use is like this:
+	Typical use is like this:
 
- @code
- #include <errno.h>
- #include <string.h>
- GL_TRY {
+	@code
+	#include <errno.h>
+	#include <string.h>
+	GL_TRY {
 
- // block of code
+		// block of code
 
- // exception
- if (errno!=0)
- GL_THROW("Error condition %d: %s", errno, strerror(errno));
+		// exception
+		if (errno!=0)
+			GL_THROW("Error condition %d: %s", errno, strerror(errno));
 
- // more code
+		// more code
 
- } GL_CATCH(char *msg) {
+	} GL_CATCH(char *msg) {
 
- // exception handler
+		// exception handler
 
- } GL_ENDCATCH;
- @endcode
+	} GL_ENDCATCH;
+	@endcode
 
- Note: it is ok to use GL_THROW inside a C++ catch statement.  This behavior is defined
- (unlike using C++ throw inside C++ catch) because GL_THROW is implemented using longjmp().
+	Note: it is ok to use GL_THROW inside a C++ catch statement.  This behavior is defined
+	(unlike using C++ throw inside C++ catch) because GL_THROW is implemented using longjmp().
 
- See \ref exception "Exception handling" for detail on the message format conventions.
+	See \ref exception "Exception handling" for detail on the message format conventions.
 
- @{
+	@{
  **/
 /** You may create your own #GL_TRY block and throw exception using GL_THROW(Msg,...) within
- the block.  Declaring this block will change the behavior of GL_THROW(Msg,...) only
- within the block.  Calls to GL_THROW(Msg,...) within this try block will be transfer
- control to the GL_CATCH(Msg) block.
+	the block.  Declaring this block will change the behavior of GL_THROW(Msg,...) only
+	within the block.  Calls to GL_THROW(Msg,...) within this try block will be transfer
+	control to the GL_CATCH(Msg) block.
  **/
 #define GL_TRY { EXCEPTIONHANDLER *_handler = (*callback->exception.create_exception_handler)(); if (_handler==NULL) (*callback->output_error)("%s(%d): module exception handler creation failed",__FILE__,__LINE__); else if (setjmp(_handler->buf)==0) {
 /* TROUBLESHOOT
- This error is caused when the system is unable to implement an exception handler for a module.
- This is an internal error and should be reported to the module developer.
+	This error is caused when the system is unable to implement an exception handler for a module.
+	This is an internal error and should be reported to the module developer.
  */
 /** The behavior of GL_THROW(Msg,...) differs depending on the situation:
- - Inside a #GL_TRY block, program flow is transfered to the GL_CATCH(Msg) block that follows.
- - Inside a GL_CATCH(Msg) block, GL_THROW(Msg,...) behavior is undefined (read \em bad).
- - Outside a #GL_TRY or GL_CATCH(Msg) block, control is transfered to the main core exception handler.
+	- Inside a #GL_TRY block, program flow is transfered to the GL_CATCH(Msg) block that follows.
+	- Inside a GL_CATCH(Msg) block, GL_THROW(Msg,...) behavior is undefined (read \em bad).
+	- Outside a #GL_TRY or GL_CATCH(Msg) block, control is transfered to the main core exception handler.
  **/
 #ifdef __cplusplus
-inline void GL_THROW(char *format, ...) {
+inline void GL_THROW(char *format, ...)
+{
 	static char buffer[1024];
 	va_list ptr;
-	va_start(ptr, format);
-	vsprintf(buffer, format, ptr);
+	va_start(ptr,format);
+	vsprintf(buffer,format,ptr);
 	va_end(ptr);
-	throw(const char*) buffer;
+	throw (const char*) buffer;
 }
 #else
 #define GL_THROW (*callback->exception.throw_exception)
@@ -264,37 +266,37 @@ inline void GL_THROW(char *format, ...) {
  */
 /**	@defgroup gridlabd_h_output Output functions
 
- Module may output messages to stdout, stderr, and the core test record file
- using the output functions.
+	Module may output messages to stdout, stderr, and the core test record file
+	using the output functions.
 
- See \ref output "Output function" for details on message format conventions.
- @{
+	See \ref output "Output function" for details on message format conventions.
+	@{
  **/
 
 #define gl_verbose (*callback->output_verbose)
 
 /** Produces a message on stdout.
- @see output_message(char *format, ...)
+	@see output_message(char *format, ...)
  **/
 #define gl_output (*callback->output_message)
 
 /** Produces a warning message on stderr, but only when \b --warning is provided on the command line.
- @see output_warning(char *format, ...)
+	@see output_warning(char *format, ...)
  **/
 #define gl_warning (*callback->output_warning)
 
 /** Produces an error message on stderr, but only when \b --quiet is not provided on the command line.
- @see output_error(char *format, ...)
- **/
+ 	@see output_error(char *format, ...)
+**/
 #define gl_error (*callback->output_error)
 
 /** Produces a debug message on stderr, but only when \b --debug is provided on the command line.
- @see output_debug(char *format, ...)
+ 	@see output_debug(char *format, ...)
  **/
 #define gl_debug (*callback->output_debug)
 
 /** Produces a test message in the test record file, but only when \b --testfile is provided on the command line.
- @see output_testmsg(char *format, ...)
+	@see output_testmsg(char *format, ...)
  **/
 #define gl_testmsg (*callback->output_test)
 /** @} **/
@@ -304,14 +306,14 @@ inline void GL_THROW(char *format, ...) {
  */
 /**	@defgroup gridlabd_h_memory Memory allocation functions
 
- The core is responsible for managing any memory that is shared.  Use these
- macros to manage the allocation of objects that are registered classes.
+	The core is responsible for managing any memory that is shared.  Use these
+	macros to manage the allocation of objects that are registered classes.
 
- @{
+	@{
  **/
 /** Allocate a block of memory from the core's heap.
- This is necessary for any memory that the core will have to manage.
- @see malloc()
+	This is necessary for any memory that the core will have to manage.
+	@see malloc()
  **/
 #define gl_malloc (*callback->malloc)
 /** @} **/
@@ -321,24 +323,24 @@ inline void GL_THROW(char *format, ...) {
  */
 /**	@defgroup gridlabd_h_corelib Core access functions
 
- Most module function use core library functions and variables.
- Use these macros to access the core library and other global module variables.
+	Most module function use core library functions and variables.
+	Use these macros to access the core library and other global module variables.
 
- @{
+	@{
  **/
 /** Defines the callback table for the module.
- Callback function provide module with direct access to important core functions.
- @see struct s_callback
+	Callback function provide module with direct access to important core functions.
+	@see struct s_callback
  **/
 #define set_callback(CT) (callback=(CT))
 
 /** Provides access to a global module variable.
- @see global_getvar(), global_setvar()
+	@see global_getvar(), global_setvar()
  **/
 #define gl_get_module_var (*callback->module.getvar)
 
 /** Provide file search function
- @see find_file()
+	@see find_file()
  **/
 #define gl_findfile (*callback->file.find_file)
 
@@ -347,21 +349,22 @@ inline void GL_THROW(char *format, ...) {
 #define gl_find_property (*callback->find_property)
 
 /** Declare a module dependency.  This will automatically load
- the module if it is not already loaded.
- @return 1 on success, 0 on failure
+    the module if it is not already loaded.
+	@return 1 on success, 0 on failure
  **/
 #ifdef __cplusplus
 inline int gl_module_depends(char *name, /**< module name */
-unsigned char major = 0, /**< major version, if any required (module must match exactly) */
-unsigned char minor = 0, /**< minor version, if any required (module must be greater or equal) */
-unsigned short build = 0) /**< build number, if any required (module must be greater or equal) */
+							 unsigned char major=0, /**< major version, if any required (module must match exactly) */
+							 unsigned char minor=0, /**< minor version, if any required (module must be greater or equal) */
+							 unsigned short build=0) /**< build number, if any required (module must be greater or equal) */
 {
-	return (*callback->module.depends)(name, major, minor, build);
+	return (*callback->module.depends)(name,major,minor,build);
 }
 #else
 #define gl_module_getfirst (*callback->module.getfirst)
 #define gl_module_depends (*callback->module.depends)
 #endif
+
 
 /** @} **/
 
@@ -370,14 +373,14 @@ unsigned short build = 0) /**< build number, if any required (module must be gre
  */
 /**	@defgroup gridlabd_h_class Class registration
 
- Class registration is used to make sure the core knows how objects are implemented
- in modules.  Use the class management macros to create and destroy classes.
+	Class registration is used to make sure the core knows how objects are implemented
+	in modules.  Use the class management macros to create and destroy classes.
 
- @{
+	@{
  **/
 /** Allow an object class to be registered with the core.
- Note that C file may publish structures, even they are not implemented as classes.
- @see class_register()
+	Note that C file may publish structures, even they are not implemented as classes.
+	@see class_register()
  **/
 #define gl_register_class (*callback->register_class)
 #define gl_class_get_first (*callback->class_getfirst)
@@ -389,120 +392,107 @@ unsigned short build = 0) /**< build number, if any required (module must be gre
  */
 /**	@defgroup gridlabd_h_object Object management
 
- Object management macros are create to allow modules to create, test,
- control ranks, and reveal members of objects and registered classes.
+	Object management macros are create to allow modules to create, test,
+	control ranks, and reveal members of objects and registered classes.
 
- @{
+	@{
  **/
 /** Creates an object by allocating on from core heap.
- @see object_create_single()
+	@see object_create_single()
  */
 #define gl_create_object (*callback->create.single)
 
 /** Creates an array of objects on core heap.
- @see object_create_array()
+	@see object_create_array()
  **/
 #define gl_create_array (*callback->create.array)
 
 /** Creates an array of objects on core heap.
- @see object_create_array()
+	@see object_create_array()
  **/
 #define gl_create_foreign (*callback->create.foreign)
 
 /** Object type test
 
- Checks the type (and supertypes) of an object.
+	Checks the type (and supertypes) of an object.
 
- @see object_isa()
+	@see object_isa()
  **/
 #ifdef __cplusplus
 inline bool gl_object_isa(OBJECT *obj, /**< object to test */
-char *type, char *modname = NULL) /**< type to test */
-{
-	bool rv = (*callback->object_isa)(obj, type) != 0;
-	bool mv =
-			modname ?
-					obj->oclass->module == (*callback->module_find)(modname) :
-					true;
-	return (rv && mv);
-}
+						  char *type,
+						  char *modname=NULL) /**< type to test */
+{	bool rv = (*callback->object_isa)(obj,type)!=0;
+	bool mv = modname ? obj->oclass->module == (*callback->module_find)(modname) : true;
+	return (rv && mv);}
 #else
 #define gl_object_isa (*callback->object_isa)
 #endif
 
 /** Declare an object property as publicly accessible.
- @see object_define_map()
+	@see object_define_map()
  **/
 #define gl_publish_variable (*callback->define_map)
 
 #define gl_publish_loadmethod (*callback->loadmethod)
 
 /** Publishes an object function.  This is currently unused.
- @see object_define_function()
+	@see object_define_function()
  **/
 #ifdef __cplusplus
-inline FUNCTION* gl_publish_function(CLASS *oclass, /**< class to which function belongs */
-FUNCTIONNAME functionname, /**< name of function */
-FUNCTIONADDR call) /**< address of function entry */
-{
-	return (*callback->function.define)(oclass, functionname, call);
-}
-inline FUNCTIONADDR gl_get_function(OBJECT *obj, char *name) {
-	return obj ? (*callback->function.get)(obj->oclass->name, name) : NULL;
-}
+inline FUNCTION *gl_publish_function(CLASS *oclass, /**< class to which function belongs */
+									 FUNCTIONNAME functionname, /**< name of function */
+									 FUNCTIONADDR call) /**< address of function entry */
+{ return (*callback->function.define)(oclass, functionname, call);}
+inline FUNCTIONADDR gl_get_function(OBJECT *obj, char *name)
+{ return obj?(*callback->function.get)(obj->oclass->name,name):NULL;}
 #else
 #define gl_publish_function (*callback->function.define)
 #define gl_get_function (*callback->function.get)
 #endif
 
 /** Changes the dependency rank of an object.
- Normally dependency rank is determined by the object parent,
- but an object's rank may be increased using this call.
- An object's rank may not be decreased.
- @see object_set_rank(), object_set_parent()
+	Normally dependency rank is determined by the object parent,
+	but an object's rank may be increased using this call.
+	An object's rank may not be decreased.
+	@see object_set_rank(), object_set_parent()
  **/
 #ifdef __cplusplus
 inline int gl_set_dependent(OBJECT *obj, /**< object to set dependency */
-OBJECT *dep) /**< object dependent on */
-{
-	return (*callback->object.set_dependent)(obj, dep);
-}
+							OBJECT *dep) /**< object dependent on */
+{ return (*callback->object.set_dependent)(obj,dep);}
 #else
 #define gl_set_dependent (*callback->object.set_dependent)
 #endif
 
 /** Establishes the rank of an object relative to another object (it's parent).
- When an object is parent to another object, it's rank is always greater.
- Object of higher rank are processed first on top-down passes,
- and later on bottom-up passes.
- Objects of the same rank may be processed in parallel,
- if system resources make it possible.
- @see object_set_rank(), object_set_parent()
+	When an object is parent to another object, it's rank is always greater.
+	Object of higher rank are processed first on top-down passes,
+	and later on bottom-up passes.
+	Objects of the same rank may be processed in parallel,
+	if system resources make it possible.
+	@see object_set_rank(), object_set_parent()
  **/
 #ifdef __cplusplus
 inline int gl_set_parent(OBJECT *obj, /**< object to set parent of */
-OBJECT *parent) /**< parent object */
-{
-	return (*callback->object.set_parent)(obj, parent);
-}
+						 OBJECT *parent) /**< parent object */
+{ return (*callback->object.set_parent)(obj,parent);}
 #else
 #define gl_set_parent (*callback->object.set_parent)
 #endif
 
 /** Adjusts the rank of an object relative to another object (it's parent).
- When an object is parent to another object, it's rank is always greater.
- Object of higher rank are processed first on top-down passes,
- and later on bottom-up passes.
- Objects of the same rank may be processed in parallel,
- if system resources make it possible.
- @see object_set_rank(), object_set_parent()
+	When an object is parent to another object, it's rank is always greater.
+	Object of higher rank are processed first on top-down passes,
+	and later on bottom-up passes.
+	Objects of the same rank may be processed in parallel,
+	if system resources make it possible.
+	@see object_set_rank(), object_set_parent()
  **/
 #ifdef __cplusplus
 inline int gl_set_rank(OBJECT *obj, /**< object to change rank */
-int rank) /**< new rank of object */
-{
-	return (*callback->object.set_rank)(obj, rank);
-}
+					   int rank)	/**< new rank of object */
+{ return (*callback->object.set_rank)(obj,rank);}
 #else
 #define gl_set_rank (*callback->object.set_rank)
 #endif
@@ -516,66 +506,59 @@ int rank) /**< new rank of object */
  */
 /**	@defgroup gridlabd_h_property Property management
 
- Use the property management functions to provide and gain access to published
- variables from other modules.  This include getting property information
- and unit conversion.
+	Use the property management functions to provide and gain access to published
+	variables from other modules.  This include getting property information
+	and unit conversion.
 
- @{
+	@{
  **/
 /** Create an object
- @see class_register()
+	@see class_register()
  **/
 #define gl_register_type (*callback->register_type)
 #define gl_class_add_extended_property (*callback->class_add_extended_property)
 
 /** Publish an delegate property type for a class
- @note This is not supported in Version 1.
+	@note This is not supported in Version 1.
  **/
 #define gl_publish_delegate (*callback->define_type)
 
 /** Get a property of an object
- @see object_get_property()
+	@see object_get_property()
  **/
 #ifdef __cplusplus
-inline PROPERTY* gl_get_property(OBJECT *obj, /**< a pointer to the object */
-PROPERTYNAME name, /**< the name of the property */
-PROPERTYSTRUCT *part = NULL) /**< part info */
-{
-	return (*callback->properties.get_property)(obj, name, part);
-}
+inline PROPERTY *gl_get_property(OBJECT *obj, /**< a pointer to the object */
+								 PROPERTYNAME name, /**< the name of the property */
+								 PROPERTYSTRUCT *part=NULL) /**< part info */
+{ return (*callback->properties.get_property)(obj,name,part); }
 #else
 #define gl_get_property (*callback->properties.get_property)
 #endif
 
 /** Get the value of a property in an object
- @see object_get_value_by_addr()
+	@see object_get_value_by_addr()
  **/
 #ifdef __cplusplus
 inline int gl_get_value(OBJECT *obj, /**< the object from which to get the data */
-void *addr, /**< the addr of the data to get */
-char *value, /**< the buffer to which to write the result */
-int size, /**< the size of the buffer */
-PROPERTY *prop = NULL) /**< the property to use or NULL if unknown */
-{
-	return (*callback->properties.get_value_by_addr)(obj, addr, value, size,
-			prop);
-}
+						void *addr, /**< the addr of the data to get */
+						char *value, /**< the buffer to which to write the result */
+						int size, /**< the size of the buffer */
+						PROPERTY *prop=NULL) /**< the property to use or NULL if unknown */
+{ return (*callback->properties.get_value_by_addr)(obj,addr,value,size,prop);}
 #else
 #define gl_get_value (*callback->properties.get_value_by_addr)
 #endif
 #define gl_set_value_by_type (*callback->properties.set_value_by_type)
 
 /** Set the value of a property in an object
- @see object_set_value_by_addr()
+	@see object_set_value_by_addr()
  **/
 #ifdef __cplusplus
 inline int gl_set_value(OBJECT *obj, /**< the object to alter */
-void *addr, /**< the address of the property */
-char *value, /**< the value to set */
-PROPERTY *prop) /**< the property to use or NULL if unknown */
-{
-	return (*callback->properties.set_value_by_addr)(obj, addr, value, prop);
-}
+						void *addr, /**< the address of the property */
+						char *value, /**< the value to set */
+						PROPERTY *prop) /**< the property to use or NULL if unknown */
+{ return (*callback->properties.set_value_by_addr)(obj,addr,value,prop);}
 #else
 #define gl_set_value (*callback->properties.set_value_by_addr)
 #endif
@@ -585,28 +568,25 @@ char* gl_name(OBJECT *my, char *buffer, size_t size);
 /* 'stolen' from rt/gridlabd.h, something dchassin squirreled in. -mhauer */
 /// Set the typed value of a property
 /// @return nothing
-template<class T> inline int gl_set_value(OBJECT *obj, ///< the object whose property value is being obtained
-		PROPERTY *prop, ///< the name of the property being obtained
-		T &value) ///< a reference to the local value where the property's value is being copied
-		{
+template <class T> inline int gl_set_value(OBJECT *obj, ///< the object whose property value is being obtained
+											PROPERTY *prop, ///< the name of the property being obtained
+											T &value) ///< a reference to the local value where the property's value is being copied
+{
 	//T *ptr = (T*)gl_get_addr(obj,propname);
 	char buffer[256];
-	T *ptr = (T*) ((char*) (obj + 1) + (int64)(prop->addr)); /* warning: cast from pointer to integer of different size */
+	T *ptr = (T *)((char *)(obj + 1) + (int64)(prop->addr)); /* warning: cast from pointer to integer of different size */
 	// @todo it would be a good idea to check the property type here
-	if (ptr == NULL)
-		GL_THROW("property %s not found in object %s", prop->name,
-				gl_name(obj, buffer, 255));
-	if (obj->oclass->notify) {
-		if (obj->oclass->notify(obj, NM_PREUPDATE, prop) == 0) {
-			gl_error("preupdate notify failure on %s in %s", prop->name,
-					obj->name ? obj->name : "an unnamed object");
+	if (ptr==NULL)
+		GL_THROW("property %s not found in object %s", prop->name, gl_name(obj, buffer, 255));
+	if(obj->oclass->notify){
+		if(obj->oclass->notify(obj,NM_PREUPDATE,prop) == 0){
+			gl_error("preupdate notify failure on %s in %s", prop->name, obj->name ? obj->name : "an unnamed object");
 		}
 	}
 	*ptr = value;
-	if (obj->oclass->notify) {
-		if (obj->oclass->notify(obj, NM_POSTUPDATE, prop) == 0) {
-			gl_error("postupdate notify failure on %s in %s", prop->name,
-					obj->name ? obj->name : "an unnamed object");
+	if(obj->oclass->notify){
+		if(obj->oclass->notify(obj,NM_POSTUPDATE,prop) == 0){
+			gl_error("postupdate notify failure on %s in %s", prop->name, obj->name ? obj->name : "an unnamed object");
 		}
 	}
 	return 1;
@@ -614,45 +594,48 @@ template<class T> inline int gl_set_value(OBJECT *obj, ///< the object whose pro
 #endif
 
 /** Get a reference to another object
- @see object_get_reference()
+	@see object_get_reference()
  **/
 #define gl_get_reference (*callback->properties.get_reference)
 
 /** Get the value of a property in an object
- @see object_get_value_by_name()
+	@see object_get_value_by_name()
  **/
 #ifdef __cplusplus
-inline int gl_get_value_by_name(OBJECT *obj, PROPERTYNAME name, char *value,
-		int size) {
-	return (*callback->properties.get_value_by_name)(obj, name, value, size);
-}
+inline int gl_get_value_by_name(OBJECT *obj,
+								PROPERTYNAME name,
+								char *value,
+								int size)
+{ return (*callback->properties.get_value_by_name)(obj,name,value,size);}
 #else
 #define gl_get_value_by_name (*callback->properties.get_value_by_name)
 #endif
 
 #ifdef __cplusplus
-inline char* gl_getvalue(OBJECT *obj, PROPERTYNAME name, char *buffer, int sz) {
-	return gl_get_value_by_name(obj, name, buffer, sz) >= 0 ? buffer : NULL;
+inline char *gl_getvalue(OBJECT *obj,
+						 PROPERTYNAME name, char *buffer, int sz)
+{
+	return gl_get_value_by_name(obj,name,buffer,sz)>=0 ? buffer : NULL;
 }
 #endif
 
 /** Set the value of a property in an object
- @see object_set_value_by_name()
+	@see object_set_value_by_name()
  **/
 #define gl_set_value_by_name (*callback->properties.set_value_by_name)
 
 /** Get unit of property
- @see object_get_unit()
+	@see object_get_unit()
  **/
 #define gl_get_unit (*callback->properties.get_unit)
 
 /** Convert the units of a property using unit name
- @see unit_convert()
+	@see unit_convert()
  **/
 #define gl_convert (*callback->unit_convert)
 
 /** Convert the units of a property using unit data
- @see unit_convert_ex()
+	@see unit_convert_ex()
  **/
 #define gl_convert_ex (*callback->unit_convert_ex)
 
@@ -665,36 +648,36 @@ inline char* gl_getvalue(OBJECT *obj, PROPERTYNAME name, char *buffer, int sz) {
 #define gl_get_object_count (*callback->object_count)
 
 #ifdef __cplusplus
-inline OBJECT** gl_get_object_prop(OBJECT *obj, PROPERTY *prop) {
-	return (*callback->objvar.object_var)(obj, prop);
+inline OBJECT **gl_get_object_prop(OBJECT *obj, PROPERTY *prop){
+    return (*callback->objvar.object_var)(obj, prop);
 }
 #else
 #define gl_get_object_prop (*callback->objvar.object_var)
 #endif
 
 #ifdef __cplusplus
-inline bool* gl_get_bool(OBJECT *obj, /**< object to set dependency */
-PROPERTY *prop) /**< object dependent on */
+inline bool *gl_get_bool(OBJECT *obj, /**< object to set dependency */
+							PROPERTY *prop) /**< object dependent on */
 {
-	return (*callback->objvar.bool_var)(obj, prop);
+    return (*callback->objvar.bool_var)(obj,prop);
 }
 #else
 #define gl_get_bool (*callback->objvar.bool_var)
 #endif
 
 #ifdef __cplusplus
-inline bool* gl_get_bool(OBJECT *obj, /**< object to set dependency */
-char *propname) /**< object dependent on */
+inline bool *gl_get_bool(OBJECT *obj, /**< object to set dependency */
+							char *propname) /**< object dependent on */
 {
-	return (*callback->objvarname.bool_var)(obj, propname);
+    return (*callback->objvarname.bool_var)(obj,propname);
 }
 #else
 #define gl_get_bool_by_name (*callback->objvarname.bool_var)
 #endif
 
 /** Retrieve the complex value associated with the property
- @see object_get_complex()
- **/
+	@see object_get_complex()
+**/
 #define gl_get_complex (*callback->objvar.complex_var)
 
 #define gl_get_complex_by_name (*callback->objvarname.complex_var)
@@ -738,39 +721,39 @@ char *propname) /**< object dependent on */
  */
 /**	@defgroup gridlabd_h_search Object search
 
- Searches and navigates object lists.
+	Searches and navigates object lists.
 
- @{
+	@{
  **/
 /** Find one or more object
- @see find_objects()
+	@see find_objects()
  **/
 #define gl_find_objects (*callback->find.objects)
 
 /** Scan a list of found objects
- @see find_first(), find_next()
+	@see find_first(), find_next()
  **/
 #define gl_find_next (*callback->find.next)
 
 /** Duplicate a list of found objects
- @see find_copylist()
+	@see find_copylist()
  **/
 #define gl_findlist_copy (*callback->find.copy)
 #define gl_findlist_add (*callback->find.add)
 #define gl_findlist_del (*callback->find.del)
 #define gl_findlist_clear (*callback->find.clear)
 /** Release memory used by a find list
- @see free()
+	@see free()
  **/
 #define gl_free (*callback->free)
 
 /** Create an aggregate property from a find list
- @see aggregate_mkgroup()
+	@see aggregate_mkgroup()
  **/
 #define gl_create_aggregate (*callback->aggregate.create)
 
 /** Evaluate an aggregate property
- @see aggregate_value()
+	@see aggregate_value()
  **/
 #define gl_run_aggregate (*callback->aggregate.refresh)
 /** @} **/
@@ -780,61 +763,61 @@ char *propname) /**< object dependent on */
  */
 /**	@defgroup gridlabd_h_random Random numbers
 
- The random number library provides a variety of random number generations
- for different distributions.
+	The random number library provides a variety of random number generations
+	for different distributions.
 
- @{
+	@{
  **/
 
 #define RNGSTATE (&(OBJECTHDR(this))->rng_state)
 
 /** Determine the distribution type to be used from its name
- @see RANDOMTYPE, random_type()
+	@see RANDOMTYPE, random_type()
  **/
 #define gl_randomtype (*callback->random.type)
 
 /** Obtain an arbitrary random value using RANDOMTYPE
- @see RANDOMTYPE, random_value()
+	@see RANDOMTYPE, random_value()
  **/
 #define gl_randomvalue (*callback->random.value)
 
 /** Obtain an arbitrary random value using RANDOMTYPE
- @see RANDOMTYPE, pseudorandom_value()
+	@see RANDOMTYPE, pseudorandom_value()
  **/
 #define gl_pseudorandomvalue (*callback->random.pseudo)
 
 /** Generate a uniformly distributed random number
- @see random_uniform()
+	@see random_uniform()
  **/
 #define gl_random_uniform (*callback->random.uniform)
 
 /** Generate a normal distributed random number
- @see random_normal()
+	@see random_normal()
  **/
 #define gl_random_normal (*callback->random.normal)
 
 /** Generate a log normal distributed random number
- @see random_lognormal()
+	@see random_lognormal()
  **/
 #define gl_random_lognormal (*callback->random.lognormal)
 
 /** Generate a Bernoulli distributed random number
- @see random_bernoulli()
+	@see random_bernoulli()
  **/
 #define gl_random_bernoulli (*callback->random.bernoulli)
 
 /** Generate a Pareto distributed random number
- @see random_pareto()
+	@see random_pareto()
  **/
 #define gl_random_pareto (*callback->random.pareto)
 
 /** Generate a random number drawn uniformly from a sample
- @see random_sampled()
+	@see random_sampled()
  **/
 #define gl_random_sampled (*callback->random.sampled)
 
 /** Generate an examponentially distributed random number
- @see random_exponential()
+	@see random_exponential()
  **/
 #define gl_random_exponential (*callback->random.exponential)
 #define gl_random_triangle (*callback->random.triangle)
@@ -860,7 +843,7 @@ char *propname) /**< object dependent on */
 #define gl_globalstoptime (*(callback->global_stoptime))
 
 /** Convert a string to a timestamp
- @see convert_to_timestamp()
+	@see convert_to_timestamp()
  **/
 #define gl_parsetime (*callback->time.convert_to_timestamp)
 
@@ -871,53 +854,55 @@ char *propname) /**< object dependent on */
 #define gl_printtimedelta (*callback->time.convert_from_deltatime_timestamp)
 
 /** Convert a timestamp to a date/time structure
- @see mkdatetime()
+	@see mkdatetime()
  **/
 #define gl_mktime (*callback->time.mkdatetime)
 
 /** Convert a date/time structure to a string
- @see strdatetime()
+	@see strdatetime()
  **/
 #define gl_strtime (*callback->time.strdatetime)
 
 /** Convert a timestamp to days
- @see timestamp_to_days()
+	@see timestamp_to_days()
  **/
 #define gl_todays (*callback->time.timestamp_to_days)
 
 /** Convert a timestamp to hours
- @see timestamp_to_hours()
+	@see timestamp_to_hours()
  **/
 #define gl_tohours (*callback->time.timestamp_to_hours)
 
 /** Convert a timestamp to minutes
- @see timestamp_to_minutes()
+	@see timestamp_to_minutes()
  **/
 #define gl_tominutes (*callback->time.timestamp_to_minutes)
 
 /** Convert a timestamp to seconds
- @see timestamp_to_seconds()
+	@see timestamp_to_seconds()
  **/
 #define gl_toseconds (*callback->time.timestamp_to_seconds)
 
 /** Convert a timestamp to a local date/time structure
- @see local_datetime()
+	@see local_datetime()
  **/
 #define gl_localtime (*callback->time.local_datetime)
 
 /** Convert a timestamp to a local date/time structure
- Use this if it is a double precision time (deltamode)
- @see local_datetime()
+	Use this if it is a double precision time (deltamode)
+	@see local_datetime()
  **/
 #define gl_localtime_delta (*callback->time.local_datetime_delta)
 
 #ifdef __cplusplus
-inline int gl_getweekday(TIMESTAMP t) {
+inline int gl_getweekday(TIMESTAMP t)
+{
 	DATETIME dt;
 	gl_localtime(t, &dt);
 	return dt.weekday;
 }
-inline int gl_gethour(TIMESTAMP t) {
+inline int gl_gethour(TIMESTAMP t)
+{
 	DATETIME dt;
 	gl_localtime(t, &dt);
 	return dt.hour;
@@ -932,22 +917,22 @@ inline int gl_gethour(TIMESTAMP t) {
  **/
 
 /** Create a new global variable
- @see global_create()
+	@see global_create()
  **/
 #define gl_global_create (*callback->global.create)
 
 /** Set a global variable
- @see global_setvar()
+	@see global_setvar()
  **/
 #define gl_global_setvar (*callback->global.setvar)
 
 /** Get a global variable
- @see global_getvar()
+	@see global_getvar()
  **/
 #define gl_global_getvar (*callback->global.getvar)
 
 /** Find a global variable
- @see global_find()
+	@see global_find()
  **/
 #define gl_global_find (*callback->global.find)
 
@@ -963,32 +948,29 @@ inline int gl_gethour(TIMESTAMP t) {
  **/
 
 /** Clip a value \p x if outside the range (\p a, \p b)
- @return the clipped value of x
- @note \f clip() is only supported in C++
+	@return the clipped value of x
+	@note \f clip() is only supported in C++
  **/
 inline double clip(double x, /**< the value to clip **/
-double a, /**< the lower limit of the range **/
-double b) /**< the upper limit of the range **/
+				   double a, /**< the lower limit of the range **/
+				   double b) /**< the upper limit of the range **/
 {
-	if (x < a)
-		return a;
-	else if (x > b)
-		return b;
-	else
-		return x;
+	if (x<a) return a;
+	else if (x>b) return b;
+	else return x;
 }
 
 /** Determine which bit is set in a bit pattern
- @return the bit number \e n; \p -7f is no bit found; \e -n if more than one bit found
+	@return the bit number \e n; \p -7f is no bit found; \e -n if more than one bit found
  **/
 inline char bitof(unsigned int64 x,/**< bit pattern to scan */
-		bool use_throw=false) /**< flag to use throw when more than one bit is set */
+						   bool use_throw=false) /**< flag to use throw when more than one bit is set */
 {
 	char n=0;
 	if (x==0)
 	{
 		if (use_throw)
-		throw "bitof empty bit pattern";
+			throw "bitof empty bit pattern";
 		return -0x7f;
 	}
 	while ((x&1)==0)
@@ -999,24 +981,24 @@ inline char bitof(unsigned int64 x,/**< bit pattern to scan */
 	if (x!=0)
 	{
 		if (use_throw)
-		throw "bitof found more than one bit";
+			throw "bitof found more than one bit";
 		else
-		return -n;
+			return -n;
 	}
 	return n;
 }
 /** Construct a proper object object
- @return a pointer to the struct buffer or NULL if failed
+    @return a pointer to the struct buffer or NULL if failed
  **/
-inline char* gl_name(OBJECT *my, char *buffer, size_t size) {
+inline char* gl_name(OBJECT *my, char *buffer, size_t size)
+{
 	char temp[256];
-	if (my == NULL || buffer == NULL)
-		return NULL;
-	if (my->name == NULL)
-		sprintf(temp, "%s:%d", my->oclass->name, my->id);
+	if(my == NULL || buffer == NULL) return NULL;
+	if (my->name==NULL)
+		sprintf(temp,"%s:%d", my->oclass->name, my->id);
 	else
-		sprintf(temp, "%s", my->name);
-	if (size < strlen(temp))
+		sprintf(temp,"%s", my->name);
+	if(size < strlen(temp))
 		return NULL;
 	strcpy(buffer, temp);
 	return buffer;
@@ -1024,48 +1006,57 @@ inline char* gl_name(OBJECT *my, char *buffer, size_t size) {
 
 /** Find a schedule 
  **/
-inline SCHEDULE* gl_schedule_find(char *name) {
+inline SCHEDULE *gl_schedule_find(char *name)
+{
 	return callback->schedule.find(name);
 }
 /** Create a schedule
  **/
-inline SCHEDULE* gl_schedule_create(char *name, char *definition) {
-	return callback->schedule.create(name, definition);
+inline SCHEDULE *gl_schedule_create(char *name, char *definition)
+{
+	return callback->schedule.create(name,definition);
 }
 /** Find the time index in a schedule
  **/
-inline SCHEDULEINDEX gl_schedule_index(SCHEDULE *sch, TIMESTAMP ts) {
-	return callback->schedule.index(sch, ts);
+inline SCHEDULEINDEX gl_schedule_index(SCHEDULE *sch, TIMESTAMP ts)
+{
+	return callback->schedule.index(sch,ts);
 }
 /** Find the value at a time index in a schedule
  **/
-inline double gl_schedule_value(SCHEDULE *sch, SCHEDULEINDEX index) {
-	return callback->schedule.value(sch, index);
+inline double gl_schedule_value(SCHEDULE *sch, SCHEDULEINDEX index)
+{
+	return callback->schedule.value(sch,index);
 }
 /** Find the elapsed time until the value at an index changes
  **/
-inline int32 gl_schedule_dtnext(SCHEDULE *sch, SCHEDULEINDEX index) {
-	return callback->schedule.dtnext(sch, index);
+inline int32 gl_schedule_dtnext(SCHEDULE *sch, SCHEDULEINDEX index)
+{
+	return callback->schedule.dtnext(sch,index);
 }
-inline SCHEDULE* gl_schedule_getfirst(void) {
+inline SCHEDULE *gl_schedule_getfirst(void)
+{
 	return callback->schedule.getfirst();
 }
 /** Create an enduse
  **/
-inline int gl_enduse_create(enduse *e) {
+inline int gl_enduse_create(enduse *e)
+{
 	return callback->enduse.create(e);
 }
 /** Synchronize an enduse
  **/
-inline TIMESTAMP gl_enduse_sync(enduse *e, TIMESTAMP t1) {
-	return callback->enduse.sync(e, PC_BOTTOMUP, t1);
+inline TIMESTAMP gl_enduse_sync(enduse *e, TIMESTAMP t1)
+{
+	return callback->enduse.sync(e,PC_BOTTOMUP,t1);
 }
 /** Create a loadshape 
  **/
-inline loadshape* gl_loadshape_create(SCHEDULE *s) {
-	loadshape *ls = (loadshape*) malloc(sizeof(loadshape));
-	memset(ls, 0, sizeof(loadshape));
-	if (0 == callback->loadshape.create(ls)) {
+inline loadshape *gl_loadshape_create(SCHEDULE *s)
+{
+	loadshape *ls = (loadshape*)malloc(sizeof(loadshape));
+	memset(ls,0,sizeof(loadshape));
+	if (0 == callback->loadshape.create(ls)){
 		return NULL;
 	}
 	ls->schedule = s;
@@ -1073,7 +1064,8 @@ inline loadshape* gl_loadshape_create(SCHEDULE *s) {
 }
 /** Get the current value of a loadshape
  **/
-inline double gl_get_loadshape_value(loadshape *shape) {
+inline double gl_get_loadshape_value(loadshape *shape)
+{
 	if (shape)
 		return shape->load;
 	else
@@ -1081,47 +1073,46 @@ inline double gl_get_loadshape_value(loadshape *shape) {
 }
 /** Format a DATETIME into a string buffer
  **/
-inline char* gl_strftime(DATETIME *dt, char *buffer, int size) {
-	return callback->time.strdatetime(dt, buffer, size) ? buffer : NULL;
-}
-;
+inline char *gl_strftime(DATETIME *dt, char *buffer, int size) { return callback->time.strdatetime(dt,buffer,size)?buffer:NULL;};
 /** Format a TIMESTAMP into a string buffer
  **/
-inline char* gl_strftime(TIMESTAMP ts, char *buffer, int size) {
+inline char *gl_strftime(TIMESTAMP ts, char *buffer, int size)
+{
 	//static char buffer[64];
 	DATETIME dt;
-	if (buffer == 0) {
+	if(buffer == 0){
 		gl_error("gl_strftime: buffer is a null pointer");
 		return 0;
 	}
-	if (size < 15) {
+	if(size < 15){
 		gl_error("gl_strftime: buffer size is too small");
 		return 0;
 	}
-	if (gl_localtime(ts, &dt)) {
-		return gl_strftime(&dt, buffer, size);
+	if(gl_localtime(ts,&dt)){
+		return gl_strftime(&dt,buffer,size);
 	} else {
-		strncpy(buffer, "(invalid time)", size);
+		strncpy(buffer,"(invalid time)", size);
 	}
 	return buffer;
 }
 /** Calculate the next power of 2 greater than a number
  **/
-inline size_t nextpow2(register size_t x) {
-	if (x < 0)
-		return 0;
+inline size_t nextpow2(register size_t x)
+{
+	if (x<0) return 0;
 	x--;
-	x |= x >> 1;
-	x |= x >> 2;
-	x |= x >> 4;
-	x |= x >> 8;
-	x |= x >> 16;
+	x|=x>>1;
+	x|=x>>2;
+	x|=x>>4;
+	x|=x>>8;
+	x|=x>>16;
 	// won't work for anything over 2^30
-	return x + 1;
+	return x+1;
 }
 
 /**@}*/
 #endif //__cplusplus
+
 
 /******************************************************************************
  * Interpolation routines
@@ -1165,6 +1156,7 @@ inline size_t nextpow2(register size_t x) {
 #define gl_forecast_save (*callback->forecast.save)
 /**@}*/
 
+
 /******************************************************************************
  * Init/Sync/Create catchall macros
  */
@@ -1194,32 +1186,11 @@ inline size_t nextpow2(register size_t x) {
  * @{
  */
 #ifdef __cplusplus
-inline TRANSFORM* gl_transform_getfirst(void) {
-	return callback->transform.getnext(NULL);
-}
-;
-inline TRANSFORM* gl_transform_getnext(TRANSFORM *xform) {
-	return callback->transform.getnext(xform);
-}
-;
-inline int gl_transform_add_linear(TRANSFORMSOURCE stype, double *source,
-		void *target, double scale, double bias, OBJECT *obj, PROPERTY *prop,
-		SCHEDULE *sched) {
-	return callback->transform.add_linear(stype, source, target, scale, bias,
-			obj, prop, sched);
-}
-;
-inline int gl_transform_add_external(OBJECT *target_obj, PROPERTY *target_prop,
-		char *function, OBJECT *source_obj, PROPERTY *source_prop) {
-	return callback->transform.add_external(target_obj, target_prop, function,
-			source_obj, source_prop);
-}
-;
-inline const char* gl_module_find_transform_function(
-		TRANSFORMFUNCTION function) {
-	return callback->module.find_transform_function(function);
-}
-;
+inline TRANSFORM *gl_transform_getfirst(void) { return callback->transform.getnext(NULL); };
+inline TRANSFORM *gl_transform_getnext(TRANSFORM *xform) { return callback->transform.getnext(xform); };
+inline int gl_transform_add_linear(TRANSFORMSOURCE stype,double *source,void *target,double scale,double bias,OBJECT *obj,PROPERTY *prop,SCHEDULE *sched) { return callback->transform.add_linear(stype,source,target,scale,bias,obj,prop,sched); };
+inline int gl_transform_add_external(OBJECT *target_obj, PROPERTY *target_prop,char *function,OBJECT *source_obj, PROPERTY* source_prop) { return callback->transform.add_external(target_obj,target_prop,function,source_obj,source_prop); };
+inline const char *gl_module_find_transform_function(TRANSFORMFUNCTION function) { return callback->module.find_transform_function(function); };
 #else
 #define gl_transform_getnext (*callback->transform.getnext) /* TRANSFORM *(*transform.getnext)(TRANSFORM*); */
 #define gl_transform_add_linear (*callback->transfor.add_linear) /* int transform_add_linear(TRANSFORMSOURCE stype,double *source,void *target,double scale,double bias,OBJECT *obj,PROPERTY *prop,SCHEDULE *sched) */
@@ -1229,19 +1200,9 @@ inline const char* gl_module_find_transform_function(
 /**@}*/
 
 #ifdef __cplusplus
-inline randomvar* gl_randomvar_getfirst(void) {
-	return callback->randomvar.getnext(NULL);
-}
-;
-inline randomvar* gl_randomvar_getnext(randomvar *var) {
-	return callback->randomvar.getnext(var);
-}
-;
-inline size_t gl_randomvar_getspec(char *str, size_t size,
-		const randomvar *var) {
-	return callback->randomvar.getspec(str, size, var);
-}
-;
+inline randomvar *gl_randomvar_getfirst(void) { return callback->randomvar.getnext(NULL); };
+inline randomvar *gl_randomvar_getnext(randomvar *var) { return callback->randomvar.getnext(var); };
+inline size_t gl_randomvar_getspec(char *str, size_t size, const randomvar *var) { return callback->randomvar.getspec(str,size,var); };
 #else
 #define gl_randomvar_getnext (*callback->randomvar.getnext) /* randomvar *(*randomvar.getnext)(randomvar*) */
 #define gl_randomvar_getspec (*callback->randomvar.getspec) /* size_t (*randomvar.getspec(char*,size_t,randomvar*) */
@@ -1256,33 +1217,33 @@ inline size_t gl_randomvar_getspec(char *str, size_t size,
 
 #ifdef __cplusplus
 /** read remote object data **/
-inline void* gl_read(void *local, /**< local memory for data (must be correct size for property) */
-OBJECT *obj, /**< object from which to get data */
-PROPERTY *prop) /**< property from which to get data */
+inline void *gl_read(void *local, /**< local memory for data (must be correct size for property) */
+					 OBJECT *obj, /**< object from which to get data */
+					 PROPERTY *prop) /**< property from which to get data */
 {
-	return callback->remote.readobj(local, obj, prop);
+	return callback->remote.readobj(local,obj,prop);
 }
 /** write remote object data **/
 inline void gl_write(void *local, /** local memory for data */
-OBJECT *obj, /** object to which data is written */
-PROPERTY *prop) /**< property to which data is written */
+					 OBJECT *obj, /** object to which data is written */
+					 PROPERTY *prop) /**< property to which data is written */
 {
 	/* @todo */
-	return callback->remote.writeobj(local, obj, prop);
+	return callback->remote.writeobj(local,obj,prop);
 }
 /** read remote global data **/
-inline void* gl_read(void *local, /** local memory for data (must be correct size for global */
-GLOBALVAR *var) /** global variable from which to get data */
+inline void *gl_read(void *local, /** local memory for data (must be correct size for global */
+					 GLOBALVAR *var) /** global variable from which to get data */
 {
 	/* @todo */
-	return callback->remote.readvar(local, var);
+	return callback->remote.readvar(local,var);
 }
 /** write remote global data **/
 inline void gl_write(void *local, /** local memory for data */
-GLOBALVAR *var) /** global variable to which data is written */
+					 GLOBALVAR *var) /** global variable to which data is written */
 {
 	/* @todo */
-	return callback->remote.writevar(local, var);
+	return callback->remote.writevar(local,var);
 }
 #endif
 /**@}*/
@@ -1294,18 +1255,10 @@ GLOBALVAR *var) /** global variable to which data is written */
 #define READUNLOCK(X) ::runlock(X); /**< Unlocks an read lock */
 #define WRITEUNLOCK(X) ::wunlock(X); /**< Unlocks a write lock */
 
-inline void rlock(unsigned int *lock) {
-	callback->lock.read(lock);
-}
-inline void wlock(unsigned int *lock) {
-	callback->lock.write(lock);
-}
-inline void runlock(unsigned int *lock) {
-	callback->unlock.read(lock);
-}
-inline void wunlock(unsigned int *lock) {
-	callback->unlock.write(lock);
-}
+inline void rlock(unsigned int* lock) { callback->lock.read(lock); }
+inline void wlock(unsigned int* lock) { callback->lock.write(lock); }
+inline void runlock(unsigned int* lock) { callback->unlock.read(lock); }
+inline void wunlock(unsigned int* lock) { callback->unlock.write(lock); }
 
 #else
 #define READLOCK(X) rlock(X); /**< Locks an item for reading (allows other reads but blocks write) */
@@ -1333,6 +1286,7 @@ static unsigned long _nan[] = { 0xffffffff, 0x7fffffff, };
 #define NaN NAN
 #endif
 
+
 #ifdef __cplusplus
 
 /**************************************************************************************
@@ -1358,278 +1312,109 @@ private: // data
 	STRBUF *buf;
 public: // construction/destructor
 	/// construct an empty string
-	inline gld_string(void) :
-			buf(NULL) {
-		init();
-	}
-	;
+	inline gld_string(void) : buf(NULL) { init(); };
 	/// construct a linked string
-	inline gld_string(gld_string &s) :
-			buf(NULL) {
-		init();
-		link(s);
-	}
-	;
+	inline gld_string(gld_string&s) : buf(NULL) { init(); link(s); };
 	/// construct a new string
-	inline gld_string(const char *s) :
-			buf(NULL) {
-		init();
-		copy(s);
-	}
-	;
+	inline gld_string(const char *s) : buf(NULL) { init(); copy(s); };
 	/// construct a new string of a particular length
-	inline gld_string(const char *s, size_t n) :
-			buf(NULL) {
-		init();
-		copy(s, n);
-	}
-	;
+	inline gld_string(const char *s, size_t n) : buf(NULL) { init(); copy(s,n); };
 	/// destroy a string (or unlink from one)
-	inline ~gld_string(void) {
-		unlink();
-	}
-	;
+	inline ~gld_string(void) { unlink(); };
 public: // copy
 	/// copy a string
-	inline gld_string& operator=(const char *s) {
-		copy(s);
-		return *this;
-	}
-	;
+	inline gld_string &operator=(const char *s) { copy(s); return *this; };
 	/// link to a string
-	inline gld_string& operator=(gld_string &s) {
-		link(s);
-		return *this;
-	}
-	;
+	inline gld_string &operator=(gld_string&s) { link(s); return *this; };
 public: // casts
 	/// cast to a pointer to the string buffer
-	inline operator const char*(void) {
-		return buf->str;
-	}
-	;
+	inline operator const char*(void) { return buf->str; };
 	/// cast to the size of the string
-	inline operator size_t(void) {
-		return buf->len;
-	}
-	;
+	inline operator size_t(void) { return buf->len; };
 	/// cast to a pointer to the string data
-	inline operator STRBUF *(void) {
-		return buf;
-	}
-	;
+	inline operator STRBUF *(void) { return buf; };
 private: // internals
-	inline void init(void) {
-		buf = (STRBUF*) malloc(sizeof(STRBUF));
-		memset(buf, 0, sizeof(STRBUF));
-	}
-	;
-	inline void lock(void) {
-		if (buf)
-			::wlock(&buf->lock);
-	}
-	;
-	inline void unlock(void) {
-		if (buf)
-			::wunlock(&buf->lock);
-	}
-	;
-	inline void fit(size_t n) {
-		if (buf == NULL || n > buf->len)
-			alloc(n);
-	}
-	;
-	inline void alloc(size_t n) {
+	inline void init(void) { buf=(STRBUF*)malloc(sizeof(STRBUF)); memset(buf,0,sizeof(STRBUF)); }; 
+	inline void lock(void) { if ( buf ) ::wlock(&buf->lock); };
+	inline void unlock(void) { if ( buf ) ::wunlock(&buf->lock); };
+	inline void fit(size_t n) { if ( buf==NULL || n>buf->len) alloc(n); };
+	inline void alloc(size_t n) 
+	{
 		size_t len = nextpow2(n);
-		if (len < sizeof(NATIVE))
-			len = sizeof(NATIVE);
-		char *newstr = (char*) malloc(len);
-		if (buf->str != NULL) {
-			strcpy(newstr, buf->str);
+		if ( len<sizeof(NATIVE) ) 
+			len=sizeof(NATIVE); 
+		char *newstr=(char*)malloc(len);
+		if ( buf->str!=NULL )
+		{
+			strcpy(newstr,buf->str);
 			free(buf->str);
-		} else
-			buf->nrefs = 1;
+		}
+		else
+			buf->nrefs=1;
 		buf->str = newstr;
 		buf->len = len;
-	}
-	;
-	inline void copy(const char *s) {
-		fit(strlen(s) + 1);
-		strcpy(buf->str, s);
-	}
-	;
-	inline void copy(const char *s, size_t n) {
-		fit(n + 1);
-		strncpy(buf->str, s, n);
-	}
-	;
-	inline void link(gld_string &s) {
-		unlink();
-		buf = (STRBUF*) s;
-		buf->nrefs++;
-	}
-	;
-	inline void unlink() {
-		if (buf->nrefs <= 1) {
-			free(buf->str);
-			free(buf);
-		} else
-			buf->nrefs--;
-	}
-	;
+	};
+	inline void copy(const char *s) { fit(strlen(s)+1); strcpy(buf->str,s); };
+	inline void copy(const char *s, size_t n) { fit(n+1); strncpy(buf->str,s,n); };
+	inline void link(gld_string&s) { unlink(); buf=(STRBUF*)s; buf->nrefs++;};
+	inline void unlink() { if ( buf->nrefs<=1 ) {free(buf->str); free(buf);} else buf->nrefs--; };
 public: // status accessors
 	/// determine whether a string is valid
-	inline bool is_valid(void) {
-		return buf != NULL;
-	}
-	;
+	inline bool is_valid(void) { return buf!=NULL; };
 	/// determine whether a string is null
-	inline bool is_null(void) {
-		return is_valid() && buf->str == NULL;
-	}
-	;
+	inline bool is_null(void) { return is_valid() && buf->str==NULL; };
 public: // read accessors
 	/// get a pointer to the string buffer
-	inline const char* get_buffer(void) {
-		return buf ? buf->str : NULL;
-	}
-	;
+	inline const char* get_buffer(void) { return buf ? buf->str : NULL; };
 	/// get the size of the string buffer (as allocated)
-	inline size_t get_size(void) {
-		return buf ? buf->len : -1;
-	}
-	;
+	inline size_t get_size(void) { return buf ? buf->len : -1; };
 	/// get the length of the string (up to the null termination)
-	inline size_t get_length(void) {
-		return buf && buf->str ? strlen(buf->str) : -1;
-	}
-	;
+	inline size_t get_length(void) { return buf && buf->str ? strlen(buf->str) : -1; };
 public: // write accessors
 	/// set the string
-	inline void set_string(const char *s) {
-		copy(s);
-	}
-	;
+	inline void set_string(const char *s) { copy(s); };
 	/// set the string buffer size
-	inline void set_size(size_t n) {
-		fit(n);
-	}
-	;
+	inline void set_size(size_t n) { fit(n); };
 	/// format the string (a la printf)
-	inline size_t format(const char *fmt, ...) {
-		va_list ptr;
-		va_start(ptr, fmt);
-		int len = vsnprintf(buf->str, buf->len, fmt, ptr);
-		va_end(ptr);
-		return len;
-	}
-	;
+	inline size_t format(const char *fmt,...) { va_list ptr; va_start(ptr,fmt); int len=vsnprintf(buf->str,buf->len,fmt,ptr); va_end(ptr); return len;};
 	/// format the string with a specific buffer size
-	inline size_t format(size_t len, const char *fmt, ...) {
-		fit(len);
-		va_list ptr;
-		va_start(ptr, fmt);
-		int rv = vsnprintf(buf->str, buf->len, fmt, ptr);
-		va_end(ptr);
-		return rv;
-	}
-	;
+	inline size_t format(size_t len,const char *fmt,...) { fit(len); va_list ptr; va_start(ptr,fmt); int rv=vsnprintf(buf->str,buf->len,fmt,ptr); va_end(ptr); return rv;};
 public: // compare ops
 	/// alphabetic before comparison
-	inline bool operator<(const char *s) {
-		return strcmp(buf->str, s) < 0;
-	}
-	;
+	inline bool operator<(const char*s) { return strcmp(buf->str,s)<0; };
 	/// alphabetic before or same comparison
-	inline bool operator<=(const char *s) {
-		return strcmp(buf->str, s) <= 0;
-	}
-	;
+	inline bool operator<=(const char*s) { return strcmp(buf->str,s)<=0; };
 	/// alphabetic same comparison
-	inline bool operator==(const char *s) {
-		return strcmp(buf->str, s) == 0;
-	}
-	;
+	inline bool operator==(const char*s) { return strcmp(buf->str,s)==0; };
 	/// alphabetic after or same comparison
-	inline bool operator>=(const char *s) {
-		return strcmp(buf->str, s) >= 0;
-	}
-	;
+	inline bool operator>=(const char*s) { return strcmp(buf->str,s)>=0; };
 	/// alphabetic after comparison
-	inline bool operator>(const char *s) {
-		return strcmp(buf->str, s) > 0;
-	}
-	;
+	inline bool operator>(const char*s) { return strcmp(buf->str,s)>0; };
 	/// alphabetic differs comparison
-	inline bool operator!=(const char *s) {
-		return strcmp(buf->str, s) != 0;
-	}
-	;
+	inline bool operator!=(const char*s) { return strcmp(buf->str,s)!=0; };
 public: // manipulation
 	/// trim left whitespace
-	inline void trimleft(void) {
-		if (is_null())
-			return;
-		size_t n = 0;
-		while (buf->str[n] != '\0' && isspace(*buf->str))
-			n++;
-		strcpy(buf->str, buf->str + n);
-	}
-	;
+	inline void trimleft(void) { if ( is_null() ) return; size_t n=0; while (buf->str[n]!='\0'&&isspace(*buf->str)) n++; strcpy(buf->str,buf->str+n); };
 	/// trim right whitespace
-	inline void trimright(void) {
-		if (is_null())
-			return;
-		size_t n = strlen(buf->str);
-		while (n > 0 && isspace(buf->str[n - 1]))
-			buf->str[--n] = '\0';
-	}
-	;
+	inline void trimright(void) { if ( is_null() ) return; size_t n=strlen(buf->str); while (n>0&&isspace(buf->str[n-1])) buf->str[--n]='\0'; };
 	/// extract left string
-	inline gld_string left(size_t n) {
-		if (is_null())
-			return gld_string();
-		return gld_string(buf->str, n);
-	}
-	;
+	inline gld_string left(size_t n) { if ( is_null() ) return gld_string(); return gld_string(buf->str,n); };
 	/// extract right string
-	inline gld_string right(size_t n) {
-		if (is_null())
-			return gld_string();
-		return gld_string(buf->str + buf->len - n);
-	}
-	;
+	inline gld_string right(size_t n) { if ( is_null() ) return gld_string(); return gld_string(buf->str+buf->len-n); };
 	/// extract mid string
-	inline gld_string mid(size_t n, size_t m) {
-		if (is_null())
-			return gld_string();
-		return gld_string(buf->str + buf->len - n, m);
-	}
-	;
+	inline gld_string mid(size_t n, size_t m) { if ( is_null() ) return gld_string(); return gld_string(buf->str+buf->len-n,m); };
 	/// locate substring
-	inline size_t findstr(const char *s) {
-		if (is_null())
-			return -1;
-		char *p = strstr(buf->str, s);
-		return p == NULL ? -1 : (p - buf->str);
-	}
-	;
+	inline size_t findstr(const char *s) { if ( is_null() ) return -1; char *p=strstr(buf->str,s); return p==NULL ? -1 : (p-buf->str); };
 	/// find character
-	inline size_t findchr(char c) {
-		if (is_null())
-			return -1;
-		char *p = strchr(buf->str, c);
-		return p == NULL ? -1 : (p - buf->str);
-	}
-	;
-	inline size_t split(gld_string *&list, const char *delim = " ") {
+	inline size_t findchr(char c) { if ( is_null() ) return -1; char *p=strchr(buf->str,c); return p==NULL ? -1 : (p-buf->str); };
+	inline size_t split(gld_string *&list, const char *delim=" ") 
+	{
 		// TODO
-		if (is_null())
-			return 0;
+		if ( is_null() ) return 0;
 		return 0;
 	}
-	inline gld_string merge(gld_string *&list, size_t n,
-			const char *delim = " ") {
+	inline gld_string merge(gld_string *&list, size_t n, const char *delim=" ")
+	{
 		// TODO
 		return gld_string();
 	}
@@ -1641,353 +1426,140 @@ private: // data
 	DATETIME dt;
 public: // constructors
 	/// Clock constructor for current global clock
-	gld_clock(void) {
-		callback->time.local_datetime(*(callback->global_clock), &dt);
-	}
-	;
+	gld_clock(void) { callback->time.local_datetime(*(callback->global_clock),&dt); }; 
 	/// Clock constructor for an arbitrary TIMESTAMP
-	gld_clock(TIMESTAMP ts) {
-		if (!callback->time.local_datetime(ts, &dt))
-			memset(&dt, 0, sizeof(dt));
-	}
-	;
+	gld_clock(TIMESTAMP ts) { if ( !callback->time.local_datetime(ts,&dt)) memset(&dt,0,sizeof(dt)); };
 	/// Clock constructor for a time string
-	gld_clock(char *str) {
-		from_string(str);
-	}
-	;
+	gld_clock(char *str) { from_string(str); };
 	/// Clock constructor for year, month, day, hour, minute, second, nanosecond values
-	gld_clock(unsigned short y, unsigned short m = 0, unsigned short d = 0,
-			unsigned short H = 0, unsigned short M = 0, unsigned short S = 0,
-			unsigned short int ms = 0, char *tz = NULL, int dst = -1) {
-		dt.year = y;
-		dt.month = m;
-		dt.day = d;
-		dt.hour = H;
-		dt.minute = M;
-		dt.second = S;
-		dt.nanosecond = ms;
-		if (dst >= 0)
-			dt.is_dst = dst;
-		if (tz != NULL)
-			set_tz(tz);
-		else
-			callback->time.mkdatetime(&dt);
+	gld_clock(unsigned short y, unsigned short m=0, unsigned short d=0, unsigned short H=0, unsigned short M=0, unsigned short S=0, unsigned short int ms=0, char *tz=NULL, int dst=-1)
+	{
+		dt.year = y; dt.month=m; dt.day=d; dt.hour=H; dt.minute=M; dt.second=S; dt.nanosecond=ms;
+		if ( dst>=0 ) dt.is_dst=dst;
+		if ( tz!=NULL ) set_tz(tz); else callback->time.mkdatetime(&dt);
 	}
 public: // cast operators
 	/// Cast to TIMESTAMP
-	inline operator TIMESTAMP(void) {
-		return dt.timestamp;
-	}
-	;
+	inline operator TIMESTAMP (void) { return dt.timestamp; };
 public: // comparison operators
 	/// Compare after TIMESTAMP
-	inline bool operator >(TIMESTAMP t) {
-		return dt.timestamp > t;
-	}
-	;
+	inline bool operator > (TIMESTAMP t) { return dt.timestamp>t; };
 	/// Compare after or same TIMESTAMP
-	inline bool operator >=(TIMESTAMP t) {
-		return dt.timestamp >= t;
-	}
-	;
+	inline bool operator >= (TIMESTAMP t) { return dt.timestamp>=t; };
 	/// Compare before TIMESTAMP
-	inline bool operator <(TIMESTAMP t) {
-		return dt.timestamp < t;
-	}
-	;
+	inline bool operator < (TIMESTAMP t) { return dt.timestamp<t; };
 	/// Compare before or same TIMESTAMP
-	inline bool operator <=(TIMESTAMP t) {
-		return dt.timestamp <= t;
-	}
-	;
+	inline bool operator <= (TIMESTAMP t) { return dt.timestamp<=t; };
 	/// Compare same TIMESTAMP
-	inline bool operator ==(TIMESTAMP t) {
-		return dt.timestamp == t;
-	}
-	;
+	inline bool operator == (TIMESTAMP t) { return dt.timestamp==t; };
 	/// Compare different TIMESTAMP
-	inline bool operator !=(TIMESTAMP t) {
-		return dt.timestamp != t;
-	}
-	;
+	inline bool operator != (TIMESTAMP t) { return dt.timestamp!=t; };
 	/// Check if valid TIMESTAMP
-	inline bool is_valid(void) {
-		return dt.timestamp > 0;
-	}
-	;
+	inline bool is_valid(void) { return dt.timestamp>0; };
 	/// Check if NEVER
-	inline bool is_never(void) {
-		return dt.timestamp == TS_NEVER;
-	}
-	;
+	inline bool is_never(void) { return dt.timestamp==TS_NEVER; };
 public: // read accessors
 	/// Get the year
-	inline unsigned short get_year(void) {
-		return dt.year;
-	}
-	;
+	inline unsigned short get_year(void) { return dt.year; };
 	/// Get the month (0-11)
-	inline unsigned short get_month(void) {
-		return dt.month;
-	}
-	;
+	inline unsigned short get_month(void) { return dt.month; };
 	/// Get the day (1-31)
-	inline unsigned short get_day(void) {
-		return dt.day;
-	}
-	;
+	inline unsigned short get_day(void) { return dt.day; };
 	/// Get the hour (0-23)
-	inline unsigned short get_hour(void) {
-		return dt.hour;
-	}
-	;
+	inline unsigned short get_hour(void) { return dt.hour; };
 	/// Get the minute (0-59)
-	inline unsigned short get_minute(void) {
-		return dt.minute;
-	}
-	;
+	inline unsigned short get_minute(void) { return dt.minute; };
 	/// Get the second (0-59)
-	inline unsigned short get_second(void) {
-		return dt.second;
-	}
-	;
+	inline unsigned short get_second(void) { return dt.second; };
 	/// Get the nanosecond (0-999999)
-	inline unsigned int get_nanosecond(void) {
-		return dt.nanosecond;
-	}
-	;
+	inline unsigned int get_nanosecond(void) { return dt.nanosecond; };
 	/// Get the Unix Day Number (full days since the Unix Epoch)
-	inline unsigned int get_uday(void) {
-		return dt.timestamp / 86400;
-	}
-	;
+	inline unsigned int get_uday(void) { return dt.timestamp / 86400; };
 	/// Get the Julian Day Number
-	inline unsigned int get_jday(void) {
-		return (dt.timestamp / 86400) + 2440587.5;
-	}
-	;
+	inline unsigned int get_jday(void) { return (dt.timestamp / 86400) + 2440587.5; };
 	/// Get the timezone spec
-	inline char* get_tz(void) {
-		return dt.tz;
-	}
-	;
+	inline char* get_tz(void) { return dt.tz; };
 	/// Get the summer/daylight time flag
-	inline bool get_is_dst(void) {
-		return dt.is_dst ? true : false;
-	}
-	;
+	inline bool get_is_dst(void) { return dt.is_dst?true:false; };
 	/// Get the weekday (Sunday=0)
-	inline unsigned short get_weekday(void) {
-		return dt.weekday;
-	}
-	;
+	inline unsigned short get_weekday(void) { return dt.weekday; };
 	/// Get the day of the year (Jan 1=0)
-	inline unsigned short get_yearday(void) {
-		return dt.yearday;
-	}
-	;
+	inline unsigned short get_yearday(void) { return dt.yearday; };
 	/// Get the timezone offer (in seconds)
-	inline int get_tzoffset(void) {
-		return dt.tzoffset;
-	}
-	;
+	inline int get_tzoffset(void) { return dt.tzoffset; };
 	/// Get the TIMESTAMP value (UTC)
-	inline TIMESTAMP get_timestamp(void) {
-		return dt.timestamp;
-	}
-	;
+	inline TIMESTAMP get_timestamp(void) { return dt.timestamp; };
 	/// Get the local TIMESTAMP value (ignoring DST)
-	inline TIMESTAMP get_localtimestamp(void) {
-		return dt.timestamp - dt.tzoffset;
-	}
-	;
+	inline TIMESTAMP get_localtimestamp(void) { return dt.timestamp - dt.tzoffset; };
 	/// Get the local TIMESTAMP value (including DST)
-	inline TIMESTAMP get_localtimestamp_dst(bool force_dst = false) {
-		return dt.timestamp - dt.tzoffset + (dt.is_dst || force_dst ? 3600 : 0);
-	}
-	;
+	inline TIMESTAMP get_localtimestamp_dst(bool force_dst=false) { return dt.timestamp - dt.tzoffset + (dt.is_dst||force_dst?3600:0); };
 public: // write accessors
 	/// Set the date
-	inline TIMESTAMP set_date(unsigned short y, unsigned short m,
-			unsigned short d) {
-		dt.year = y;
-		dt.month = m;
-		dt.day = d;
-		return callback->time.mkdatetime(&dt);
-	}
-	;
+	inline TIMESTAMP set_date(unsigned short y, unsigned short m, unsigned short d) { dt.year=y; dt.month=m; dt.day=d; return callback->time.mkdatetime(&dt); };
 	/// Set the time
-	inline TIMESTAMP set_time(unsigned short H, unsigned short M,
-			unsigned short S, unsigned long u = 0, char *t = NULL,
-			bool force_dst = false) {
-		dt.hour = H;
-		dt.minute = M;
-		dt.second = S;
-		dt.nanosecond = u;
-		strncpy(dt.tz, t, sizeof(dt.tz));
-		if (force_dst)
-			dt.is_dst = true;
-		return callback->time.mkdatetime(&dt);
-	}
-	;
+	inline TIMESTAMP set_time(unsigned short H, unsigned short M, unsigned short S, unsigned long u=0, char *t=NULL, bool force_dst=false) { dt.hour=H; dt.minute=M; dt.second=S; dt.nanosecond=u; strncpy(dt.tz,t,sizeof(dt.tz)); if (force_dst) dt.is_dst=true; return callback->time.mkdatetime(&dt); };
 	/// Set the date and time
-	inline TIMESTAMP set_datetime(unsigned short y, unsigned short m,
-			unsigned short d, unsigned short H, unsigned short M,
-			unsigned short S, unsigned long u = 0, char *t = NULL,
-			bool force_dst = false) {
-		dt.year = y;
-		dt.month = m;
-		dt.day = d;
-		dt.hour = H;
-		dt.minute = M;
-		dt.second = S;
-		dt.nanosecond = u;
-		strncpy(dt.tz, t, sizeof(dt.tz));
-		if (force_dst)
-			dt.is_dst = true;
-		return callback->time.mkdatetime(&dt);
-	}
-	;
+	inline TIMESTAMP set_datetime(unsigned short y, unsigned short m, unsigned short d, unsigned short H, unsigned short M, unsigned short S, unsigned long u=0, char *t=NULL, bool force_dst=false) { dt.year=y; dt.month=m; dt.day=d; dt.hour=H; dt.minute=M; dt.second=S; dt.nanosecond=u; strncpy(dt.tz,t,sizeof(dt.tz)); if (force_dst) dt.is_dst=true; return callback->time.mkdatetime(&dt); };
 	/// Set the year
-	inline TIMESTAMP set_year(unsigned short y) {
-		dt.year = y;
-		return callback->time.mkdatetime(&dt);
-	}
-	;
+	inline TIMESTAMP set_year(unsigned short y) { dt.year=y; return callback->time.mkdatetime(&dt); };
 	/// Set the month (Jan=0)
-	inline TIMESTAMP set_month(unsigned short m) {
-		dt.month = m;
-		return callback->time.mkdatetime(&dt);
-	}
-	;
+	inline TIMESTAMP set_month(unsigned short m) { dt.month=m; return callback->time.mkdatetime(&dt); };
 	/// Set the day (1-31)
-	inline TIMESTAMP set_day(unsigned short d) {
-		dt.day = d;
-		return callback->time.mkdatetime(&dt);
-	}
-	;
+	inline TIMESTAMP set_day(unsigned short d) { dt.day=d; return callback->time.mkdatetime(&dt); };
 	/// Set the hour (0-23)
-	inline TIMESTAMP set_hour(unsigned short h) {
-		dt.hour = h;
-		return callback->time.mkdatetime(&dt);
-	}
-	;
+	inline TIMESTAMP set_hour(unsigned short h) { dt.hour=h; return callback->time.mkdatetime(&dt); };
 	/// Set the minute (0-59)
-	inline TIMESTAMP set_minute(unsigned short m) {
-		dt.minute = m;
-		return callback->time.mkdatetime(&dt);
-	}
-	;
+	inline TIMESTAMP set_minute(unsigned short m) { dt.minute=m; return callback->time.mkdatetime(&dt); };
 	/// Set the second (0-59)
-	inline TIMESTAMP set_second(unsigned short s) {
-		dt.second = s;
-		return callback->time.mkdatetime(&dt);
-	}
-	;
+	inline TIMESTAMP set_second(unsigned short s) { dt.second=s; return callback->time.mkdatetime(&dt); };
 	/// Set the nanosecond (0-999999)
-	inline TIMESTAMP set_nanosecond(unsigned int u) {
-		dt.nanosecond = u;
-		return callback->time.mkdatetime(&dt);
-	}
-	;
+	inline TIMESTAMP set_nanosecond(unsigned int u) { dt.nanosecond=u; return callback->time.mkdatetime(&dt); };
 	/// Set the timezone (see tzinfo.txt)
-	inline TIMESTAMP set_tz(char *t) {
-		strncpy(dt.tz, t, sizeof(dt.tz));
-		return callback->time.mkdatetime(&dt);
-	}
-	;
+	inline TIMESTAMP set_tz(char* t) { strncpy(dt.tz,t,sizeof(dt.tz)); return callback->time.mkdatetime(&dt); };
 	/// Set the DST flag
-	inline TIMESTAMP set_is_dst(bool i) {
-		dt.is_dst = i;
-		return callback->time.mkdatetime(&dt);
-	}
-	;
+	inline TIMESTAMP set_is_dst(bool i) { dt.is_dst=i; return callback->time.mkdatetime(&dt); };
 public: // special functions
 	/// Convert from string
-	inline bool from_string(char *str) {
-		return callback->time.local_datetime(
-				callback->time.convert_to_timestamp(str), &dt) ? true : false;
-	}
-	;
+	inline bool from_string(char *str) { return callback->time.local_datetime(callback->time.convert_to_timestamp(str),&dt)?true:false; };
 	/// Convert to string
-	inline unsigned int to_string(char *str, int size) {
-		return callback->time.convert_from_timestamp(dt.timestamp, str, size);
-	}
-	;
+	inline unsigned int to_string(char *str, int size) {return callback->time.convert_from_timestamp(dt.timestamp,str,size); };
 	/// Extract the total number of days since 1/1/1970 0:00:00 UTC
-	inline double to_days(TIMESTAMP ts = 0) {
-		return (dt.timestamp - ts) / 86400.0 + dt.nanosecond * 1e-9;
-	}
-	;
+	inline double to_days(TIMESTAMP ts=0) { return (dt.timestamp-ts)/86400.0 + dt.nanosecond*1e-9; };
 	/// Extract the total number of hours since 1/1/1970 0:00:00 UTC
-	inline double to_hours(TIMESTAMP ts = 0) {
-		return (dt.timestamp - ts) / 3600.0 + dt.nanosecond * 1e-9;
-	}
-	;
+	inline double to_hours(TIMESTAMP ts=0) { return (dt.timestamp-ts)/3600.0 + dt.nanosecond*1e-9; };
 	/// Extract the total number of minutes since 1/1/1970 0:00:00 UTC
-	inline double to_minutes(TIMESTAMP ts = 0) {
-		return (dt.timestamp - ts) / 60.0 + dt.nanosecond * 1e-9;
-	}
-	;
+	inline double to_minutes(TIMESTAMP ts=0) { return (dt.timestamp-ts)/60.0 + dt.nanosecond*1e-9; };
 	/// Extract the total number of seconds since 1/1/1970 0:00:00 UTC
-	inline double to_seconds(TIMESTAMP ts = 0) {
-		return dt.timestamp - ts + dt.nanosecond * 1e-9;
-	}
-	;
+	inline double to_seconds(TIMESTAMP ts=0) { return dt.timestamp-ts + dt.nanosecond*1e-9; };
 	/// Extract the total number of nanoseconds since 1/1/1970 0:00:00 UTC
-	inline double to_nanoseconds(TIMESTAMP ts = 0) {
-		return (dt.timestamp - ts) * 1e9 + dt.nanosecond;
-	}
-	;
+	inline double to_nanoseconds(TIMESTAMP ts=0) { return (dt.timestamp-ts)*1e9 + dt.nanosecond; };
 	/// Get the timestamp as a string
-	inline gld_string get_string(const size_t sz = 1024) {
+	inline gld_string get_string(const size_t sz=1024) 
+	{
 		gld_string res;
 		char buf[1024];
-		if (sizeof(buf) < sz)
-			throw "get_string() over size limit";
-		if (to_string(buf, (int) sz) >= 0)
+		if ( sizeof(buf)<sz ) throw "get_string() over size limit";
+		if ( to_string(buf,(int)sz)>=0 )
 			res = buf;
 		return res;
-	}
-	;
+	};
 };
 
 /// Read lock container
 class gld_rlock {
-private:
-	OBJECT *my;
+private: OBJECT *my;
 	/// Constructor
-public:
-	inline gld_rlock(OBJECT *obj) :
-			my(obj) {
-		::rlock(&my->lock);
-	}
-	;
+public: inline gld_rlock(OBJECT *obj) : my(obj) {::rlock(&my->lock);}; 
 	/// Destructor
-public:
-	inline ~gld_rlock(void) {
-		::runlock(&my->lock);
-	}
-	;
+public: inline ~gld_rlock(void) {::runlock(&my->lock);};
 };
 /// Write lock container
 class gld_wlock {
-private:
-	OBJECT *my;
-	/// Constructor
-public:
-	inline gld_wlock(OBJECT *obj) :
-			my(obj) {
-		::wlock(&my->lock);
-	}
-	;
-	/// Destructor
-public:
-	inline ~gld_wlock(void) {
-		::wunlock(&my->lock);
-	}
-	;
+private: OBJECT *my;
+		 /// Constructor
+public: inline gld_wlock(OBJECT *obj) : my(obj) {::wlock(&my->lock);}; 
+		/// Destructor
+public: inline ~gld_wlock(void) {::wunlock(&my->lock);};
 };
 
 class gld_class;
@@ -1999,55 +1571,27 @@ private: // data
 
 public: // constructors/casts
 	/// Constructor
-	inline gld_module(void) {
-		MODULE *m = callback->module.getfirst();
-		if (m)
-			core = *m;
-		else
-			throw "no modules loaded";
-	}
-	;
+	inline gld_module(void) { MODULE *m = callback->module.getfirst(); if (m) core=*m; else throw "no modules loaded";};
 	/// Cast to MODULE
-	inline operator MODULE*(void) {
-		return &core;
-	}
-	;
+	inline operator MODULE*(void) { return &core; };
 
 public: // read accessors
 	/// Get module name
-	inline char* get_name(void) {
-		return core.name;
-	}
-	;
+	inline char* get_name(void) { return core.name; };
 	/// Get module major version number
-	inline unsigned short get_major(void) {
-		return core.major;
-	}
-	;
+	inline unsigned short get_major(void) { return core.major; };
 	/// Get module minor version number
-	inline unsigned short get_minor(void) {
-		return core.minor;
-	}
-	;
+	inline unsigned short get_minor(void) { return core.minor; };
 	/// Get first class in module
-	inline gld_class* get_first_class(void) {
-		return (gld_class*) core.oclass;
-	}
-	;
+	inline gld_class* get_first_class(void) { return (gld_class*)core.oclass; };
 
 public: // write accessors
 
 public: // iterators
 	/// Check if last module loaded
-	inline bool is_last(void) {
-		return core.next == NULL;
-	}
-	;
+	inline bool is_last(void) { return core.next==NULL; };
 	/// Get next module loaded
-	inline void get_next(void) {
-		core = *(core.next);
-	}
-	;
+	inline void get_next(void) { core = *(core.next); };
 };
 
 class gld_property;
@@ -2060,94 +1604,45 @@ private: // data
 
 public: // constructors
 	/// Constructor (blocker implementation)
-	inline gld_class(void) {
-		throw "gld_class constructor not permitted";
-	}
-	;
+	inline gld_class(void) { throw "gld_class constructor not permitted"; };
 	/// Cast to CLASS
-	inline operator CLASS*(void) {
-		return &core;
-	}
-	;
+	inline operator CLASS*(void) { return &core; };
 
 public: // read accessors
 	/// Get class name
-	inline char* get_name(void) {
-		return core.name;
-	}
-	;
+	inline char* get_name(void) { return core.name; };
 	/// Get class size
-	inline size_t get_size(void) {
-		return core.size;
-	}
-	;
+	inline size_t get_size(void) { return core.size; };
 	/// Get class parent
-	inline gld_class* get_parent(void) {
-		return (gld_class*) core.parent;
-	}
-	;
+	inline gld_class* get_parent(void) { return (gld_class*)core.parent; };
 	/// Get module that implements the class
-	inline gld_module* get_module(void) {
-		return (gld_module*) core.module;
-	}
-	;
+	inline gld_module* get_module(void) { return (gld_module*)core.module; };
 	/// Get the first property in the class
-	inline gld_property* get_first_property(void) {
-		return (gld_property*) core.pmap;
-	}
-	;
+	inline gld_property* get_first_property(void) { return (gld_property*)core.pmap; };
 	/// Get the next property in the class
-	inline gld_property* get_next_property(PROPERTY *p) {
-		PROPERTY *prop = (PROPERTY*) p->next;
-		return (prop && prop->oclass == &core) ? (gld_property*) prop : NULL;
-	}
-	;
+	inline gld_property* get_next_property(PROPERTY*p) { PROPERTY *prop=(PROPERTY*)p->next; return ( prop && prop->oclass==&core ) ? (gld_property*)prop : NULL; };
 	/// Get the first function in the class
-	inline gld_function* get_first_function(void) {
-		return (gld_function*) core.fmap;
-	}
-	;
+	inline gld_function* get_first_function(void) { return (gld_function*)core.fmap; };
 	/// Get the next function in the class
-	inline gld_function* get_next_function(FUNCTION *f) {
-		return (gld_function*) f->next;
-	}
-	;
+	inline gld_function* get_next_function(FUNCTION*f) { return (gld_function*)f->next; };
 	/// Get TRL 
-	inline TECHNOLOGYREADINESSLEVEL get_trl(void) {
-		return core.trl;
-	}
-	;
+	inline TECHNOLOGYREADINESSLEVEL get_trl(void) { return core.trl; };
 
 public: // write accessors
 	/// Set TRL
-	inline void set_trl(TECHNOLOGYREADINESSLEVEL t) {
-		core.trl = t;
-	}
-	;
+	inline void set_trl(TECHNOLOGYREADINESSLEVEL t) { core.trl=t; };
 
 public: // special functions
 	/// Register a class	
-	static inline CLASS* create(MODULE *m, char *n, size_t s, unsigned int f) {
-		return callback->register_class(m, n, (unsigned int) s, f);
-	}
-	;
-
+	static inline CLASS *create(MODULE *m, char *n, size_t s, unsigned int f) { return callback->register_class(m,n,(unsigned int)s,f); };
+	
 public: // iterators
 	/// Check if last class registered
-	inline bool is_last(void) {
-		return core.next == NULL;
-	}
-	;
+	inline bool is_last(void) { return core.next==NULL; };
 	/// Check if last class defined by this class' module
-	inline bool is_module_last(void) {
-		return core.next == NULL || core.module != core.next->module;
-	}
-	;
+	inline bool is_module_last(void) { return core.next==NULL || core.module!=core.next->module; };
 	/// Get the next class
-	inline gld_class* get_next(void) {
-		return (gld_class*) core.next;
-	}
-	;
+	inline gld_class* get_next(void) { return (gld_class*)core.next; };
 };
 
 /// Function container
@@ -2158,46 +1653,25 @@ private: // data
 
 public: // constructors
 	/// Construct a function (blocker implementation)
-	inline gld_function(void) {
-		throw "gld_function constructor not permitted";
-	}
-	;
+	inline gld_function(void) { throw "gld_function constructor not permitted"; };
 	/// Cast to a FUNCTION pointer
-	inline operator FUNCTION*(void) {
-		return &core;
-	}
-	;
+	inline operator FUNCTION*(void) { return &core; };
 
 public: // read accessors
 	/// Get function name
-	inline char* get_name(void) {
-		return core.name;
-	}
-	;
+	inline char *get_name(void) { return core.name; };
 	/// Get function class
-	inline gld_class* get_class(void) {
-		return (gld_class*) core.oclass;
-	}
-	;
+	inline gld_class* get_class(void) { return (gld_class*)core.oclass; };
 	/// Get function address
-	inline FUNCTIONADDR get_addr(void) {
-		return core.addr;
-	}
-	;
+	inline FUNCTIONADDR get_addr(void) { return core.addr; };
 
 public: // write accessors
 
 public: // iterators
 	/// Check whether this is the last function defined
-	inline bool is_last(void) {
-		return core.next == NULL;
-	}
-	;
+	inline bool is_last(void) { return core.next==NULL; };
 	/// Get the next function in the list
-	inline gld_function* get_next(void) {
-		return (gld_function*) core.next;
-	}
-	;
+	inline gld_function* get_next(void) { return (gld_function*)core.next; };
 };
 
 /// Built-in type container
@@ -2208,41 +1682,23 @@ private: // data
 
 public: // constructors/casts
 	/// Constructor
-	inline gld_type(PROPERTYTYPE t) :
-			type(t) {
-	}
-	;
+	inline gld_type(PROPERTYTYPE t) : type(t) {};
 	/// Cast to PROPERTYTYPE
-	inline operator PROPERTYTYPE(void) {
-		return type;
-	}
-	;
+	inline operator PROPERTYTYPE(void) { return type; };
 
 public: // read accessors
 	// TODO size,conversions,etc...
-	PROPERTYSPEC* get_spec(void) {
-		return callback->properties.get_spec(type);
-	}
-	;
+	PROPERTYSPEC *get_spec(void) { return callback->properties.get_spec(type);};
 
 public: // write accessors
 
 public: // iterators
 	/// Get the first property type
-	static inline PROPERTYTYPE get_first(void) {
-		return PT_double;
-	}
-	;
+	static inline PROPERTYTYPE get_first(void) { return PT_double; };
 	/// Get the next property type
-	inline PROPERTYTYPE get_next(void) {
-		return (PROPERTYTYPE)(((int) type) + 1);
-	}
-	;
+	inline PROPERTYTYPE get_next(void) { return (PROPERTYTYPE)(((int)type)+1); };
 	/// Check whether this is the last property type
-	inline bool is_last(void) {
-		return (PROPERTYTYPE)(((int) type) + 1) == _PT_LAST;
-	}
-	;
+	inline bool is_last(void) { return (PROPERTYTYPE)(((int)type)+1)==_PT_LAST; }; 
 };
 
 /// Unit container
@@ -2253,124 +1709,53 @@ private: // data
 
 public: // constructors/casts
 	/// Construct empty unit container
-	inline gld_unit(void) {
-		memset(&core, 0, sizeof(core));
-	}
-	;
+	inline gld_unit(void) { memset(&core,0,sizeof(core)); };
 	/// Construct a container for a named or derived unit
-	inline gld_unit(char *name) {
-		UNIT *unit = callback->unit_find(name);
-		if (unit)
-			memcpy(&core, unit, sizeof(UNIT));
-		else
-			memset(&core, 0, sizeof(UNIT));
-	}
-	;
+	inline gld_unit(char *name) { UNIT *unit=callback->unit_find(name); if (unit) memcpy(&core,unit,sizeof(UNIT)); else memset(&core,0,sizeof(UNIT)); };
 	/// Cast to a UNIT structure
-	inline operator UNIT*(void) {
-		return &core;
-	}
-	;
+	inline operator UNIT*(void) { return &core; };
 
 public: // read accessors
 	/// Get the name or derivation of the unit
-	inline char* get_name(void) {
-		return core.name;
-	}
-	;
+	inline char* get_name(void) { return core.name; };
 	/// Get the C exponent
-	inline double get_c(void) {
-		return core.c;
-	}
-	;
+	inline double get_c(void) { return core.c; };
 	/// Get the E exponent
-	inline double get_e(void) {
-		return core.e;
-	}
-	;
+	inline double get_e(void) { return core.e; };
 	/// Get the H exponent
-	inline double get_h(void) {
-		return core.h;
-	}
-	;
+	inline double get_h(void) { return core.h; };
 	/// Get the K exponent
-	inline double get_k(void) {
-		return core.k;
-	}
-	;
+	inline double get_k(void) { return core.k; };
 	/// Get the M exponent
-	inline double get_m(void) {
-		return core.m;
-	}
-	;
+	inline double get_m(void) { return core.m; };
 	/// Get the S exponent
-	inline double get_s(void) {
-		return core.s;
-	}
-	;
+	inline double get_s(void) { return core.s; };
 	/// Get the A constant
-	inline double get_a(void) {
-		return core.a;
-	}
-	;
+	inline double get_a(void) { return core.a; };
 	/// Get the B constant
-	inline double get_b(void) {
-		return core.b;
-	}
-	;
+	inline double get_b(void) { return core.b; };
 	/// Get the unit precision
-	inline int get_prec(void) {
-		return core.prec;
-	}
-	;
+	inline int get_prec(void) { return core.prec; };
 	/// Check whether the unit is valid
-	inline bool is_valid(void) {
-		return core.name[0] != '\0';
-	}
-	;
+	inline bool is_valid(void) { return core.name[0]!='\0'; };
 
 public: // write accessors
 	/// Change the unit
-	inline bool set_unit(char *name) {
-		UNIT *unit = callback->unit_find(name);
-		if (unit) {
-			memcpy(&core, unit, sizeof(UNIT));
-			return true;
-		} else {
-			memset(&core, 0, sizeof(UNIT));
-			return false;
-		}
-	}
-	;
+	inline bool set_unit(char *name){ UNIT *unit=callback->unit_find(name); if (unit) {memcpy(&core,unit,sizeof(UNIT));return true;} else {memset(&core,0,sizeof(UNIT));return false;} };
 
 public: // special functions
 	/// Convert a value to another named or derived unit
-	inline bool convert(char *name, double &value) {
-		UNIT *unit = callback->unit_find(name);
-		return unit && (callback->unit_convert_ex(&core, unit, &value)) ?
-				true : false;
-	}
+	inline bool convert(char *name, double &value) { UNIT *unit=callback->unit_find(name); return unit&&(callback->unit_convert_ex(&core,unit,&value))?true:false; }
 	/// Convert a value to another UNIT
-	inline bool convert(UNIT *unit, double &value) {
-		return callback->unit_convert_ex(&core, unit, &value) ? true : false;
-	}
+	inline bool convert(UNIT *unit, double &value) { return callback->unit_convert_ex(&core,unit,&value)?true:false; }
 	/// Convert a value to another gld_unit
-	inline bool convert(gld_unit &unit, double &value) {
-		return callback->unit_convert_ex(&core, (UNIT*) unit, &value) ?
-				true : false;
-	}
+	inline bool convert(gld_unit &unit, double &value) { return callback->unit_convert_ex(&core,(UNIT*)unit,&value)?true:false; }
 
 public: // iterators
 	/// Check whether this is the last defined unit
-	inline bool is_last(void) {
-		return core.next == NULL ? true : false;
-	}
-	;
+	inline bool is_last(void) { return core.next==NULL?true:false; };
 	/// Get the next unit
-	inline gld_unit* get_next(void) {
-		return (gld_unit*) core.next;
-	}
-	;
+	inline gld_unit* get_next(void) { return (gld_unit*)core.next; };
 };
 
 /// Keyword container
@@ -2381,118 +1766,47 @@ private: // data
 
 public: // constructors/casts
 	/// Construct a key word
-	inline gld_keyword(KEYWORD &key) {
-		core = key;
-	}
-	;
+	inline gld_keyword(KEYWORD &key) { core=key; };
 	/// Cast to a keyword pointer
-	inline operator KEYWORD*(void) {
-		return &core;
-	}
-	;
-	inline operator const char*(void) {
-		return core.name;
-	}
-	;
-	inline operator long unsigned int(void) {
-		return core.value;
-	}
-	;
+	inline operator KEYWORD* (void) { return &core; };
+	inline operator const char* (void) { return core.name; };
+	inline operator long unsigned int (void) { return core.value;};
 
 public: // read accessors
 	/// Get the name of a keyword
-	inline const char* get_name(void) {
-		return core.name;
-	}
-	;
+	inline const char* get_name(void) { return core.name; };
 	/// Get the bit pattern for the keyword
-	inline long unsigned int get_value(void) {
-		return core.value;
-	}
-	;
-	inline enumeration get_enumeration_value(void) {
-		return (enumeration) get_value();
-	}
-	;
-	inline set get_set_value(void) {
-		return (set) get_value();
-	}
-	;
+	inline long unsigned int get_value(void) { return core.value; };
+	inline enumeration get_enumeration_value(void) { return (enumeration)get_value(); };
+	inline set get_set_value(void) { return (set)get_value(); };
 
 public: // write accessors
-	inline int compare(const char *name) {
-		return strcmp(name, core.name);
-	}
-	;
-	inline bool operator ==(const char *name) {
-		return compare(name) == 0;
-	}
-	;
-	inline bool operator <=(const char *name) {
-		return compare(name) <= 0;
-	}
-	;
-	inline bool operator >=(const char *name) {
-		return compare(name) >= 0;
-	}
-	;
-	inline bool operator <(const char *name) {
-		return compare(name) < 0;
-	}
-	;
-	inline bool operator >(const char *name) {
-		return compare(name) > 0;
-	}
-	;
-	inline bool operator !=(const char *name) {
-		return compare(name) != 0;
-	}
-	;
-	inline int compare(long unsigned int value) {
-		return value < (long unsigned int) core.value ?
-				-1 : (value > core.value ? +1 : 0);
-	}
-	;
-	inline bool operator ==(long unsigned int value) {
-		return compare(value) == 0;
-	}
-	;
-	inline bool operator <=(long unsigned int value) {
-		return compare(value) <= 0;
-	}
-	;
-	inline bool operator >=(long unsigned int value) {
-		return compare(value) >= 0;
-	}
-	;
-	inline bool operator <(long unsigned int value) {
-		return compare(value) < 0;
-	}
-	;
-	inline bool operator >(long unsigned int value) {
-		return compare(value) > 0;
-	}
-	;
-	inline bool operator !=(long unsigned int value) {
-		return compare(value) != 0;
-	}
-	;
+	inline int compare(const char *name) { return strcmp(name,core.name); };
+	inline bool operator == (const char *name) { return compare(name)==0; };
+	inline bool operator <= (const char *name) { return compare(name)<=0; };
+	inline bool operator >= (const char *name) { return compare(name)>=0; };
+	inline bool operator < (const char *name) { return compare(name)<0; };
+	inline bool operator > (const char *name) { return compare(name)>0; };
+	inline bool operator != (const char *name) { return compare(name)!=0; };
+	inline int compare(long unsigned int value) { return value<(long unsigned int)core.value ? -1 : ( value>core.value ? +1 : 0 ); };
+	inline bool operator == (long unsigned int value) { return compare(value)==0; };
+	inline bool operator <= (long unsigned int value) { return compare(value)<=0; };
+	inline bool operator >= (long unsigned int value) { return compare(value)>=0; };
+	inline bool operator < (long unsigned int value) { return compare(value)<0; };
+	inline bool operator > (long unsigned int value) { return compare(value)>0; };
+	inline bool operator != (long unsigned int value) { return compare(value)!=0; };
 
 public: // iterators
 	/// Get the next keyword (NULL if last)
-	inline gld_keyword* get_next(void) {
-		return (gld_keyword*) core.next;
-	}
-	;
-	template<class T> inline gld_keyword* find(T value) {
-		if (compare(value) == 0)
-			return this;
-		if (get_next() == NULL)
-			return NULL;
+	inline gld_keyword* get_next(void) { return (gld_keyword*)core.next; };
+	template <class T> inline gld_keyword* find(T value)
+	{
+		if ( compare(value)==0 ) return this;
+		if ( get_next()==NULL ) return NULL;
 		return get_next()->find(value);
-	}
-	;
+	};
 };
+
 
 // object data declaration/accessors
 /// Define an atomic property
@@ -2564,324 +1878,118 @@ public: // iterators
 	inline void set_##X(char *str) { get_##X##_property().from_string(str); }; \
 
 /// Set bits of a bitflag property
-inline void setbits(unsigned long &flags, unsigned int bits) {
-	flags |= bits;
-}
-;
+inline void setbits(unsigned long &flags, unsigned int bits) { flags|=bits; }; 
 /// Clear bits of a bitflag property
-inline void clearbits(unsigned long &flags, unsigned int bits) {
-	flags &= ~bits;
-}
-;
+inline void clearbits(unsigned long &flags, unsigned int bits) { flags&=~bits; }; 
 /// Test bits of a bitflag property
-inline bool hasbits(unsigned long flags, unsigned int bits) {
-	return (flags & bits) ? true : false;
-}
-;
+inline bool hasbits(unsigned long flags, unsigned int bits) { return (flags&bits) ? true : false; };
 
 /// Object container
 class gld_object {
 public:
-	inline OBJECT* my() {
-		return this ? (((OBJECT*) this) - 1) : NULL;
-	}
+	inline OBJECT *my() { return this?(((OBJECT*)this)-1):NULL; }
 private:
 	// Make gld_object not copy-constructable.
 	gld_object& operator=(const gld_object&) = delete;
 
 public: // constructors
-	inline static gld_object* find_object(char *n) {
-		OBJECT *obj = callback->get_object(n);
-		if (obj)
-			return (gld_object*) (obj + 1);
-		else
-			return NULL;
-	}
-	;
+	inline static gld_object *find_object(char *n) { OBJECT *obj = callback->get_object(n); if (obj) return (gld_object*)(obj+1); else return NULL; };
 
 public: // header read accessors (no locking)
-	inline OBJECTNUM get_id(void) {
-		return my()->id;
-	}
-	;
-	inline char* get_groupid(void) {
-		return my()->groupid.get_string();
-	}
-	;
-	inline gld_class* get_oclass(void) {
-		return (gld_class*) my()->oclass;
-	}
-	;
-	inline gld_object* get_parent(void) {
-		return my()->parent ? OBJECTDATA(my()->parent, gld_object) : NULL;
-	}
-	;
-	inline OBJECTRANK get_rank(void) {
-		return my()->rank;
-	}
-	;
-	inline TIMESTAMP get_clock(void) {
-		return my()->clock;
-	}
-	;
-	inline TIMESTAMP get_valid_to(void) {
-		return my()->valid_to;
-	}
-	;
-	inline TIMESTAMP get_schedule_skew(void) {
-		return my()->schedule_skew;
-	}
-	;
-	inline FORECAST* get_forecast(void) {
-		return my()->forecast;
-	}
-	;
-	inline double get_latitude(void) {
-		return my()->latitude;
-	}
-	;
-	inline double get_longitude(void) {
-		return my()->longitude;
-	}
-	;
-	inline TIMESTAMP get_in_svc(void) {
-		return my()->in_svc;
-	}
-	;
-	inline TIMESTAMP get_out_svc(void) {
-		return my()->out_svc;
-	}
-	;
+	inline OBJECTNUM get_id(void) { return my()->id; };
+	inline char* get_groupid(void) { return my()->groupid.get_string(); };
+	inline gld_class* get_oclass(void) { return (gld_class*)my()->oclass; };
+	inline gld_object* get_parent(void) { return my()->parent?OBJECTDATA(my()->parent,gld_object):NULL; };
+	inline OBJECTRANK get_rank(void) { return my()->rank; };
+	inline TIMESTAMP get_clock(void) { return my()->clock; };
+	inline TIMESTAMP get_valid_to(void) { return my()->valid_to; };
+	inline TIMESTAMP get_schedule_skew(void) { return my()->schedule_skew; };
+	inline FORECAST* get_forecast(void) { return my()->forecast; };
+	inline double get_latitude(void) { return my()->latitude; };
+	inline double get_longitude(void) { return my()->longitude; };
+	inline TIMESTAMP get_in_svc(void) { return my()->in_svc; };
+	inline TIMESTAMP get_out_svc(void) { return my()->out_svc; };
 	inline const char* get_name(void) {
 		static char _name[sizeof(CLASS) + 16];
-		if (my()->name) {
-			return my()->name;
-		} else if (my()->oclass) {
-			snprintf(_name, sizeof(CLASS) + 16, "%s:%d", my()->oclass->name,
-					my()->id);
+		if(my()->name){
+				return my()->name;
+		} else if(my()->oclass){
+			snprintf(_name, sizeof(CLASS) + 16, "%s:%d",
+					my()->oclass->name, my()->id);
 		} else {
 			snprintf(_name, sizeof(CLASS) + 16, "Unknown");
 		}
 		return _name;
 	}
 	;
-	inline NAMESPACE* get_space(void) {
-		return my()->space;
-	}
-	;
-	inline unsigned int get_lock(void) {
-		return my()->lock;
-	}
-	;
-	inline unsigned int get_rng_state(void) {
-		return my()->rng_state;
-	}
-	;
-	inline TIMESTAMP get_heartbeat(void) {
-		return my()->heartbeat;
-	}
-	;
-	inline unsigned long get_flags(unsigned long mask = 0xffffffff) {
-		return (my()->flags) & mask;
-	}
-	;
+	inline NAMESPACE* get_space(void) { return my()->space; };
+	inline unsigned int get_lock(void) { return my()->lock; };
+	inline unsigned int get_rng_state(void) { return my()->rng_state; };
+	inline TIMESTAMP get_heartbeat(void) { return my()->heartbeat; };
+	inline unsigned long get_flags(unsigned long mask=0xffffffff) { return (my()->flags)&mask; };
 
 protected: // header write accessors (no locking)
-	inline void set_clock(TIMESTAMP ts = 0) {
-		my()->clock = (ts ? ts : gl_globalclock);
-	}
-	;
-	inline void set_heartbeat(TIMESTAMP dt) {
-		my()->heartbeat = dt;
-	}
-	;
-	inline void set_forecast(FORECAST *fs) {
-		my()->forecast = fs;
-	}
-	;
-	inline void set_latitude(double x) {
-		my()->latitude = x;
-	}
-	;
-	inline void set_longitude(double x) {
-		my()->longitude = x;
-	}
-	;
-	inline void set_flags(unsigned long flags) {
-		my()->flags = flags;
-	}
-	;
-	inline void set_flags_bits(unsigned long bits) {
-		my()->flags |= bits;
-	}
-	;
-	inline void unset_flags_bits(unsigned long bits) {
-		my()->flags &= ~bits;
-	}
-	;
+	inline void set_clock(TIMESTAMP ts=0) { my()->clock=(ts?ts:gl_globalclock); };
+	inline void set_heartbeat(TIMESTAMP dt) { my()->heartbeat=dt; };
+	inline void set_forecast(FORECAST *fs) { my()->forecast=fs; };
+	inline void set_latitude(double x) { my()->latitude=x; };
+	inline void set_longitude(double x) { my()->longitude=x; };
+	inline void set_flags(unsigned long flags) { my()->flags=flags; };
+	inline void set_flags_bits(unsigned long bits) { my()->flags|=bits; };
+	inline void unset_flags_bits(unsigned long bits) { my()->flags&=~bits; };
 
 protected: // locking (self)
-	inline void rlock(void) {
-		::rlock(&my()->lock);
-	}
-	;
-	inline void runlock(void) {
-		::runlock(&my()->lock);
-	}
-	;
-	inline void wlock(void) {
-		::wlock(&my()->lock);
-	}
-	;
-	inline void wunlock(void) {
-		::wunlock(&my()->lock);
-	}
-	;
+	inline void rlock(void) { ::rlock(&my()->lock); };
+	inline void runlock(void) { ::runlock(&my()->lock); };
+	inline void wlock(void) { ::wlock(&my()->lock); };
+	inline void wunlock(void) { ::wunlock(&my()->lock); };
 protected: // locking (others)
-	inline void rlock(OBJECT *obj) {
-		::rlock(&obj->lock);
-	}
-	;
-	inline void runlock(OBJECT *obj) {
-		::runlock(&obj->lock);
-	}
-	;
-	inline void wlock(OBJECT *obj) {
-		::wlock(&obj->lock);
-	}
-	;
-	inline void wunlock(OBJECT *obj) {
-		::wunlock(&obj->lock);
-	}
-	;
+	inline void rlock(OBJECT *obj) { ::rlock(&obj->lock); };
+	inline void runlock(OBJECT *obj) { ::runlock(&obj->lock); };
+	inline void wlock(OBJECT *obj) { ::wlock(&obj->lock); };
+	inline void wunlock(OBJECT *obj) { ::wunlock(&obj->lock); };
 
 protected: // special functions
-	inline bool operator ==(gld_object *o) {
-		return o != NULL && my() == o->my();
-	}
-	;
-	inline bool operator ==(OBJECT *o) {
-		return o != NULL && my() == o;
-	}
-	;
+	inline bool operator == (gld_object *o) { return o!=NULL && my()==o->my(); };
+	inline bool operator == (OBJECT *o) { return o!=NULL && my()==o; };
 
 public: // member lookup functions
-	inline PROPERTY* get_property(char *name, PROPERTYSTRUCT *pstruct = NULL) {
-		return callback->properties.get_property(my(), name, pstruct);
-	}
-	;
-	inline FUNCTIONADDR get_function(char *name) {
-		return (*callback->function.get)(my()->oclass->name, name);
-	}
-	;
+	inline PROPERTY* get_property(char *name, PROPERTYSTRUCT *pstruct=NULL) { return callback->properties.get_property(my(),name,pstruct); };
+	inline FUNCTIONADDR get_function(char *name) { return (*callback->function.get)(my()->oclass->name,name); };
 
 public: // external accessors
-	template<class T> inline void getp(PROPERTY &prop, T &value) {
-		rlock();
-		value = *(T*) (GETADDR(my(), &prop));
-		wunlock();
-	}
-	;
-	template<class T> inline void setp(PROPERTY &prop, T &value) {
-		wlock();
-		*(T*) (GETADDR(my(), &prop)) = value;
-		wunlock();
-	}
-	;
-	template<class T> inline void getp(PROPERTY &prop, T &value, gld_rlock&) {
-		value = *(T*) (GETADDR(my(), &prop));
-	}
-	;
-	template<class T> inline void getp(PROPERTY &prop, T &value, gld_wlock&) {
-		value = *(T*) (GETADDR(my(), &prop));
-	}
-	;
-	template<class T> inline void setp(PROPERTY &prop, T &value, gld_wlock&) {
-		*(T*) (GETADDR(my(), &prop)) = value;
-	}
-	;
+	template <class T> inline void getp(PROPERTY &prop, T &value) { rlock(); value=*(T*)(GETADDR(my(),&prop)); wunlock(); };
+	template <class T> inline void setp(PROPERTY &prop, T &value) { wlock(); *(T*)(GETADDR(my(),&prop))=value; wunlock(); };
+	template <class T> inline void getp(PROPERTY &prop, T &value, gld_rlock&) { value=*(T*)(GETADDR(my(),&prop)); };
+	template <class T> inline void getp(PROPERTY &prop, T &value, gld_wlock&) { value=*(T*)(GETADDR(my(),&prop)); };
+	template <class T> inline void setp(PROPERTY &prop, T &value, gld_wlock&) { *(T*)(GETADDR(my(),&prop))=value; };
 
 public: // core interface
-	inline int set_dependent(OBJECT *obj) {
-		return callback->object.set_dependent(my(), obj);
-	}
-	;
-	inline int set_parent(OBJECT *obj) {
-		return callback->object.set_parent(my(), obj);
-	}
-	;
-	inline int set_rank(unsigned int r) {
-		return callback->object.set_rank(my(), r);
-	}
-	;
-	inline bool isa(char *type) {
-		return callback->object_isa(my(), type) ? true : false;
-	}
-	;
-	inline bool is_valid(void) {
-		return my() != NULL && my() == OBJECTHDR(this);
-	}
-	;
+	inline int set_dependent(OBJECT *obj) { return callback->object.set_dependent(my(),obj); };
+	inline int set_parent(OBJECT *obj) { return callback->object.set_parent(my(),obj); };
+	inline int set_rank(unsigned int r) { return callback->object.set_rank(my(),r); };
+	inline bool isa(char *type) { return callback->object_isa(my(),type) ? true : false; };
+	inline bool is_valid(void) { return my()!=NULL && my()==OBJECTHDR(this); };
 
 public: // iterators
-	inline bool is_last(void) {
-		return my()->next == NULL;
-	}
-	;
-	inline static gld_object* get_first(void) {
-		OBJECT *o = callback->object.get_first();
-		return OBJECTDATA(o, gld_object);
-	}
-	;
-	inline gld_object* get_next(void) {
-		return OBJECTDATA(my()->next, gld_object);
-	}
-	;
+	inline bool is_last(void) { return my()->next==NULL; };
+	inline static gld_object *get_first(void) { OBJECT *o=callback->object.get_first(); return OBJECTDATA(o,gld_object);};
+	inline gld_object* get_next(void) { return OBJECTDATA(my()->next,gld_object); };
 
 public: // exceptions
-	inline void exception(const char *msg, ...) {
-		static char buf[1024];
-		va_list ptr;
-		va_start(ptr, msg);
-		vsprintf(buf + sprintf(buf, "%s: ", get_name()), msg, ptr);
-		va_end(ptr);
-		throw(const char*) buf;
-	}
-	;
-	inline void error(const char *msg, ...) {
-		static char buf[1024];
-		va_list ptr;
-		va_start(ptr, msg);
-		vsprintf(buf + sprintf(buf, "%s: ", get_name()), msg, ptr);
-		va_end(ptr);
-		gl_error("%s", buf);
-	}
-	;
-	inline void warning(const char *msg, ...) {
-		static char buf[1024];
-		va_list ptr;
-		va_start(ptr, msg);
-		vsprintf(buf + sprintf(buf, "%s: ", get_name()), msg, ptr);
-		va_end(ptr);
-		gl_warning("%s", buf);
-	}
-	;
-	inline void debug(const char *msg, ...) {
-		static char buf[1024];
-		va_list ptr;
-		va_start(ptr, msg);
-		vsprintf(buf + sprintf(buf, "%s: ", get_name()), msg, ptr);
-		va_end(ptr);
-		gl_debug("%s", buf);
-	}
-	;
+	inline void exception(const char *msg, ...) { static char buf[1024]; va_list ptr; va_start(ptr,msg); vsprintf(buf+sprintf(buf,"%s: ",get_name()),msg,ptr); va_end(ptr); throw (const char*)buf;};
+	inline void error(const char *msg, ...) { static char buf[1024]; va_list ptr; va_start(ptr,msg); vsprintf(buf+sprintf(buf,"%s: ",get_name()),msg,ptr); va_end(ptr); gl_error("%s",buf);};
+	inline void warning(const char *msg, ...) { static char buf[1024]; va_list ptr; va_start(ptr,msg); vsprintf(buf+sprintf(buf,"%s: ",get_name()),msg,ptr); va_end(ptr); gl_warning("%s",buf);};
+	inline void debug(const char *msg, ...) { static char buf[1024]; va_list ptr; va_start(ptr,msg); vsprintf(buf+sprintf(buf,"%s: ",get_name()),msg,ptr); va_end(ptr); gl_debug("%s",buf);};
 };
 /// Create a gld_object from an OBJECT
-static inline gld_object* get_object(OBJECT *obj) {
-	return obj ? (gld_object*) (obj + 1) : NULL;
+static inline gld_object* get_object(OBJECT*obj)
+{
+	return obj ? (gld_object*)(obj+1) : NULL;
 }
 /// Find a gld_object from an object name
-static inline gld_object* get_object(char *n) {
+static inline gld_object* get_object(char *n)
+{
 	OBJECT *obj = callback->get_object(n);
 	return get_object(obj);
 }
@@ -2895,518 +2003,195 @@ private: // data
 	OBJECT *obj;
 
 public: // constructors/casts
-	inline gld_property(void) :
-			obj(NULL), pstruct(nullpstruct) {
-	}
-	;
-	inline gld_property(gld_object *o, char *n) :
-			obj(o->my()), pstruct(nullpstruct) {
-		if (o)
-			callback->properties.get_property(o->my(), n, &pstruct);
-		else {
-			GLOBALVAR *v = callback->global.find(n);
-			pstruct.prop = (v ? v->prop : NULL);
-		}
-	}
-	;
-	inline gld_property(OBJECT *o, char *n) :
-			obj(o), pstruct(nullpstruct) {
-		if (o)
-			callback->properties.get_property(o, n, &pstruct);
-		else {
-			GLOBALVAR *v = callback->global.find(n);
-			pstruct.prop = (v ? v->prop : NULL);
-		}
-	}
-	;
-	inline gld_property(OBJECT *o) :
-			obj(o), pstruct(nullpstruct) {
-		pstruct.prop = o->oclass->pmap;
-	}
-	;
-	inline gld_property(OBJECT *o, PROPERTY *p) :
-			obj(o), pstruct(nullpstruct) {
-		pstruct.prop = p;
-	}
-	;
-	inline gld_property(OBJECT *o, PROPERTYSTRUCT *p) :
-			obj(o), pstruct(nullpstruct) {
-		pstruct = *p;
-	}
-	;
-	inline gld_property(GLOBALVAR *v) :
-			obj(NULL), pstruct(nullpstruct) {
-		pstruct.prop = v->prop;
-	}
-	;
-	inline gld_property(char *n) :
-			obj(NULL), pstruct(nullpstruct) {
+	inline gld_property(void) : obj(NULL), pstruct(nullpstruct) {};
+	inline gld_property(gld_object *o, char *n) : obj(o->my()), pstruct(nullpstruct)  
+	{ 
+		if (o) 
+			callback->properties.get_property(o->my(),n,&pstruct); 
+		else 
+		{
+			GLOBALVAR *v=callback->global.find(n); 
+			pstruct.prop= (v?v->prop:NULL);
+		} 
+	};
+	inline gld_property(OBJECT *o, char *n) : obj(o), pstruct(nullpstruct)  
+	{ 
+		if (o) 
+			callback->properties.get_property(o,n,&pstruct); 
+		else 
+		{
+			GLOBALVAR *v=callback->global.find(n); 
+			pstruct.prop= (v?v->prop:NULL);
+		} 
+	};
+	inline gld_property(OBJECT *o) : obj(o), pstruct(nullpstruct) { pstruct.prop=o->oclass->pmap; };
+	inline gld_property(OBJECT *o, PROPERTY *p) : obj(o), pstruct(nullpstruct) { pstruct.prop=p; };
+	inline gld_property(OBJECT *o, PROPERTYSTRUCT *p) : obj(o), pstruct(nullpstruct) { pstruct=*p; };
+	inline gld_property(GLOBALVAR *v) : obj(NULL), pstruct(nullpstruct) { pstruct.prop=v->prop; };
+	inline gld_property(char *n) : obj(NULL), pstruct(nullpstruct)
+	{
 		char oname[256], vname[256];
-		if (sscanf(n, "%[A-Za-z0-9_].%[A-Za-z0-9_.]", oname, vname) == 2) {
+		if ( sscanf(n,"%[A-Za-z0-9_].%[A-Za-z0-9_.]",oname,vname)==2 )
+		{
 			obj = callback->get_object(oname);
-			if (obj) {
-				callback->properties.get_property(obj, vname, &pstruct);
+			if ( obj )
+			{
+				callback->properties.get_property(obj,vname,&pstruct);
 				return;
 			}
 		}
-		GLOBALVAR *v = callback->global.find(n);
-		pstruct.prop = (v ? v->prop : NULL);
-	}
-	;
-	inline gld_property(char *m, char *n) :
-			obj(NULL), pstruct(nullpstruct) {
+		GLOBALVAR *v=callback->global.find(n); 
+		pstruct.prop = (v?v->prop:NULL);  
+	};
+	inline gld_property(char *m, char *n) : obj(NULL), pstruct(nullpstruct) 
+	{
 		obj = callback->get_object(m);
-		if (obj != NULL) {
+		if ( obj != NULL ) {
 			callback->properties.get_property(obj, n, &pstruct);
 			return;
-		}
-		char1024 vn;
-		sprintf(vn, "%s::%s", m, n);
-		GLOBALVAR *v = callback->global.find(vn);
-		pstruct.prop = (v ? v->prop : NULL);
-	}
-	;
-	inline operator PROPERTY*(void) {
-		return pstruct.prop;
-	}
-	;
-	inline operator OBJECT*(void) {
-		return obj;
-	}
-	;
+		} 
+		char1024 vn; 
+		sprintf(vn,"%s::%s",m,n); 
+		GLOBALVAR *v=callback->global.find(vn); 
+		pstruct.prop= (v?v->prop:NULL);  
+	};
+	inline operator PROPERTY*(void) { return pstruct.prop; };
+	inline operator OBJECT*(void) { return obj; };
 
 public: // read accessors
-	inline OBJECT* get_object(void) {
-		return obj;
-	}
-	;
-	inline PROPERTY* get_property(void) {
-		return pstruct.prop;
-	}
-	;
-	inline PROPERTYSTRUCT* get_property_struct(void) {
-		return &pstruct;
-	}
-	;
-	inline gld_class* get_class(void) {
-		return (gld_class*) pstruct.prop->oclass;
-	}
-	;
-	inline char* get_name(void) {
-		return pstruct.prop->name;
-	}
-	;
-	inline char* get_sql_safe_name(char *return_val) {
+	inline OBJECT *get_object(void) { return obj; };
+	inline PROPERTY *get_property(void) { return pstruct.prop; };
+	inline PROPERTYSTRUCT *get_property_struct(void) { return &pstruct; };
+	inline gld_class* get_class(void) { return (gld_class*)pstruct.prop->oclass; };
+	inline char *get_name(void) { return pstruct.prop->name; };
+	inline char *get_sql_safe_name(char* return_val) {
 		if (pstruct.part[0] != '\0') {
 			sprintf(return_val, "%s_%s", pstruct.prop->name, pstruct.part);
 		} else {
 			sprintf(return_val, "%s", pstruct.prop->name);
 		}
 		return return_val;
-	}
-	;
-	inline gld_type get_type(void) {
-		return gld_type(pstruct.prop->ptype);
-	}
-	;
-	inline size_t get_size(void) {
-		return (size_t)(pstruct.prop->size);
-	}
-	;
-	inline size_t get_width(void) {
-		return (size_t)(pstruct.prop->width);
-	}
-	;
-	inline PROPERTYACCESS get_access(void) {
-		return pstruct.prop->access;
-	}
-	;
-	inline bool get_access(unsigned int bits, unsigned int mask = 0xffff) {
-		return ((pstruct.prop->access & mask) | bits);
-	}
-	;
-	inline gld_unit* get_unit(void) {
-		return (gld_unit*) pstruct.prop->unit;
-	}
-	;
-	inline void* get_addr(void) {
-	return obj?((void*)((char*)(obj+1)+(unsigned int64)(pstruct.prop->addr))):pstruct.prop->addr;}
-;
-inline gld_keyword* get_first_keyword(void) {
-	return (gld_keyword*) pstruct.prop->keywords;
-}
-;
-inline char* get_description(void) {
-	return pstruct.prop->description;
-}
-;
-inline PROPERTYFLAGS get_flags(void) {
-	return pstruct.prop->flags;
-}
-;
-inline int to_string(char *buffer, int size) {
-	return callback->convert.property_to_string(pstruct.prop, get_addr(),
-			buffer, size);
-}
-;
-inline gld_string get_string(const size_t sz = 1024) {
-	gld_string res;
-	char buf[1024];
-	if (sizeof(buf) < sz)
-		throw "get_string() over size limit";
-	if (to_string(buf, (int) sz) >= 0)
-		res = buf;
-	return res;
-}
-;
-inline int from_string(char *string) {
-	return callback->convert.string_to_property(pstruct.prop, get_addr(),
-			string);
-}
-;
-inline char* get_partname(void) {
-	return pstruct.part;
-}
-;
-inline double get_part(char *part = NULL) {
-	return callback->properties.get_part(obj, pstruct.prop,
-			part ? part : pstruct.part);
-}
-;
+	};
+	inline gld_type get_type(void) { return gld_type(pstruct.prop->ptype); };
+	inline size_t get_size(void) { return (size_t)(pstruct.prop->size); };
+	inline size_t get_width(void) { return (size_t)(pstruct.prop->width); };
+	inline PROPERTYACCESS get_access(void) { return pstruct.prop->access; };
+	inline bool get_access(unsigned int bits, unsigned int mask=0xffff) {  return ((pstruct.prop->access&mask)|bits); };
+	inline gld_unit* get_unit(void) { return (gld_unit*)pstruct.prop->unit; };
+	inline void* get_addr(void) { return obj?((void*)((char*)(obj+1)+(unsigned int64)(pstruct.prop->addr))):pstruct.prop->addr; };
+	inline gld_keyword* get_first_keyword(void) { return (gld_keyword*)pstruct.prop->keywords; };
+	inline char* get_description(void) { return pstruct.prop->description; };
+	inline PROPERTYFLAGS get_flags(void) { return pstruct.prop->flags; };
+	inline int to_string(char *buffer, int size) { return callback->convert.property_to_string(pstruct.prop,get_addr(),buffer,size); };
+	inline gld_string get_string(const size_t sz=1024)
+	{
+		gld_string res;
+		char buf[1024];
+		if ( sizeof(buf)<sz ) throw "get_string() over size limit";
+		if ( to_string(buf,(int)sz)>=0 )
+			res = buf;
+		return res;
+	};
+	inline int from_string(char *string) { return callback->convert.string_to_property(pstruct.prop,get_addr(),string); };
+	inline char *get_partname(void) { return pstruct.part; };
+	inline double get_part(char *part=NULL) { return callback->properties.get_part(obj,pstruct.prop,part?part:pstruct.part); };
 
 public: // write accessors
-inline void set_object(OBJECT *o) {
-	obj = o;
-}
-;
-inline void set_object(gld_object *o) {
-	obj = o->my();
-}
-;
-inline void set_property(char *n) {
-	callback->properties.get_property(obj, n, &pstruct);
-}
-;
-inline void set_property(PROPERTY *p) {
-	pstruct.prop = p;
-}
-;
+	inline void set_object(OBJECT *o) { obj=o; };
+	inline void set_object(gld_object *o) { obj=o->my(); };
+	inline void set_property(char *n) { callback->properties.get_property(obj,n,&pstruct); };
+	inline void set_property(PROPERTY *p) { pstruct.prop=p; };
 
 public: // special operations
-inline bool is_valid(void) {
-	return pstruct.prop != NULL;
-}
-inline bool has_part(void) {
-	return pstruct.part[0] != '\0';
-}
-;
-inline bool is_complex(void) {
-	if (pstruct.prop->ptype == PT_complex)
-		return true;
-	return false;
-}
-inline bool is_double(void) {
-	switch (pstruct.prop->ptype) {
-	case PT_double:
-	case PT_random:
-	case PT_enduse:
-	case PT_loadshape:
-		return true;
-	default:
-		return false;
-	}
-}
-;
-inline bool is_integer(void) {
-	switch (pstruct.prop->ptype) {
-	case PT_int16:
-	case PT_int32:
-	case PT_int64:
-		return true;
-	default:
-		return false;
-	}
-}
-;
-inline bool is_enumeration(void) {
-	return pstruct.prop->ptype == PT_enumeration;
-}
-;
-inline bool is_set(void) {
-	return pstruct.prop->ptype == PT_set;
-}
-;
-inline bool is_character(void) {
-	switch (pstruct.prop->ptype) {
-	case PT_char8:
-	case PT_char32:
-	case PT_char256:
-	case PT_char1024:
-		return true;
-	default:
-		return false;
-	}
-}
-;
-inline bool is_random(void) {
-	return pstruct.prop->ptype == PT_random;
-}
-;
-inline bool is_enduse(void) {
-	return pstruct.prop->ptype == PT_enduse;
-}
-;
-inline bool is_loadshape(void) {
-	return pstruct.prop->ptype == PT_loadshape;
-}
-;
-inline bool is_double_array(void) {
-	return pstruct.prop->ptype == PT_double_array;
-}
-;
-inline bool is_complex_array(void) {
-	return pstruct.prop->ptype == PT_complex_array;
-}
-;
-inline bool is_objectref(void) {
-	return pstruct.prop->ptype == PT_object;
-}
-;
-inline bool is_bool(void) {
-	return pstruct.prop->ptype == PT_bool;
-}
-;
-inline bool is_timestamp(void) {
-	return pstruct.prop->ptype == PT_timestamp;
-}
-;
+	inline bool is_valid(void) { return pstruct.prop!=NULL; }
+	inline bool has_part(void) { return pstruct.part[0]!='\0'; };
+	inline bool is_complex(void) { if(pstruct.prop->ptype == PT_complex) return true; return false;}
+	inline bool is_double(void) { switch(pstruct.prop->ptype) { case PT_double: case PT_random: case PT_enduse: case PT_loadshape: return true; default: return false;} };
+	inline bool is_integer(void) { switch(pstruct.prop->ptype) { case PT_int16: case PT_int32: case PT_int64: return true; default: return false;} };
+	inline bool is_enumeration(void) { return pstruct.prop->ptype==PT_enumeration; };
+	inline bool is_set(void) { return pstruct.prop->ptype==PT_set; };
+	inline bool is_character(void) { switch(pstruct.prop->ptype) { case PT_char8: case PT_char32: case PT_char256: case PT_char1024: return true; default: return false;} };
+	inline bool is_random(void) { return pstruct.prop->ptype==PT_random; };
+	inline bool is_enduse(void) { return pstruct.prop->ptype==PT_enduse; };
+	inline bool is_loadshape(void) { return pstruct.prop->ptype==PT_loadshape; };
+	inline bool is_double_array(void) { return pstruct.prop->ptype==PT_double_array; };
+	inline bool is_complex_array(void) { return pstruct.prop->ptype==PT_complex_array; };
+	inline bool is_objectref(void) { return pstruct.prop->ptype==PT_object; };
+	inline bool is_bool(void) { return pstruct.prop->ptype==PT_bool; };
+	inline bool is_timestamp(void) { return pstruct.prop->ptype==PT_timestamp; };
 
-// TODO these need to use throw instead of returning overloaded values
-inline double get_double(void) {
-	errno = 0;
-	switch (pstruct.prop->ptype) {
-	case PT_double:
-	case PT_random:
-	case PT_enduse:
-	case PT_loadshape:
-		return has_part() ? get_part() : *(double*) get_addr();
-	default:
-		errno = EINVAL;
-		return NaN;
-	}
-}
-;
-inline double get_double(UNIT *to) {
-	double rv = get_double();
-	return get_unit()->convert(to, rv) ? rv : QNAN;
-}
-;
-inline double get_double(gld_unit &to) {
-	double rv = get_double();
-	return get_unit()->convert(to, rv) ? rv : QNAN;
-}
-;
-inline double get_double(char *to) {
-	double rv = get_double();
-	return get_unit()->convert(to, rv) ? rv : QNAN;
-}
-;
-inline complex get_complex(void) {
-	errno = 0;
-	if (pstruct.prop->ptype == PT_complex)
-		return *(complex*) get_addr();
-	else
-		return complex(QNAN, QNAN);
-}
-;
-inline int64 get_integer(void) {
-	errno = 0;
-	switch (pstruct.prop->ptype) {
-	case PT_int16:
-		return (int64) * (int16*) get_addr();
-	case PT_int32:
-		return (int64) * (int32*) get_addr();
-	case PT_int64:
-		return *(int64*) get_addr();
-	default:
-		errno = EINVAL;
-		return 0;
-	}
-}
-;
+	// TODO these need to use throw instead of returning overloaded values
+	inline double get_double(void) { errno=0; switch(pstruct.prop->ptype) { case PT_double: case PT_random: case PT_enduse: case PT_loadshape: return has_part() ? get_part() : *(double*)get_addr(); default: errno=EINVAL; return NaN;} };
+	inline double get_double(UNIT*to) { double rv = get_double(); return get_unit()->convert(to,rv) ? rv : QNAN; };
+	inline double get_double(gld_unit&to) { double rv = get_double(); return get_unit()->convert(to,rv) ? rv : QNAN; };
+	inline double get_double(char*to) { double rv = get_double(); return get_unit()->convert(to,rv) ? rv : QNAN; };
+	inline complex get_complex(void) { errno=0; if ( pstruct.prop->ptype==PT_complex ) return *(complex*)get_addr(); else return complex(QNAN,QNAN); };
+	inline int64 get_integer(void) { errno=0; switch(pstruct.prop->ptype) { case PT_int16: return (int64)*(int16*)get_addr(); case PT_int32: return (int64)*(int32*)get_addr(); case PT_int64: return *(int64*)get_addr(); default: errno=EINVAL; return 0;} };
 //	inline TIMESTAMP get_timestamp(void) { if (pstruct.prop->ptype == PT_timestamp) return *(TIMESTAMP*)get_addr(); exception("get_timestamp() called on a property that is not a timestamp"); };
-inline TIMESTAMP get_timestamp(void) {
-	if (pstruct.prop->ptype != PT_timestamp)
-		exception(
-				"get_timestamp() called on a property that is not a timestamp");
-	return *(TIMESTAMP*) get_addr();
-}
-;
+	inline TIMESTAMP get_timestamp(void) { if (pstruct.prop->ptype != PT_timestamp) exception("get_timestamp() called on a property that is not a timestamp");return *(TIMESTAMP*) get_addr();};
 //	inline enumeration get_enumeration(void) { if ( pstruct.prop->ptype == PT_enumeration ) return *(enumeration*)get_addr(); exception("get_enumeration() called on a property that is not an enumeration"); };
-inline enumeration get_enumeration(void) {
-	if (pstruct.prop->ptype != PT_enumeration)
-		exception(
-				"get_enumeration() called on a property that is not an enumeration");
-	return *(enumeration*) get_addr();
-}
-;
+	inline enumeration get_enumeration(void) { if ( pstruct.prop->ptype != PT_enumeration ) exception("get_enumeration() called on a property that is not an enumeration"); return *(enumeration*)get_addr(); };
 //	inline set get_set(void) { if ( pstruct.prop->ptype == PT_set ) return *(set*)get_addr(); exception("get_set() called on a property that is not a set"); };
-inline set get_set(void) {
-	if (pstruct.prop->ptype != PT_set)
-		exception("get_set() called on a property that is not a set");
-	return *(set*) get_addr();
-}
-;
-inline gld_object* get_objectref(void) {
-	if (is_objectref())
-		return ::get_object(*(OBJECT**) get_addr());
-	else
-		return NULL;
-}
-;
-template<class T> inline void getp(T &value) {
-	::rlock(&obj->lock);
-	value = *(T*) get_addr();
-	::runlock(&obj->lock);
-}
-;
-template<class T> inline void setp(T &value) {
-	::wlock(&obj->lock);
-	*(T*) get_addr() = value;
-	::wunlock(&obj->lock);
-}
-;
-template<class T> inline void getp(T &value, gld_rlock&) {
-	value = *(T*) get_addr();
-}
-;
-template<class T> inline void getp(T &value, gld_wlock&) {
-	value = *(T*) get_addr();
-}
-;
-template<class T> inline void setp(T &value, gld_wlock&) {
-	*(T*) get_addr() = value;
-}
-;
-inline void setp(enumeration value) {
-	::wlock(&obj->lock);
-	*(enumeration*) get_addr() = value;
-	::wunlock(&obj->lock);
-}
-;
-inline void setp(set value) {
-	::wlock(&obj->lock);
-	*(set*) get_addr() = value;
-	::wunlock(&obj->lock);
-}
-;
-inline gld_keyword* find_keyword(unsigned long value) {
-	return get_first_keyword()->find(value);
-}
-;
-inline gld_keyword* find_keyword(const char *name) {
-	return get_first_keyword()->find(name);
-}
-;
-inline bool compare(char *op, char *a, char *b = NULL, char *p = NULL) {
-	PROPERTYCOMPAREOP n = callback->properties.get_compare_op(
-			pstruct.prop->ptype, op);
-	if (n == TCOP_ERR)
-		throw "invalid property compare operation";
-	return compare((enumeration) n, a, b, p);
-}
-;
-inline bool compare(enumeration op, char *a, char *b = NULL) {
-	char v1[1024], v2[1024];
-	return callback->convert.string_to_property(pstruct.prop, (void*) v1, a) > 0
-			&& callback->properties.compare_basic(pstruct.prop->ptype,
-					(PROPERTYCOMPAREOP) op, get_addr(), (void*) v1,
-					(b
-							&& callback->convert.string_to_property(
-									pstruct.prop, (void*) v2, b) > 0) ?
-							(void*) v2 : NULL, NULL);
-}
-;
-inline bool compare(enumeration op, char *a, char *b, char *p) {
-	double v1, v2;
-	v1 = atof(a);
-	v2 = b ? atof(b) : 0;
-	return callback->properties.compare_basic(pstruct.prop->ptype,
-			(PROPERTYCOMPAREOP) op, get_addr(), (void*) &v1,
-			b ? (void*) &v2 : NULL, p);
-}
-;
-inline bool compare(enumeration op, double *a, double *b = NULL,
-		char *p = NULL) {
-	return callback->properties.compare_basic(pstruct.prop->ptype,
-			(PROPERTYCOMPAREOP) op, get_addr(), a, b, p);
-}
-;
-inline bool compare(enumeration op, void *a, void *b = NULL) {
-	return callback->properties.compare_basic(pstruct.prop->ptype,
-			(PROPERTYCOMPAREOP) op, get_addr(), a, b, NULL);
-}
-;
+	inline set get_set(void) { if ( pstruct.prop->ptype != PT_set ) exception("get_set() called on a property that is not a set"); return *(set*)get_addr(); };
+	inline gld_object* get_objectref(void) { if ( is_objectref() ) return ::get_object(*(OBJECT**)get_addr()); else return NULL; };
+	template <class T> inline void getp(T &value) { ::rlock(&obj->lock); value = *(T*)get_addr(); ::runlock(&obj->lock); };
+	template <class T> inline void setp(T &value) { ::wlock(&obj->lock); *(T*)get_addr()=value; ::wunlock(&obj->lock); };
+	template <class T> inline void getp(T &value, gld_rlock&) { value = *(T*)get_addr(); };
+	template <class T> inline void getp(T &value, gld_wlock&) { value = *(T*)get_addr(); };
+	template <class T> inline void setp(T &value, gld_wlock&) { *(T*)get_addr()=value; };
+	inline void setp(enumeration value) { ::wlock(&obj->lock); *(enumeration*)get_addr()=value; ::wunlock(&obj->lock); };
+	inline void setp(set value) { ::wlock(&obj->lock); *(set*)get_addr()=value; ::wunlock(&obj->lock); };
+	inline gld_keyword* find_keyword(unsigned long value) { return get_first_keyword()->find(value); };
+	inline gld_keyword* find_keyword(const char *name) { return get_first_keyword()->find(name); };
+	inline bool compare(char *op, char *a, char *b=NULL, char *p=NULL) 
+	{ 
+		PROPERTYCOMPAREOP n = callback->properties.get_compare_op(pstruct.prop->ptype,op); 
+		if (n==TCOP_ERR) throw "invalid property compare operation"; 
+		return compare((enumeration)n,a,b,p); 
+	};
+	inline bool compare(enumeration op, char *a, char *b=NULL) 
+	{ 
+		char v1[1024], v2[1024]; 
+		return callback->convert.string_to_property(pstruct.prop,(void*)v1,a)>0 && callback->properties.compare_basic(pstruct.prop->ptype,(PROPERTYCOMPAREOP)op,get_addr(),(void*)v1,(b&&callback->convert.string_to_property(pstruct.prop,(void*)v2,b)>0)?(void*)v2:NULL, NULL);
+	};
+	inline bool compare(enumeration op, char *a, char *b, char *p) 
+	{
+		double v1, v2; v1=atof(a); v2=b?atof(b):0;
+		return callback->properties.compare_basic(pstruct.prop->ptype,(PROPERTYCOMPAREOP)op,get_addr(),(void*)&v1,b?(void*)&v2:NULL, p);
+	};
+	inline bool compare(enumeration op, double *a, double *b=NULL, char *p=NULL) 
+	{ 
+		return callback->properties.compare_basic(pstruct.prop->ptype,(PROPERTYCOMPAREOP)op,get_addr(),a,b,p);
+	};
+	inline bool compare(enumeration op, void *a, void *b=NULL) 
+	{ 
+		return callback->properties.compare_basic(pstruct.prop->ptype,(PROPERTYCOMPAREOP)op,get_addr(),a,b,NULL);
+	};
 
 public: // iterators
-inline bool is_last(void) {
-	return pstruct.prop == NULL || pstruct.prop->next == NULL
-			|| pstruct.prop->oclass != pstruct.prop->next->oclass;
-}
-;
-inline PROPERTY* get_next(void) {
-	return is_last() ? NULL : pstruct.prop->next;
-}
-;
+	inline bool is_last(void) { return pstruct.prop==NULL || pstruct.prop->next==NULL || pstruct.prop->oclass!=pstruct.prop->next->oclass; };
+	inline PROPERTY* get_next(void) { return is_last() ? NULL : pstruct.prop->next; };
 
 public: // comparators
-inline bool operator ==(char *a) {
-	return compare(TCOP_EQ, a, NULL);
-}
-;
-inline bool operator <=(char *a) {
-	return compare(TCOP_LE, a, NULL);
-}
-;
-inline bool operator >=(char *a) {
-	return compare(TCOP_GE, a, NULL);
-}
-;
-inline bool operator !=(char *a) {
-	return compare(TCOP_NE, a, NULL);
-}
-;
-inline bool operator <(char *a) {
-	return compare(TCOP_LT, a, NULL);
-}
-;
-inline bool operator >(char *a) {
-	return compare(TCOP_GT, a, NULL);
-}
-;
-inline bool inside(char *a, char *b) {
-	return compare(TCOP_IN, a, b);
-}
-;
-inline bool outside(char *a, char *b) {
-	return compare(TCOP_NI, a, b);
-}
-;
+	inline bool operator == (char* a) { return compare(TCOP_EQ,a,NULL); };
+	inline bool operator <= (char* a) { return compare(TCOP_LE,a,NULL); };
+	inline bool operator >= (char* a) { return compare(TCOP_GE,a,NULL); };
+	inline bool operator != (char* a) { return compare(TCOP_NE,a,NULL); };
+	inline bool operator < (char* a) { return compare(TCOP_LT,a,NULL); };
+	inline bool operator > (char* a) { return compare(TCOP_GT,a,NULL); };
+	inline bool inside(char* a, char* b) { return compare(TCOP_IN,a,b); };
+	inline bool outside(char* a, char* b) { return compare(TCOP_NI,a,b); };
 
 private: // exceptions
-inline void exception(const char *msg, ...) {
-	static char buf[1024];
-	va_list ptr;
-	va_start(ptr, msg);
-	vsprintf(
-			buf
-					+ sprintf(buf, "%s.%s: ",
-							OBJECTDATA(obj, gld_object)->get_name(),
-							pstruct.prop->name), msg, ptr);
-	va_end(ptr);
-	throw(const char*) buf;
-}
-;
+	inline void exception(const char *msg, ...)
+	{ 
+		static char buf[1024]; 
+		va_list ptr; 
+		va_start(ptr,msg); 
+		vsprintf(buf+sprintf(buf,"%s.%s: ",OBJECTDATA(obj,gld_object)->get_name(),pstruct.prop->name),msg,ptr); 
+		va_end(ptr); 
+		throw (const char*)buf;
+	};
 };
 
 /// Global variable container
@@ -3416,131 +2201,46 @@ private: // data
 	GLOBALVAR *var;
 
 public: // constructors
-	inline gld_global(void) {
-		var = callback->global.find(NULL);
-	}
-	;
-	inline gld_global(GLOBALVAR *v) :
-			var(v) {
-	}
-	;
-	inline gld_global(char *n) {
-		var = callback->global.find(n);
-	}
-	;
-	inline gld_global(char *n, PROPERTYTYPE t, void *p) {
-		var = callback->global.create(n, t, p, NULL);
-	}
-	;
+	inline gld_global(void) { var=callback->global.find(NULL); };
+	inline gld_global(GLOBALVAR *v) : var(v) {};
+	inline gld_global(char *n) { var=callback->global.find(n); };
+	inline gld_global(char *n, PROPERTYTYPE t, void *p) { var=callback->global.create(n,t,p,NULL); };
 
 public: // read accessors
-	inline operator GLOBALVAR*(void) {
-		return var;
-	}
-	;
-	inline bool is_valid(void) {
-		return var != NULL;
-	}
-	;
-	inline PROPERTY* get_property(void) {
-		if (!var)
-			return NULL;
-		return var->prop;
-	}
-	;
-	inline unsigned long get_flags(void) {
-		if (!var)
-			return -1;
-		return var->flags;
-	}
-	;
-	inline size_t to_string(char *bp, size_t sz) {
-		if (!var)
-			return -1;
-		gld_property p(var);
-		return p.to_string(bp, (int) sz);
-	}
-	;
-	inline gld_string get_string(const size_t sz = 1024) {
+	inline operator GLOBALVAR*(void) { return var; };
+	inline bool is_valid(void) { return var!=NULL; };
+	inline PROPERTY* get_property(void) { if (!var) return NULL; return var->prop; };
+	inline unsigned long get_flags(void) { if (!var) return -1; return var->flags; };
+	inline size_t to_string(char *bp, size_t sz) { if (!var) return -1; gld_property p(var); return p.to_string(bp,(int)sz); };
+	inline gld_string get_string(const size_t sz=1024)
+	{
 		gld_string res;
 		char buf[1024];
-		if (sizeof(buf) < sz)
-			throw "get_string() over size limit";
-		if (to_string(buf, (int) sz) >= 0)
+		if ( sizeof(buf)<sz ) throw "get_string() over size limit";
+		if ( to_string(buf,(int)sz)>=0 )
 			res = buf;
 		return res;
-	}
-	;
-	inline bool get_bool(void) {
-		return *(bool*) (var->prop->addr);
-	}
-	;
-	inline int16 get_int16(void) {
-		return *(int16*) (var->prop->addr);
-	}
-	;
-	inline int32 get_int32(void) {
-		return *(int32*) (var->prop->addr);
-	}
-	;
-	inline int64 get_int64(void) {
-		return *(int64*) (var->prop->addr);
-	}
-	;
-	inline double get_double(void) {
-		return *(double*) (var->prop->addr);
-	}
-	;
-	inline complex get_complex(void) {
-		return *(complex*) (var->prop->addr);
-	}
-	;
-	inline TIMESTAMP get_timestamp(void) {
-		return *(TIMESTAMP*) (var->prop->addr);
-	}
-	;
+	};
+	inline bool get_bool(void) { return *(bool*)(var->prop->addr); };
+	inline int16 get_int16(void) { return *(int16*)(var->prop->addr); };
+	inline int32 get_int32(void) { return *(int32*)(var->prop->addr); };
+	inline int64 get_int64(void) { return *(int64*)(var->prop->addr); };
+	inline double get_double(void) { return *(double*)(var->prop->addr); };
+	inline complex get_complex(void) { return *(complex*)(var->prop->addr); };
+	inline TIMESTAMP get_timestamp(void) { return *(TIMESTAMP*)(var->prop->addr); };
 
 public: // write accessors
-	inline size_t from_string(char *bp) {
-		if (!var)
-			return -1;
-		gld_property p(var);
-		return p.from_string(bp);
-	}
-	;
-	inline bool get(char *n) {
-		var = callback->global.find(n);
-		return var != NULL;
-	}
-	;
-	inline bool create(char *n, PROPERTYTYPE t, void *p) {
-		var = callback->global.create(n, t, p, NULL);
-		return var != NULL;
-	}
-	;
+	inline size_t from_string(char *bp) { if (!var) return -1; gld_property p(var); return p.from_string(bp); };
+	inline bool get(char *n) { var=callback->global.find(n); return var!=NULL; };
+	inline bool create(char *n, PROPERTYTYPE t, void *p) { var=callback->global.create(n,t,p,NULL); return var!=NULL; };
 
 public: // external accessors
 	// TODO
 
 public: // iterators
-	inline GLOBALVAR* get_first(void) {
-		return callback->global.find(NULL);
-	}
-	;
-	inline bool is_last(void) {
-		if (!var)
-			return false;
-		else
-			return (var->next == NULL);
-	}
-	;
-	inline GLOBALVAR* get_next(void) {
-		if (!var)
-			return NULL;
-		else
-			return var->next;
-	}
-	;
+	inline GLOBALVAR* get_first(void) { return callback->global.find(NULL); };
+	inline bool is_last(void) { if (!var) return false; else return (var->next==NULL); };
+	inline GLOBALVAR* get_next(void) { if (!var) return NULL; else return var->next; };
 };
 
 /// Aggregation container
@@ -3548,30 +2248,12 @@ class gld_aggregate {
 private:
 	AGGREGATION *aggr;
 public:
-	inline gld_aggregate(void) {
-		aggr = NULL;
-	}
-	;
-	inline gld_aggregate(char *spec, char *group) {
-		set_aggregate(spec, group);
-	}
-	;
+	inline gld_aggregate(void) { aggr=NULL; };
+	inline gld_aggregate(char *spec, char *group) { set_aggregate(spec,group); };
 public:
-	inline bool set_aggregate(char *spec, char *group) {
-		aggr = callback->aggregate.create(spec, group);
-		return aggr != NULL;
-	}
-	;
-	inline bool is_valid(void) {
-		return aggr != NULL;
-	}
-	;
-	inline double get_value(void) {
-		if (!aggr)
-			throw "null aggregate";
-		return callback->aggregate.refresh(aggr);
-	}
-	;
+	inline bool set_aggregate(char *spec, char *group) { aggr=callback->aggregate.create(spec,group); return aggr!=NULL; };
+	inline bool is_valid(void) { return aggr!=NULL; };
+	inline double get_value(void) { if (!aggr) throw "null aggregate"; return callback->aggregate.refresh(aggr); };
 };
 
 /// Object list container
@@ -3579,106 +2261,40 @@ class gld_objlist {
 private:
 	struct s_objlist *list;
 public:
-	inline operator OBJLIST*() {
-		return list;
-	}
-	;
+	inline operator OBJLIST*() { return list; };
 public:
-	inline gld_objlist(void) :
-			list(NULL) {
-	}
-	;
-	inline gld_objlist(char *group) {
-		list = callback->objlist.search(group);
-	}
-	;
-	inline gld_objlist(CLASS *c, PROPERTY *m, char *p, char *o, void *a,
-			void *b = NULL) {
-		list = callback->objlist.create(c, m, p, o, a, b);
-	}
-	;
-	inline gld_objlist(char *cn, char *mn, char *p, char *o, void *a, void *b =
-			NULL) {
-		CLASS *c = callback->class_getname(cn);
-		if (!c)
-			exception("gld_objlist(): class '%s' is not found", cn);
-		PROPERTY *m = callback->find_property(c, mn);
-		if (!m)
-			exception("gld_objlist(): property '%s' is not found in class '%s'",
-					mn, cn);
-		list = callback->objlist.create(c, m, p, o, a, b);
-	}
-	;
-	inline ~gld_objlist(void) {
-		callback->objlist.destroy(list);
-	}
-	;
+	inline gld_objlist(void) : list(NULL) {};
+	inline gld_objlist(char *group) { list=callback->objlist.search(group); };
+	inline gld_objlist(CLASS *c, PROPERTY *m, char *p, char *o, void *a, void *b=NULL) { list=callback->objlist.create(c,m,p,o,a,b); };
+	inline gld_objlist(char *cn, char *mn, char *p, char *o, void *a, void *b=NULL) 
+	{ 
+		CLASS *c=callback->class_getname(cn); if (!c) exception("gld_objlist(): class '%s' is not found",cn); 
+		PROPERTY *m=callback->find_property(c,mn); if (!m) exception("gld_objlist(): property '%s' is not found in class '%s'",mn,cn);
+		list=callback->objlist.create(c,m,p,o,a,b); 
+	};
+	inline ~gld_objlist(void) { callback->objlist.destroy(list); };
 public:
-	inline size_t set(char *group) {
-		if (list)
-			callback->objlist.destroy(list);
-		list = callback->objlist.search(group);
-		return list ? list->size : -1;
-	}
-	;
-	inline size_t add(PROPERTY *m, char *p, char *o, void *a, void *b = NULL) {
-		return callback->objlist.add(list, m, p, o, a, b);
-	}
-	;
-	inline size_t del(PROPERTY *m, char *p, char *o, void *a, void *b = NULL) {
-		return callback->objlist.add(list, m, p, o, a, b);
-	}
-	;
-	inline size_t add(char *cn, char *mn, char *p, char *o, void *a, void *b =
-			NULL) {
-		CLASS *c = callback->class_getname(cn);
-		if (!c)
-			exception("gld_objlist(): class '%s' is not found", cn);
-		PROPERTY *m = callback->find_property(c, mn);
-		if (!m)
-			exception("gld_objlist(): property '%s' is not found in class '%s'",
-					mn, cn);
-		return callback->objlist.add(list, m, p, o, a, b);
-	}
-	;
-	inline size_t del(char *cn, char *mn, char *p, char *o, void *a, void *b =
-			NULL) {
-		CLASS *c = callback->class_getname(cn);
-		if (!c)
-			exception("gld_objlist(): class '%s' is not found", cn);
-		PROPERTY *m = callback->find_property(c, mn);
-		if (!m)
-			exception("gld_objlist(): property '%s' is not found in class '%s'",
-					mn, cn);
-		return callback->objlist.add(list, m, p, o, a, b);
-	}
-	;
+	inline size_t set(char *group) { if ( list ) callback->objlist.destroy(list); list=callback->objlist.search(group); return list?list->size:-1; };
+	inline size_t add(PROPERTY *m, char *p, char *o, void *a, void *b=NULL) { return callback->objlist.add(list,m,p,o,a,b); };
+	inline size_t del(PROPERTY *m, char *p, char *o, void *a, void *b=NULL) { return callback->objlist.add(list,m,p,o,a,b); };
+	inline size_t add(char *cn, char *mn, char *p, char *o, void *a, void *b=NULL) 
+	{
+		CLASS *c=callback->class_getname(cn); if (!c) exception("gld_objlist(): class '%s' is not found",cn); 
+		PROPERTY *m=callback->find_property(c,mn); if (!m) exception("gld_objlist(): property '%s' is not found in class '%s'",mn,cn);
+		return callback->objlist.add(list,m,p,o,a,b); 
+	};
+	inline size_t del(char *cn, char *mn, char *p, char *o, void *a, void *b=NULL) 
+	{ 
+		CLASS *c=callback->class_getname(cn); if (!c) exception("gld_objlist(): class '%s' is not found",cn); 
+		PROPERTY *m=callback->find_property(c,mn); if (!m) exception("gld_objlist(): property '%s' is not found in class '%s'",mn,cn);
+		return callback->objlist.add(list,m,p,o,a,b); 
+	};
 public:
-	inline bool is_valid(void) {
-		return list != NULL;
-	}
-	;
-	inline size_t get_size(void) {
-		return list->size;
-	}
-	;
-	inline OBJECT* get(size_t n) {
-		return list->objlist[n];
-	}
-	;
-	inline int apply(void *arg, int (*function)(OBJECT*, void*, int)) {
-		return callback->objlist.apply(list, arg, function);
-	}
-	;
-	inline void exception(const char *msg, ...) {
-		static char buf[1024];
-		va_list ptr;
-		va_start(ptr, msg);
-		vsprintf(buf, msg, ptr);
-		va_end(ptr);
-		throw(const char*) buf;
-	}
-	;
+	inline bool is_valid(void) { return list!=NULL; };
+	inline size_t get_size(void) { return list->size; };
+	inline OBJECT *get(size_t n) { return list->objlist[n]; };
+	inline int apply(void *arg, int (*function)(OBJECT *,void*,int)) { return callback->objlist.apply(list,arg,function);};
+	inline void exception(const char *msg, ...) { static char buf[1024]; va_list ptr; va_start(ptr,msg); vsprintf(buf,msg,ptr); va_end(ptr); throw (const char*)buf;};
 };
 
 /// Web data container
@@ -3692,51 +2308,18 @@ private:
 		int status;
 	} *result;
 public:
-	inline gld_webdata(void) {
-		result = NULL;
-	}
-	;
-	inline gld_webdata(char *url, size_t maxlen = 4096) {
-		open(url, maxlen);
-	}
-	;
-	inline ~gld_webdata(void) {
-	}
-	;
+	inline gld_webdata(void) {result=NULL;};
+	inline gld_webdata(char *url, size_t maxlen=4096) {open(url,maxlen);};
+	inline ~gld_webdata(void) {};
 public:
-	inline bool open(char *url, size_t maxlen = 4096) {
-		result = (struct s_http*) callback->http.read(url, (int) maxlen);
-		return is_valid();
-	}
-	;
-	inline void close(void) {
-		callback->http.free((void*) result);
-	}
-	;
-	inline bool is_valid(void) {
-		return result != NULL;
-	}
-	;
-	inline char* get_header(void) {
-		return result->header.data;
-	}
-	;
-	inline size_t get_header_size(void) {
-		return result->header.size;
-	}
-	;
-	inline char* get_body(void) {
-		return result->body.data;
-	}
-	;
-	inline size_t get_body_size(void) {
-		return result->body.size;
-	}
-	;
-	inline int get_status(void) {
-		return result->status;
-	}
-	;
+	inline bool open(char *url, size_t maxlen=4096) { result = (struct s_http*)callback->http.read(url,(int)maxlen); return is_valid();};
+	inline void close(void) { callback->http.free((void*)result);};
+	inline bool is_valid(void) { return result!=NULL; };
+	inline char *get_header(void) { return result->header.data;};
+	inline size_t get_header_size(void) { return result->header.size; };
+	inline char *get_body(void) { return result->body.data; };
+	inline size_t get_body_size(void) { return result->body.size; };
+	inline int get_status(void) { return result->status; };
 };
 ////////////////////////////////////////////////////////////////////////////////////
 // Module-Core Linkage Export Macros

--- a/gldcore/instance_slave.c
+++ b/gldcore/instance_slave.c
@@ -610,6 +610,7 @@ STATUS instance_slave_init_mem(){
 	return SUCCESS;
 #else
 	// @todo linux/unix slave signalling
+	return FAILED; // default to resolve return-value undefined value.
 #endif
 }
 

--- a/gldcore/object.c
+++ b/gldcore/object.c
@@ -1212,7 +1212,7 @@ OBJECT *object_get_next(OBJECT *obj){ /**< the object from which to start */
 	the request to prevent looping.  This will prevent
 	an object_set_parent call from creating a parent loop.
  */
-static int _set_rank(OBJECT *obj, OBJECTRANK rank, OBJECT *first)
+static unsigned int _set_rank(OBJECT *obj, OBJECTRANK rank, OBJECT *first)
 {
 	OBJECTRANK parent_rank = -1;
 	if(obj == NULL){
@@ -1251,10 +1251,10 @@ static int _set_rank(OBJECT *obj, OBJECTRANK rank, OBJECT *first)
 			return -1;
 	}
 	obj->flags &= ~OF_RERANK;
-	return obj->rank;
+	return obj != NULL ? obj->rank : 0;
 }
 /* this version is fast, blind to errors, and not recursive -- it's only used when global_fastrank is TRUE */
-static int _set_rankx(OBJECT *obj, OBJECTRANK rank, OBJECT *first)
+static unsigned int _set_rankx(OBJECT *obj, OBJECTRANK rank, OBJECT *first)
 {
 	int n = object_get_count();
 	if ( obj == NULL )
@@ -1299,10 +1299,12 @@ static int _set_rankx(OBJECT *obj, OBJECTRANK rank, OBJECT *first)
 	}
 	for ( obj=first ; obj!=NULL ; obj=obj->parent )
 		obj->flags &= ~OF_RERANK;
+
+	return obj != NULL ? obj->rank : 0;
 }
-static int set_rank(OBJECT *obj, OBJECTRANK rank, OBJECT *first)
+static unsigned int set_rank(OBJECT *obj, OBJECTRANK rank, OBJECT *first)
 {
-	global_bigranks==TRUE ? _set_rankx(obj,rank,NULL) : _set_rank(obj,rank,NULL);
+	return global_bigranks==TRUE ? _set_rankx(obj,rank,NULL) : _set_rank(obj,rank,NULL);
 }
 
 /** Set the rank of an object but forcing it's parent

--- a/gldcore/object.c
+++ b/gldcore/object.c
@@ -1212,7 +1212,7 @@ OBJECT *object_get_next(OBJECT *obj){ /**< the object from which to start */
 	the request to prevent looping.  This will prevent
 	an object_set_parent call from creating a parent loop.
  */
-static unsigned int _set_rank(OBJECT *obj, OBJECTRANK rank, OBJECT *first)
+static int _set_rank(OBJECT *obj, OBJECTRANK rank, OBJECT *first)
 {
 	OBJECTRANK parent_rank = -1;
 	if(obj == NULL){
@@ -1254,7 +1254,7 @@ static unsigned int _set_rank(OBJECT *obj, OBJECTRANK rank, OBJECT *first)
 	return obj != NULL ? obj->rank : 0;
 }
 /* this version is fast, blind to errors, and not recursive -- it's only used when global_fastrank is TRUE */
-static unsigned int _set_rankx(OBJECT *obj, OBJECTRANK rank, OBJECT *first)
+static int _set_rankx(OBJECT *obj, OBJECTRANK rank, OBJECT *first)
 {
 	int n = object_get_count();
 	if ( obj == NULL )
@@ -1302,7 +1302,7 @@ static unsigned int _set_rankx(OBJECT *obj, OBJECTRANK rank, OBJECT *first)
 
 	return obj != NULL ? obj->rank : 0;
 }
-static unsigned int set_rank(OBJECT *obj, OBJECTRANK rank, OBJECT *first)
+static int set_rank(OBJECT *obj, OBJECTRANK rank, OBJECT *first)
 {
 	return global_bigranks==TRUE ? _set_rankx(obj,rank,NULL) : _set_rank(obj,rank,NULL);
 }

--- a/gldcore/object.h
+++ b/gldcore/object.h
@@ -19,7 +19,7 @@
 #include "enduse.h"
 
 /* this must match property_type list in object.c */
-typedef unsigned int OBJECTRANK; /**< Object rank number */
+typedef int OBJECTRANK; /**< Object rank number */
 typedef unsigned short OBJECTSIZE; /** Object data size */
 typedef unsigned int OBJECTNUM; /** Object id number */
 typedef char * OBJECTNAME; /** Object name */

--- a/gldcore/property.c
+++ b/gldcore/property.c
@@ -3,7 +3,7 @@
 	@file property.c
 	@addtogroup property Properties of objects
 	@ingroup core
-	
+
 	GridLAB-D classes contain properties,
 	which are supported by the functions in this module
 
@@ -140,19 +140,19 @@ PROPERTY *property_malloc(PROPERTYTYPE proptype, CLASS *oclass, char *name, void
 		if (prop->ptype!=PT_double && prop->ptype!=PT_complex)
 			output_error("property_malloc(oclass='%s',...): property %s cannot have unit '%s' because it is not a double or complex value",oclass->name, prop->name,unitspec);
 			/*	TROUBLESHOOT
-				Only <b>double</b> and <b>complex</b> properties can have units.  
+				Only <b>double</b> and <b>complex</b> properties can have units.
 				Either change the type of the property or remove the unit specification from the property's declaration.
 			 */
 
 		/* verify that the requested unit exists or can be derived */
-		else 
+		else
 		{
 			if ((prop->unit = unit_find(unitspec))==NULL)
 				throw_exception("property_malloc(oclass='%s',...): property %s unit '%s' is not recognized",oclass->name, prop->name,unitspec);
 				/*	TROUBLESHOOT
-					A class is attempting to publish a variable using a unit that is not defined.  
+					A class is attempting to publish a variable using a unit that is not defined.
 					This is caused by an incorrect unit specification in a variable publication (in C++) or declaration (in GLM).
-					Units are defined in the unit file located in the GridLAB-D <b>etc</b> folder.  
+					Units are defined in the unit file located in the GridLAB-D <b>etc</b> folder.
 				 */
 		}
 	}
@@ -164,7 +164,7 @@ PROPERTY *property_malloc(PROPERTYTYPE proptype, CLASS *oclass, char *name, void
 	if (oclass!=NULL && class_find_property(oclass,prop->name))
 		output_warning("property_malloc(oclass='%s',...): property name '%s' is defined more than once", oclass->name, prop->name);
 		/*	TROUBLESHOOT
-			A class is attempting to publish a variable more than once.  
+			A class is attempting to publish a variable more than once.
 			This is caused by an repeated specification for a variable publication (in C++) or declaration (in GLM).
 		 */
 	return prop;
@@ -303,10 +303,10 @@ int double_array_create(double_array*a)
 }
 double get_double_array_value(double_array*a,unsigned int n, unsigned int m)
 {
-	if ( a->n>n && a->m>m )
-		return *(a->x[n][m]);
-	else
+	if (!(a->n > n && a->m > m))
 		throw_exception("get_double_array_value(double_array*a='n=%d,m=%d,...',unsigned int n=%d,unsigned int m=%d): array index out of range",a->n,a->m,n,m);
+
+	return *(a->x[n][m]);
 }
 void set_double_array_value(double_array*a,unsigned int n, unsigned int m, double x)
 {
@@ -317,10 +317,10 @@ void set_double_array_value(double_array*a,unsigned int n, unsigned int m, doubl
 }
 double *get_double_array_ref(double_array*a,unsigned int n, unsigned int m)
 {
-	if ( a->n>n && a->m>m )
-		return a->x[n][m];
-	else
+	if (!(a->n > n && a->m > m))
 		throw_exception("get_double_array_value(double_array*a='n=%d,m=%d,...',unsigned int n=%d,unsigned int m=%d): array index out of range",a->n,a->m,n,m);
+
+	return a->x[n][m];
 }
 double double_array_get_part(void *x, char *name)
 {
@@ -351,25 +351,25 @@ int complex_array_create(complex_array *a)
 	return 1;
 }
 complex *get_complex_array_value(complex_array *a,unsigned int n, unsigned int m)
-{
-	if ( a->n>n && a->m>m )
-		return a->x[n][m];
-	else
+ {
+	if (!(a->n > n && a->m > m))
 		throw_exception("get_complex_array_value(complex_array*a='n=%d,m=%d,...',unsigned int n=%d,unsigned int m=%d): array index out of range",a->n,a->m,n,m);
+
+	return a->x[n][m];
 }
 void set_complex_array_value(complex_array *a,unsigned int n, unsigned int m, complex *x)
 {
-	if ( a->n>n && a->m>m )
+	if (a->n > n && a->m > m)
 		*(a->x[n][m]) = *x;
 	else
 		throw_exception("get_complex_array_value(complex_array*a='n=%d,m=%d,...',unsigned int n=%d,unsigned int m=%d): array index out of range",a->n,a->m,n,m);
 }
 complex *get_complex_array_ref(complex_array *a,unsigned int n, unsigned int m)
 {
-	if ( a->n>n && a->m>m )
-		return a->x[n][m];
-	else
+	if (!(a->n > n && a->m > m))
 		throw_exception("get_complex_array_value(complex_array*a='n=%d,m=%d,...',unsigned int n=%d,unsigned int m=%d): array index out of range",a->n,a->m,n,m);
+
+	return a->x[n][m];
 }
 double complex_array_get_part(void *x, char *name)
 {

--- a/gldcore/property.h
+++ b/gldcore/property.h
@@ -70,7 +70,7 @@ public:
 	inline char *find(const char c) { return strchr(buffer,c); };
 	inline char *find(const char *s) { return strstr(buffer,s); };
 	inline char *findrev(const char c) { return strrchr(buffer,c); };
-	inline char *token(char *from, const char *delim, char **context) { this->strtok_s(from,delim,context); };
+	inline char *token(char *from, const char *delim, char **context) { return this->strtok_s(from,delim,context); };
 	inline size_t format(char *fmt, ...) { va_list ptr; va_start(ptr,fmt); size_t len=vsnprintf(buffer,size,fmt,ptr); va_end(ptr); return len; };
 	inline size_t vformat(char *fmt, va_list ptr) { return vsnprintf(buffer,size,fmt,ptr); };
 };

--- a/gldcore/transform.c
+++ b/gldcore/transform.c
@@ -204,6 +204,7 @@ int get_source_type(PROPERTY *prop)
 			prop->name,property_getspec(prop->ptype)->name);
 		break;
 	}
+	return source_type;
 }
 int transform_add_filter(OBJECT *target_obj,		/* pointer to the target object (lhs) */
 						 PROPERTY *target_prop,	/* pointer to the target property */

--- a/market/auction.cpp
+++ b/market/auction.cpp
@@ -1598,8 +1598,8 @@ int auction::submit_nolock(char *from, double quantity, double real_price, KEY k
 				gl_name(OBJECTHDR(this),myname,sizeof(myname)),quantity<0?"ask":"offer",
 				from);
 		}
-		return 1;
 	}
+	return 1;
 }
 
 TIMESTAMP auction::nextclear(void) const
@@ -1671,5 +1671,6 @@ EXPORT TIMESTAMP sync_auction(OBJECT *obj, TIMESTAMP t1, PASSCONFIG pass)
 		return t2;
 	}
 	SYNC_CATCHALL(auction);
+	return TS_INVALID; // resolves compiler warning, but can not be reached.
 }
 

--- a/market/auction.cpp
+++ b/market/auction.cpp
@@ -1599,7 +1599,7 @@ int auction::submit_nolock(char *from, double quantity, double real_price, KEY k
 				from);
 		}
 	}
-	return 1;
+	return 0;
 }
 
 TIMESTAMP auction::nextclear(void) const

--- a/market/auction_ccsi.cpp
+++ b/market/auction_ccsi.cpp
@@ -1582,8 +1582,8 @@ int auction_ccsi::submit_nolock(char *from, double quantity, double real_price, 
 				gl_name(OBJECTHDR(this),myname,sizeof(myname)),quantity<0?"ask":"offer",
 				from);
 		}
-		return 1;
 	}
+	return 1;
 }
 
 TIMESTAMP auction_ccsi::nextclear(void) const
@@ -1659,5 +1659,6 @@ EXPORT TIMESTAMP sync_auction_ccsi(OBJECT *obj, TIMESTAMP t1, PASSCONFIG pass)
 		return t2;
 	}
 	SYNC_CATCHALL(auction_ccsi);
+	return TS_INVALID;
 }
 

--- a/market/auction_ccsi.cpp
+++ b/market/auction_ccsi.cpp
@@ -1583,7 +1583,7 @@ int auction_ccsi::submit_nolock(char *from, double quantity, double real_price, 
 				from);
 		}
 	}
-	return 1;
+	return 0;
 }
 
 TIMESTAMP auction_ccsi::nextclear(void) const

--- a/market/collect.cpp
+++ b/market/collect.cpp
@@ -1,5 +1,6 @@
 #include "collect.h"
 #include <algorithm>
+#include <stdexcept>
 
 //////////////////////////////////////////////////////////////////////////
 // IMPLEMENTATION OF BID collect for primary frequency control
@@ -107,6 +108,7 @@ int collect::calculate_freq_thresholds(double droop, double nom_freq, double fre
 }
 
 int collect::sort(int sort_mode) {
+	try {
 	for (int i = 0; i < number_of_bids_on; ++i){ //set mode for on bids
 		supervisor_bid_on[i].sort_by = sort_mode;
 	}
@@ -121,6 +123,10 @@ int collect::sort(int sort_mode) {
 		if (number_of_bids_off > 0) {
 			std::sort(supervisor_bid_off, supervisor_bid_off+number_of_bids_off);
 		}
+	}
+	}
+	catch (std::logic_error &ex){
+		gl_error(ex.what());
 	}
 	return 0;
 }

--- a/market/collect.h
+++ b/market/collect.h
@@ -1,4 +1,5 @@
 #include "gridlabd.h"
+#include <stdexcept>
 
 #ifndef _collect_h_
 #define _collect_h_
@@ -13,21 +14,23 @@ public:
 		double voltage_deviation;	/**< bid voltage deviation */
 		int state;	/**< bid state */
 		bool operator<(const supervisor_bid& rhs) const {
+			bool return_val = false;
 			if (sort_by == 1) {  // sort by power increasing
-				return power < rhs.power;
+				return_val = power < rhs.power;
 			}
 			else if (sort_by == 2) {  // sort by power decreasing
-				return power > rhs.power;
+				return_val = power > rhs.power;
 			}
 			else if (sort_by == 3) { // sort by deviation of voltage from nominal
-				return voltage_deviation < rhs.voltage_deviation; 
+				return_val = voltage_deviation < rhs.voltage_deviation;
 			}
 			else if (sort_by == 4) { // sort by furtherst away from nominal in each direction
-				return voltage_deviation < rhs.voltage_deviation; 
+				return_val = voltage_deviation < rhs.voltage_deviation;
 			}
 			else {
-				gl_error("sort method is not defined!");
+				throw std::logic_error("sort method is not defined!"); // This fixes no-return state.
 			}
+			return return_val;
 		}
 	} SUPERVISORBID;
 	collect(void);


### PR DESCRIPTION
#### What's this Pull Request do?
This PR fixes a class of undefined behavior throughout GridLAB-D's codebase where functions declared to return a type contain a flow-path by which it is possible to reach the end of flow control without returning a value. 
This behavior caused optimized builds to fail and segmentation fault. 

#### Where should the reviewer start?
Verify the application compiles, installs, and runs successfully using any compilers commonly used with the reviewer's use-case, including with optimizations enabled. 
Additionally, review values selected as return types, and confirm if they are reasonable default return values, for any paths where flow control allows that return to occur (note: some returns are unreachable, and exist purely to satisfy the compiler). 

This has already been tested up to `-O2` on:
-MSYS2 using GCC 9
-Ubuntu 18.04 using GCC 7
-MacOS using Homebrew GCC 8

#### How should this be tested?
#### Any background context you want to provide?
This particular category of undefined behavior causes the Segmentation Faults as identified in #1193 and #1167, among other possible related issues. 

#### What are the relevant issues?
Resolves #1167 
Resolves #1193 
