### PR TITLE
Bugfix/1232 - Fix for segfaults when "single-node-unsupported-islands" are in the GLM

### DIFF
--- a/powerflow/autotest/test_disconnected_node.glm
+++ b/powerflow/autotest/test_disconnected_node.glm
@@ -31,7 +31,7 @@ object fault_check {
     output_filename "unsupported_nodes.txt";	
 }
 
-//Manual object - open the "tie switches"
+//Manual object - just enables fault_check to remove things (not really needed)
 object eventgen {
 	name testgendev;
 	use_external_faults true;
@@ -154,7 +154,7 @@ object node {
 }
 
 //Floating nodes
-object meter {
+object node {
 	name node1C;
 	phases "ABCN";
 	nominal_voltage 7199.558;
@@ -166,3 +166,19 @@ object node {
 	phases "ABCN";
 	nominal_voltage 7199.558;
 }
+
+object load {
+	name node2CL;
+	parent node1C;
+	phases BN;
+	nominal_voltage 7199.558;
+	constant_power_B 25.0+10.0j;
+}
+
+object meter {
+	name node2CMeter;
+	parent node1C;
+	phases ABCN;
+	nominal_voltage 7199.558;
+}
+	

--- a/powerflow/autotest/test_disconnected_node.glm
+++ b/powerflow/autotest/test_disconnected_node.glm
@@ -1,0 +1,168 @@
+//4-node-esque system, with an additional node floating (and with a child)
+//Used to fail with floating node and fault_check
+//Had issues with switch sync and meter sync routines
+//Silent segfault
+
+#set profiler=1
+clock {
+	timezone EST+5EDT;
+	starttime '2000-01-01 0:00:00';
+	stoptime '2000-01-01 0:01:00';
+}
+
+//module assert;
+module tape;
+module powerflow {
+	solver_method NR;
+	line_limits false;
+}
+module reliability {
+	report_event_log false;
+}
+
+//Fault check object
+object fault_check {
+	name base_fault_check_object1;
+	check_mode ONCHANGE;
+	strictly_radial false;
+	grid_association true;
+	full_output_file false;
+	eventgen_object testgendev;
+    output_filename "unsupported_nodes.txt";	
+}
+
+//Manual object - open the "tie switches"
+object eventgen {
+	name testgendev;
+	use_external_faults true;
+}
+
+object overhead_line_conductor {
+	name olc100;
+	geometric_mean_radius 0.0244 ft;
+	resistance 0.306 Ohm/mile;
+}
+
+object overhead_line_conductor {
+	name olc101;
+	geometric_mean_radius 0.00814 ft;
+	resistance 0.592 Ohm/mile;
+}
+
+object line_spacing {
+	name ls200;
+	distance_AB 2.5 ft;
+	distance_BC 4.5 ft;
+	distance_AC 7.0 ft;
+	distance_AN 5.656854 ft; 
+	distance_BN 4.272002 ft;
+	distance_CN 5.0 ft;
+}
+
+object line_configuration {
+	name lc300;
+	conductor_A olc100;
+	conductor_B olc100;
+	conductor_C olc100;
+	conductor_N olc101;
+	spacing ls200;
+}
+
+object transformer_configuration {
+	name tc400;
+	connect_type WYE_WYE;
+	power_rating 6000;
+	primary_voltage 12470;
+	secondary_voltage 4160;
+	resistance 0.01;
+	reactance 0.06;
+}
+
+//Switches, that would presumably make this three systems, eventually
+object switch {
+	name switch3_3B;
+	phases ABCN;
+	from node3;
+	to node3B;
+	status CLOSED;
+}
+
+//First system
+object meter {
+	name node1;
+	phases "ABCN";
+	bustype SWING;
+	nominal_voltage 7199.558;
+}
+
+object overhead_line {
+	name ol12;
+	phases "ABCN";
+	from node1;
+	to node2;
+	length 2000;
+	configuration lc300;
+}
+
+object node {
+	name node2;
+	phases "ABCN";
+	nominal_voltage 7199.558;
+}
+
+object transformer {
+	name tran23;
+	phases "ABCN";
+	from node2;
+	to node3;
+	configuration tc400;
+}
+
+object node {
+	name node3;
+	phases "ABCN";
+	nominal_voltage 2401.777;
+}
+
+object overhead_line {
+	name ol34;
+	phases "ABCN";
+	from node3;
+	to load4;
+	length 2500;
+	configuration lc300;
+}
+
+object load {
+	name load4;
+	phases "ABCN";
+	constant_power_A +1275000.000+790174.031j;
+	constant_power_B +1800000.000+871779.789j;
+	constant_power_C +2375000.000+780624.750j;
+	nominal_voltage 2401.777;
+	// object recorder {
+		// property "voltage_A,voltage_B,voltage_C";
+		// interval -1;
+		// file load4out.csv;
+	// };
+}
+
+object node {
+	name node3B;
+	phases "ABCN";
+	nominal_voltage 2401.777;
+}
+
+//Floating nodes
+object meter {
+	name node1C;
+	phases "ABCN";
+	nominal_voltage 7199.558;
+}
+
+object node {
+	name node2C;
+	parent node1C;
+	phases "ABCN";
+	nominal_voltage 7199.558;
+}

--- a/powerflow/meter.cpp
+++ b/powerflow/meter.cpp
@@ -407,6 +407,7 @@ TIMESTAMP meter::presync(TIMESTAMP t0)
 void meter::BOTH_meter_sync_fxn()
 {
 	int TempNodeRef;
+	OBJECT *obj = OBJECTHDR(this);
 
 	//Reliability check
 	if ((fault_check_object != NULL) && (solver_method == SM_NR))	//proper solver and fault_object isn't null - may need to set a flag
@@ -414,6 +415,29 @@ void meter::BOTH_meter_sync_fxn()
 		if (NR_node_reference==-99)	//Childed
 		{
 			TempNodeRef=*NR_subnode_reference;
+
+			//See if our parent was initialized
+			if (TempNodeRef == -1)
+			{
+				//Try to initialize it, for giggles
+				node *Temp_Node = OBJECTDATA(SubNodeParent,node);
+
+				//Call the initialization
+				Temp_Node->NR_populate();
+
+				//Pull our reference
+				TempNodeRef=*NR_subnode_reference;
+
+				//Check it again
+				if (TempNodeRef == -1)
+				{
+					GL_THROW("meter:%d - %s - Uninitialized parent is causing odd issues - fix your model!",obj->id,(obj->name?obj->name:"Unnamed"));
+					/*  TROUBLESHOOT
+					A childed meter object is having issues mapping to its parent node - this typically happens in very odd cases of islanded/orphaned
+					topologies that only contain nodes (no links).  Adjust your GLM to work around this issue.
+					*/
+				}
+			}
 		}
 		else	//Normal
 		{

--- a/powerflow/node.cpp
+++ b/powerflow/node.cpp
@@ -2394,6 +2394,19 @@ TIMESTAMP node::sync(TIMESTAMP t0)
 	char loop_index_val;
 	complex temp_curr_rotate_value, temp_curr_calc_value;
 	
+	//Final initialization issue - has to be here, or childed deltamode stuff fails
+	//This catches any orphaned/islanded single nodes (that link wouldn't catch), so error checks work
+	//and don't segfault things
+	if ((prev_NTime==0) && (solver_method == SM_NR))
+	{
+		//See if we've been initialized yet - links typically do this, but single buses get missed
+		if (NR_node_reference == -1)
+		{
+			//Call the populate routine
+			NR_populate();
+		}
+	}
+
 	//Generic time keeping variable - used for phase checks (GS does this explicitly below)
 	if (t0!=prev_NTime)
 	{

--- a/powerflow/node.cpp
+++ b/powerflow/node.cpp
@@ -2396,7 +2396,7 @@ TIMESTAMP node::sync(TIMESTAMP t0)
 	
 	//Final initialization issue - has to be here, or childed deltamode stuff fails
 	//This catches any orphaned/islanded single nodes (that link wouldn't catch), so error checks work
-	//and don't segfault things
+	//and don't segfault things - needs to be duplicated to subclass objects that reference NR before node::sync is called
 	if ((prev_NTime==0) && (solver_method == SM_NR))
 	{
 		//See if we've been initialized yet - links typically do this, but single buses get missed

--- a/powerflow/switch_object.cpp
+++ b/powerflow/switch_object.cpp
@@ -480,6 +480,7 @@ int switch_object::init(OBJECT *parent)
 
 	//Store switch status - will get updated as things change later
 	phased_switch_status = prev_full_status;
+	prev_status = status;
 
 	return result;
 }

--- a/powerflow/triplex_meter.cpp
+++ b/powerflow/triplex_meter.cpp
@@ -328,6 +328,18 @@ TIMESTAMP triplex_meter::presync(TIMESTAMP t0)
 TIMESTAMP triplex_meter::sync(TIMESTAMP t0)
 {
 	int TempNodeRef;
+	OBJECT *obj = OBJECTHDR(this);
+
+	//Check for straggler nodes - fix so segfaults don't occur
+	if ((prev_NTime==0) && (solver_method == SM_NR))
+	{
+		//See if we've been initialized yet - links typically do this, but single buses get missed
+		if (NR_node_reference == -1)
+		{
+			//Call the populate routine
+			NR_populate();
+		}
+	}
 
 	//Reliability check
 	if ((fault_check_object != NULL) && (solver_method == SM_NR))	//proper solver fault_check is present (so might need to set flag
@@ -335,6 +347,29 @@ TIMESTAMP triplex_meter::sync(TIMESTAMP t0)
 		if (NR_node_reference==-99)	//Childed
 		{
 			TempNodeRef=*NR_subnode_reference;
+
+			//See if our parent was initialized
+			if (TempNodeRef == -1)
+			{
+				//Try to initialize it, for giggles
+				node *Temp_Node = OBJECTDATA(SubNodeParent,node);
+
+				//Call the initialization
+				Temp_Node->NR_populate();
+
+				//Pull our reference
+				TempNodeRef=*NR_subnode_reference;
+
+				//Check it again
+				if (TempNodeRef == -1)
+				{
+					GL_THROW("triplex_meter:%d - %s - Uninitialized parent is causing odd issues - fix your model!",obj->id,(obj->name?obj->name:"Unnamed"));
+					/*  TROUBLESHOOT
+					A childed triplex_meter object is having issues mapping to its parent node - this typically happens in very odd cases of islanded/orphaned
+					topologies that only contain nodes (no links).  Adjust your GLM to work around this issue.
+					*/
+				}
+			}
 		}
 		else	//Normal
 		{
@@ -845,6 +880,8 @@ SIMULATIONMODE triplex_meter::inter_deltaupdate_triplex_meter(unsigned int64 del
 				if (NR_node_reference==-99)	//Childed
 				{
 					TempNodeRef=*NR_subnode_reference;
+
+					//No child check from above -- if we're broke this late in the game, we have major problems (should have been caught by now)
 				}
 				else	//Normal
 				{


### PR DESCRIPTION
#### What's this Pull Request do?
Fixes the issue described in #1232 - when single node, unsupported islands are in a GLM with a fault_check object, it causes segfaults as objects aren't properly initialized yet.

#### Where should the reviewer start?
Pull bugfix/1232 and run the autotests.  A new autotest to duplicate the issue has been added.

#### How should this be tested?
See above.

#### What are the relevant issues?
#1232 
#### Questions:
- [X] Is there appropriate logging included? Commit logs in there
