### PR TITLE
Merge complex output format fix from #887

### DIFF
--- a/gldcore/convert.cpp
+++ b/gldcore/convert.cpp
@@ -142,6 +142,7 @@ int convert_from_complex(char *buffer, /**< pointer to the string buffer */
 	int count = 0;
 	char temp[1025];
 	complex *v = (complex*)data;
+	CNOTATION cplex_output_type = J;
 
 	double scale = 1.0;
 	if ( prop->unit!=NULL )
@@ -163,14 +164,33 @@ int convert_from_complex(char *buffer, /**< pointer to the string buffer */
 		}
 	}
 
-	if (v->Notation()==A)
+	/* Check the format or global override */
+	if (global_complex_output_format == CNF_RECT)
+	{
+		cplex_output_type = J;
+	}
+	else if (global_complex_output_format == CNF_POLAR_DEG)
+	{
+		cplex_output_type = A;
+	}
+	else if (global_complex_output_format == CNF_POLAR_RAD)
+	{
+		cplex_output_type = R;
+	}
+	else	/* Must be default - see what the property wants */
+	{
+		cplex_output_type = v->Notation();
+	}
+	
+	/* Now output appropriately */
+	if (cplex_output_type==A)
 	{
 		double m = v->Mag()*scale;
 		double a = v->Arg();
 		if (a>PI) a-=(2*PI);
 		count = sprintf(temp,global_complex_format,m,a*180/PI,A);
 	} 
-	else if (v->Notation()==R)
+	else if (cplex_output_type==R)
 	{
 		double m = v->Mag()*scale;
 		double a = v->Arg();
@@ -178,7 +198,7 @@ int convert_from_complex(char *buffer, /**< pointer to the string buffer */
 		count = sprintf(temp,global_complex_format,m,a,R);
 	} 
 	else {
-		count = sprintf(temp,global_complex_format,v->Re()*scale,v->Im()*scale,v->Notation()?v->Notation():'i');
+		count = sprintf(temp,global_complex_format,v->Re()*scale,v->Im()*scale,cplex_output_type?cplex_output_type:'i');
 	}
 	if(count < size - 1){
 		memcpy(buffer, temp, count);

--- a/gldcore/globals.c
+++ b/gldcore/globals.c
@@ -20,6 +20,12 @@
 
 static GLOBALVAR *global_varlist = NULL, *lastvar = NULL;
 
+static KEYWORD cnf_keys[] = {
+	{"DEFAULT", CNF_DEFAULT, cnf_keys+1},
+	{"RECT", CNF_RECT, cnf_keys+2},
+	{"POLAR_DEG", CNF_POLAR_DEG, cnf_keys+3},
+	{"POLAR_RAD", CNF_POLAR_RAD, NULL},
+};
 static KEYWORD df_keys[] = {
 	{"ISO", DF_ISO, df_keys+1},
 	{"US", DF_US, df_keys+2},
@@ -149,6 +155,7 @@ static struct s_varmap {
 	{"stoptime", PT_timestamp, &global_stoptime, PA_PUBLIC, "simulation stop time"},
 	{"double_format", PT_char32, &global_double_format, PA_PUBLIC, "format for writing double values"},
 	{"complex_format", PT_char256, &global_complex_format, PA_PUBLIC, "format for writing complex values"},
+	{"complex_output_format", PT_enumeration, &global_complex_output_format, PA_PUBLIC, "complex output representation", cnf_keys},
 	{"object_format", PT_char32, &global_object_format, PA_PUBLIC, "format for writing anonymous object names"},
 	{"object_scan", PT_char32, &global_object_scan, PA_PUBLIC, "format for reading anonymous object names"},
 	{"object_tree_balance", PT_bool, &global_no_balance, PA_PUBLIC, "object index tree balancing enable flag"},

--- a/gldcore/globals.h
+++ b/gldcore/globals.h
@@ -147,7 +147,15 @@ GLOBAL TIMESTAMP global_stoptime INIT(TS_NEVER); /**< The simulation stop time (
 
 GLOBAL char global_double_format[32] INIT("%+lg"); /**< the format to use when processing real numbers */
 GLOBAL char global_complex_format[256] INIT("%+lg%+lg%c"); /**< the format to use when processing complex numbers */
-//GLOBAL char global_complex_format[256] INIT("%+8.4f%+8.4f%c"); /**< the format to use when processing complex numbers */
+
+typedef enum {
+	CNF_DEFAULT, 	/**< complex numbers are left to whatever format the notation flag is set to */
+	CNF_RECT,     	/**< complex numbers are forced into rectangular format for outputs */
+	CNF_POLAR_DEG, 	/**< complex numbers are forced into polar format with degree angles */
+	CNF_POLAR_RAD, 	/**< complex numbers are forced into polar format with radian angles */
+} COMPLEXCONVERFORMAT; /**< determines the type of run */
+GLOBAL COMPLEXCONVERFORMAT global_complex_output_format INIT(CNF_DEFAULT);	/**< use whatever the numbers already are */
+
 GLOBAL char global_object_format[32] INIT("%s:%d"); 
 GLOBAL char global_object_scan[32] INIT("%[^:]:%d"); /**< the format to use when scanning for object ids */
 


### PR DESCRIPTION
## What's this Pull Request do?
Implements a global variable to force all complex outputs to the a common format.  Basically resolves the issue stated in #887, as well as other, related frustrations.

#### Where should the reviewer start?
Pull the code, compile.  Test with a GLM that outputs polar format and set the global shown in #887.  Will be added to documentation once this PR is merged.

#### How should this be tested?
Mostly make sure autotests are not failing.  Explicit functionality can be tested by implementing the global syntax shown in #887.

#### What are the relevant issues?
#887 
