### PR TITLE
(#1280) Fix build error with static dlfcn

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -577,6 +577,13 @@ AC_MSG_NOTICE
 
 m4_ifdef([AM_PROG_AR], [AM_PROG_AR])
 LT_PREREQ([2.2])
+
+dnl override platform specific check for dependent libraries
+dnl otherwise libtool linking of shared libraries will
+dnl fail on anything other than pass_all.
+AC_CACHE_VAL(lt_cv_deplibs_check_method,
+    [lt_cv_deplibs_check_method=pass_all])
+
 LT_INIT([dlopen win32-dll shared disable-static])
 AC_SUBST([LIBTOOL_DEPS])
 

--- a/connection/Makefile.mk
+++ b/connection/Makefile.mk
@@ -12,6 +12,8 @@ endif
 
 connection_connection_la_LDFLAGS =
 connection_connection_la_LDFLAGS += $(AM_LDFLAGS)
+connection_connection_la_LDFLAGS += -ldl
+
 if HAVE_FNCS
 connection_connection_la_LDFLAGS += $(FNCS_LDFLAGS)
 endif
@@ -29,7 +31,6 @@ connection_connection_la_LIBADD += $(HELICS_LIBS)
 endif
 connection_connection_la_LIBADD += $(PTHREAD_CFLAGS)
 connection_connection_la_LIBADD += $(PTHREAD_LIBS)
-connection_connection_la_LIBADD += -ldl
 
 connection_connection_la_SOURCES =
 connection_connection_la_SOURCES += connection/connection.cpp

--- a/old_autobuild_scripts/core/Makefile.am
+++ b/old_autobuild_scripts/core/Makefile.am
@@ -8,8 +8,7 @@ AM_CFLAGS = $(PTHREAD_CFLAGS)
 # Debug symbols must also be included with -g if not done elsewhere.
 AM_CPPFLAGS = $(XERCES_CPPFLAGS)
 AM_CXXFLAGS = $(PTHREAD_CFLAGS)
-#AM_LDFLAGS = $(EXTRA_gridlabd_LDFLAGS) -ldl -lX11 -L/usr/lib/X11 $(XERCES_LDFLAGS) $(XERCES_LIBS) $(PTHREAD_LIBS) $(PTHREAD_CFLAGS)
-AM_LDFLAGS = $(EXTRA_gridlabd_LDFLAGS) -ldl -L/usr/lib/X11 $(XERCES_LDFLAGS) $(XERCES_LIBS) $(PTHREAD_LIBS) $(PTHREAD_CFLAGS)
+AM_LDFLAGS = $(EXTRA_gridlabd_LDFLAGS) -L/usr/lib/X11 $(XERCES_LDFLAGS) $(XERCES_LIBS) $(PTHREAD_LIBS) $(PTHREAD_CFLAGS) -ldl
 gridlabd_bin_SOURCES = \
 	aggregate.c aggregate.h \
 	build.h \

--- a/old_autobuild_scripts/residential/Makefile.am
+++ b/old_autobuild_scripts/residential/Makefile.am
@@ -23,7 +23,7 @@ residential_la_SOURCES =                            \
 	thermal_storage.cpp    thermal_storage.h    \
 	waterheater.cpp        waterheater.h        \
 	zipload.cpp            zipload.h
-residential_la_LDFLAGS = -ldl -module -no-undefined -avoid-version -version-info 0:0:0
+residential_la_LDFLAGS = -module -no-undefined -avoid-version -version-info 0:0:0 -ldl
 
 uninstall-hook:
 	-rmdir $(DESTDIR)$(pkglibdir)

--- a/powerflow/Makefile.mk
+++ b/powerflow/Makefile.mk
@@ -14,7 +14,6 @@ powerflow_powerflow_la_LIBADD += third_party/jsonCpp/libjsoncpp.la
 powerflow_powerflow_la_LIBADD += third_party/superLU_MT/libsuperlu.la
 powerflow_powerflow_la_LIBADD += $(PTHREAD_CFLAGS)
 powerflow_powerflow_la_LIBADD += $(PTHREAD_LIBS)
-powerflow_powerflow_la_LIBADD += -ldl
 
 powerflow_powerflow_la_SOURCES =
 powerflow_powerflow_la_SOURCES += powerflow/billdump.cpp

--- a/residential/Makefile.mk
+++ b/residential/Makefile.mk
@@ -5,8 +5,7 @@ residential_residential_la_CPPFLAGS += $(AM_CPPFLAGS)
 
 residential_residential_la_LDFLAGS =
 residential_residential_la_LDFLAGS += $(AM_LDFLAGS)
-
-residential_residential_la_LIBADD = -ldl
+residential_residential_la_LDFLAGS += -ldl
 
 residential_residential_la_SOURCES =
 residential_residential_la_SOURCES += residential/appliance.cpp

--- a/rest/Makefile.mk
+++ b/rest/Makefile.mk
@@ -12,7 +12,7 @@ rest_rest_la_CPPFLAGS += -I$(top_srcdir)/core
 rest_rest_la_CPPFLAGS = $(AM_CPPFLAGS)
 
 rest_rest_la_LDFLAGS =
-rest_rest_la_LDFLAGS = $(AM_LDFLAGS)
+rest_rest_la_LDFLAGS += $(AM_LDFLAGS)
 rest_rest_la_LDFLAGS += -ldl
 
 rest_rest_la_LIBADD = 

--- a/tape/Makefile.mk
+++ b/tape/Makefile.mk
@@ -6,10 +6,10 @@ tape_tape_la_CPPFLAGS += $(AM_CPPFLAGS)
 
 tape_tape_la_LDFLAGS =
 tape_tape_la_LDFLAGS += $(AM_LDFLAGS)
+tape_tape_la_LDFLAGS += -ldl
 
 tape_tape_la_LIBADD =
 tape_tape_la_LIBADD += third_party/jsonCpp/libjsoncpp.la
-tape_tape_la_LIBADD += -ldl
 
 tape_tape_la_SOURCES =
 tape_tape_la_SOURCES += tape/collector.c


### PR DESCRIPTION
#### What's this Pull Request do?
Resolves the link-time failure caused by Autotools following the removal of the dynamic library from the MSYS2 version of dlfcn provided by `pacman`.

#### How should this be tested?
Confirm that the application builds, links, runs, and validates successfully on Windows under MSYS2, and that the application still operates as expected on other platforms.

#### Any background context you want to provide?
The dlfcn library in MSYS2 no longer provides a dynamic
library, opting for a static archive. This should not
cause any issues, however autotools seems to have issues
with the file rules created for link-time analysis.

#### What are the relevant issues?
#1280 

