### PR TITLE
Fix GridLAB builds with HELICS on MacOS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -449,7 +449,7 @@ AS_IF([test x"$HAVE_CPPUNIT" = xyes],
      LIBS="$SAVED_LIBS"
      AC_MSG_RESULT([$HAVE_CPPUNIT])])
 AS_IF([test x"$HAVE_CPPUNIT" = xyes],
-    [# CppUnit doesn't separate its flags appropriately
+    [# CppUnit does not separate its flags appropriately
      COMBINED_CPPUNIT_FLAGS="$CPPUNIT_CFLAGS $CPPUNIT_LIBS"
      CPPUNIT_CFLAGS=
      CPPUNIT_LIBS=
@@ -588,6 +588,7 @@ LIBEXT=.so
 ;;
 *darwin* )
 LIBEXT=.so
+GLD_CPPFLAGS="$GLD_CPPFLAGS -stdlib=libc++"
 # LIBEXT=.dylib # This is the proper extension for MacOS now, but libtool does not build it properly.
 ;;
 *windows* )

--- a/connection/helics_msg.cpp
+++ b/connection/helics_msg.cpp
@@ -266,7 +266,7 @@ int helics_msg::init(OBJECT *parent){
 							gld_ep_pub->propertyName = config_info["property"].asString();
 							gld_ep_pub->HelicsPublicationEndpoint = ep;
 							helics_endpoint_publications.push_back(gld_ep_pub);
-							gl_verbose("helics_msg::init(): registering publishing endpoint: %s", gld_ep_pub->name);
+							gl_verbose("helics_msg::init(): registering publishing endpoint: %s", gld_ep_pub->name.c_str());
 						} else {
 							gld_ep_sub = new helics_endpoint_subscription();
 							gld_ep_sub->name = ep.getName();
@@ -285,7 +285,7 @@ int helics_msg::init(OBJECT *parent){
 						gld_ep_pub->propertyName = config_info["publication_info"]["property"].asString();
 						gld_ep_pub->HelicsPublicationEndpoint = ep;
 						helics_endpoint_publications.push_back(gld_ep_pub);
-						gl_verbose("helics_msg::init(): registering publishing endpoint: %s", gld_ep_pub->name);
+						gl_verbose("helics_msg::init(): registering publishing endpoint: %s", gld_ep_pub->name.c_str());
 					}
 					if( config_info.isMember("subscription_info") ) {
 						gld_ep_sub = new helics_endpoint_subscription();


### PR DESCRIPTION
#### What's this Pull Request do?
This PR fixes some type handling issues in  the HELICS message code. 
It also forces use of libc++ on Mac, to prevent linkage failures with clang. 

#### Where should the reviewer start?
Verify GridLAB builds and links with HELICS without errors on available platforms. 

#### How should this be tested?
Standard `--validate` runs should be adequate, this makes very minor changes to the code, primarily affecting the build process.

#### Any background context you want to provide?
This issue is a consequence of Apple's update to the available C++ standard library on recent patches of MacOS.

#### Questions:
- [X] Does this add new dependencies? Yes, Apple-clang and libc++ on MacOS. No changes to Win/Linux buids.
