### PR TITLE
Merge of (#1261) - Reinstatement of some deleted properties

### DIFF
--- a/generators/inverter.cpp
+++ b/generators/inverter.cpp
@@ -330,6 +330,11 @@ inverter::inverter(MODULE *module)
 			PT_double,"VW_V2[pu]", PADDR(VW_V2), PT_DESCRIPTION, "FOUR QUADRANT MODEL: Voltage at which power limiting ends. (e.g. 1.1000). Used in VOLT_WATT control mode.",
 			PT_double,"VW_P1[pu]", PADDR(VW_P1), PT_DESCRIPTION, "FOUR QUADRANT MODEL: Power limit at VW_P1 (e.g. 1). Used in VOLT_WATT control mode.",
 			PT_double,"VW_P2[pu]", PADDR(VW_P2), PT_DESCRIPTION, "FOUR QUADRANT MODEL: Power limit at VW_P2 (e.g. 0). Used in VOLT_WATT control mode.",
+
+			/* DEPRECATED properties - will be deleted in next version */
+			PT_complex, "VA_In", PADDR(VA_In_deprecated), PT_DEPRECATED, PT_DESCRIPTION, "Deprecated input for inverter - use P_In instead",
+			/* END DEPRECATED */
+
 			NULL)<1) GL_THROW("unable to publish properties in %s",__FILE__);
 
 			defaults = this;

--- a/generators/inverter.h
+++ b/generators/inverter.h
@@ -108,6 +108,10 @@ private:
 
 	SIMULATIONMODE desired_simulation_mode;	//deltamode desired simulation mode after corrector pass - prevents starting iterations again
 
+	/* DEPRECATED: delete these - only here so old models work long enough to be yelled at */
+	complex VA_In_deprecated;
+	/* DEPRECATED END */
+
 protected:
 	/* TODO: put unpublished but inherited variables */
 public:

--- a/generators/solar.cpp
+++ b/generators/solar.cpp
@@ -128,6 +128,37 @@ solar::solar(MODULE *module)
 			//PT_KEYWORD, "ONE_AXIS", ONE_AXIS,			//To be implemented later
 			//PT_KEYWORD, "TWO_AXIS", TWO_AXIS,			//To be implemented later
 			//PT_KEYWORD, "AZIMUTH_AXIS", AZIMUTH_AXIS,	//To be implemented later
+
+			/* DEPRECATED properties - delete in next version */
+			PT_enumeration,"generator_mode",PADDR(gen_mode_v_deprecated),PT_DEPRECATED,	//Unused
+				PT_KEYWORD,"UNKNOWN",(enumeration)UNKNOWN,
+				PT_KEYWORD,"CONSTANT_V",(enumeration)CONSTANT_V,
+				PT_KEYWORD,"CONSTANT_PQ",(enumeration)CONSTANT_PQ,
+				PT_KEYWORD,"CONSTANT_PF",(enumeration)CONSTANT_PF,
+				PT_KEYWORD,"SUPPLY_DRIVEN",(enumeration)SUPPLY_DRIVEN,
+
+			PT_enumeration,"generator_status",PADDR(gen_status_v_deprecated), PT_DEPRECATED, //unused
+				PT_KEYWORD,"OFFLINE",(enumeration)OFFLINE,
+				PT_KEYWORD,"ONLINE",(enumeration)ONLINE,	
+
+			PT_enumeration,"power_type",PADDR(power_type_v_deprecated),
+				PT_KEYWORD,"AC",(enumeration)AC,
+				PT_KEYWORD,"DC",(enumeration)DC,
+
+			PT_enumeration, "INSTALLATION_TYPE", PADDR(installation_type_v_deprecated), PT_DEPRECATED, //unused
+			   PT_KEYWORD, "ROOF_MOUNTED", (enumeration)ROOF_MOUNTED,
+               PT_KEYWORD, "GROUND_MOUNTED",(enumeration)GROUND_MOUNTED,
+
+			PT_complex, "VA_Out[VA]", PADDR(VA_Out_deprecated), PT_DEPRECATED, //unused
+
+			PT_set, "phases", PADDR(phases_deprecated), PT_DEPRECATED, //unused
+				PT_KEYWORD, "A",(set)PHASE_A,
+				PT_KEYWORD, "B",(set)PHASE_B,
+				PT_KEYWORD, "C",(set)PHASE_C,
+				PT_KEYWORD, "N",(set)PHASE_N,
+				PT_KEYWORD, "S",(set)PHASE_S,
+			/* END Deprecated */
+
 			NULL) < 1)
 				GL_THROW("unable to publish properties in %s", __FILE__);
 

--- a/generators/solar.h
+++ b/generators/solar.h
@@ -14,6 +14,20 @@ private:
 	bool deltamode_inclusive; //Boolean for deltamode calls - pulled from object flags
 	bool first_sync_delta_enabled;
 
+	/* DEPRECATED - properties that will be deleted in the next version */
+	enum GENERATOR_MODE_deprecated {CONSTANT_V=1, CONSTANT_PQ=2, CONSTANT_PF=4, SUPPLY_DRIVEN=5};
+	enumeration gen_mode_v_deprecated;
+	enum GENERATOR_STATUS_deprecated {OFFLINE=1, ONLINE=2};
+	enumeration gen_status_v_deprecated;
+	enum POWER_TYPE_deprecated{DC=1, AC=2};
+	enumeration power_type_v_deprecated;
+    enum INSTALLATION_TYPE_deprecated {ROOF_MOUNTED=1, GROUND_MOUNTED=2};
+	enumeration installation_type_v_deprecated;
+
+	complex VA_Out_deprecated;
+	set phases_deprecated;
+
+	/* END DEPRECATED */
 protected:
 public: /* Published Variables & Other Funcs For 'PV_CURVE' Mode */
 	// Published Variables for N-R Solver (under the mode 'PV_CURVE')


### PR DESCRIPTION
#### What's this Pull Request do?
Adds back in some deleted properties of models (inverter and solar) that were deleted as part of the feature/730 merge for v4.3.  The properties never did anything, but many older models use them, so added as a PT_DEPRECATE instead.

#### Where should the reviewer start?
Pull code and compile it.

#### How should this be tested?
Test with an older model (a GridAPPS-D model revealed the issue).  Alternatively, run the autotests for v4.2 using this build - all failures will just be numbers/updates, not deleted properties from the models.

#### Any background context you want to provide?
Original deletion came in as part of PR #1256 

#### What are the relevant issues?
#1261 
