### PR TITLE
Bugfix/1312

### DIFF
--- a/generators/autotest/test_1isochronous_VSI.glm
+++ b/generators/autotest/test_1isochronous_VSI.glm
@@ -2329,7 +2329,7 @@ object load:35 {
 	 voltage_A 2401.7771;
      voltage_B -1200.8886-2080.000j;
      voltage_C -1200.8886+2080.000j;
-     base_power_A 44721.35955;
+     base_power_A 134164.0787; // 3 * 44721.35955 to fix #1312
 	impedance_fraction_A 1.0;
 	impedance_pf_A 0.894427191;
      nominal_voltage 2401.7771;

--- a/powerflow/autotest/test_ZIPLoad_Delta_FBS.glm
+++ b/powerflow/autotest/test_ZIPLoad_Delta_FBS.glm
@@ -1,0 +1,199 @@
+//  2 bus simple system
+// Tests, that base_power, current_fraction and impedance_fraction work when phasing includes D
+
+// Derived from test_ZIPLoad_ZeroBase_NR.glm except for load:node2 phases
+// The assertion criteria had to be loosened from 0.1, because for constant-current loads,
+//  the line-to-line current angle rotation is referenced to fixed baseangles in load.cpp.
+//  With unbalance in the system, the correct rotation is not exactly +30 degrees.
+
+clock {
+	timezone "PST+8PDT";
+	starttime '2001-01-01 00:00:00 PST';
+	stoptime '2001-01-01 00:01:00 PST';
+	
+}
+
+#set suppress_repeat_messages=1
+#set double_format=%+.12lg
+#set complex_format=%+.12lg%+.12lg%c
+
+module assert;
+module tape;
+
+module powerflow {
+	solver_method FBS;
+}
+
+class player {
+	double value;
+}
+
+//Player, for transform
+object player {
+	name base_power_player;
+	file ../data_ZIP_test_base_power.csv;
+}
+
+// Phase Conductor for 601: 556,500 26/7 ACSR
+object overhead_line_conductor {
+	name olc6010;
+	geometric_mean_radius 0.031300;
+	diameter 0.927 in;
+	resistance 0.185900;
+}
+
+// Phase Conductor for 602: 4/0 6/1 ACSR
+object overhead_line_conductor {
+	name olc6020;
+	geometric_mean_radius 0.00814;
+	diameter 0.56 in;
+	resistance 0.592000;
+}
+
+
+// Overhead line configurations
+object line_spacing {
+	name ls500601;	//With capacitance ability
+	distance_AB 2.5;
+	distance_AC 4.5;
+	distance_BC 7.0;
+	distance_BN 5.656854;
+	distance_AN 4.272002;
+	distance_CN 5.0;
+	distance_AE 28.0;
+	distance_BE 28.0;
+	distance_CE 28.0;
+	distance_NE 24.0;
+}
+
+object line_configuration {
+	name lc601;
+	conductor_A olc6010;
+	conductor_B olc6010;
+	conductor_C olc6010;
+	conductor_N olc6020;
+	spacing ls500601;
+}
+
+object transformer_configuration {
+    name "triplex_xformer_cfg";
+    connect_type SINGLE_PHASE_CENTER_TAPPED;
+    install_type POLETOP;
+    primary_voltage 7200.0V;
+    secondary_voltage 120.0V;
+    power_rating 150.0kVA;
+    powerB_rating 150.0kVA;
+    impedance 0.006000+0.013600j;
+    impedance1 0.012000+0.006800j;
+    impedance2 0.012000+0.006800j;
+    shunt_impedance 1728000+691200j;
+}
+
+object overhead_line {
+	phases "ABCN";
+	name node1_to_node2;
+	from node1;
+	to node2;
+	length 10.0 mile; //15.0 mile;
+	configuration lc601;
+}
+
+object transformer {
+	phases BS;
+	from node1;
+	to tpl_load2;
+	configuration triplex_xformer_cfg;
+}
+
+object meter {
+	name node1;
+	phases "ABCN";
+	bustype SWING;
+	voltage_A 2401.7771;
+	voltage_B -1200.8886-2080.000j;
+	voltage_C -1200.8886+2080.000j;
+	nominal_voltage 2401.7771;
+	// object recorder {
+		// property "measured_power_A,measured_power_B,measured_power_C";
+		// interval -1;
+		// file measured_power_out.csv;
+	// };
+	object complex_assert {
+		target measured_power_A;
+		object player {
+			property value;
+			file ../data_zip_measload_phaseA.csv;
+		};
+		within 0.3; // can not meet 0.1;
+	};
+	object complex_assert {
+		target measured_power_B;
+		object player {
+			property value;
+			file ../data_zip_measload_phaseB.csv;
+		};
+		within 0.5; // can not meet 0.1;
+	};
+	object complex_assert {
+		target measured_power_C;
+		object player {
+			property value;
+			file ../data_zip_measload_phaseC.csv;
+		};
+		within 0.3; // can not meet 0.1;
+	};
+}
+
+object load {
+	name node2;
+	phases ABCD; // this phasing is the only difference of input from test_ZIPLoad_ZeroBase_NR.glm
+	nominal_voltage 2401.7771;
+	base_power_A base_power_player.value*1.0;
+	base_power_B base_power_player.value*1.0;
+	base_power_C base_power_player.value*1.0;
+	power_pf_A 0.8;
+	current_pf_A 0.75;
+	impedance_pf_A 0.6;
+	power_pf_B 0.8;
+	current_pf_B 0.75;
+	impedance_pf_B 0.6;
+	power_pf_C 0.8;
+	current_pf_C 0.75;
+	impedance_pf_C 0.6;
+	power_fraction_A 0.5;
+	current_fraction_A 0.25;
+	impedance_fraction_A 0.25;
+	power_fraction_B 0.5;
+	current_fraction_B 0.25;
+	impedance_fraction_B 0.25;
+	power_fraction_C 0.5;
+	current_fraction_C 0.25;
+	impedance_fraction_C 0.25;
+}
+
+object triplex_load {
+	name tpl_load2;
+	phases BS;
+	nominal_voltage 120.0;
+	base_power_1 base_power_player.value*1.0;
+	base_power_2 base_power_player.value*1.0;
+	base_power_12 base_power_player.value*1.0;
+	power_pf_1 0.8;
+	current_pf_1 0.75;
+	impedance_pf_1 0.6;
+	power_pf_2 0.8;
+	current_pf_2 0.75;
+	impedance_pf_2 0.6;
+	power_pf_12 0.8;
+	current_pf_12 0.75;
+	impedance_pf_12 0.6;
+	power_fraction_1 0.5;
+	current_fraction_1 0.25;
+	impedance_fraction_1 0.25;
+	power_fraction_2 0.5;
+	current_fraction_2 0.25;
+	impedance_fraction_2 0.25;
+	power_fraction_12 0.5;
+	current_fraction_12 0.25;
+	impedance_fraction_12 0.25;
+}

--- a/powerflow/autotest/test_ZIPLoad_Delta_NR.glm
+++ b/powerflow/autotest/test_ZIPLoad_Delta_NR.glm
@@ -1,0 +1,199 @@
+//  2 bus simple system
+// Tests, that base_power, current_fraction and impedance_fraction work when phasing includes D
+
+// Derived from test_ZIPLoad_ZeroBase_NR.glm except for load:node2 phases
+// The assertion criteria had to be loosened from 0.1, because for constant-current loads,
+//  the line-to-line current angle rotation is referenced to fixed baseangles in load.cpp.
+//  With unbalance in the system, the correct rotation is not exactly +30 degrees.
+
+clock {
+	timezone "PST+8PDT";
+	starttime '2001-01-01 00:00:00 PST';
+	stoptime '2001-01-01 00:01:00 PST';
+	
+}
+
+#set suppress_repeat_messages=1
+#set double_format=%+.12lg
+#set complex_format=%+.12lg%+.12lg%c
+
+module assert;
+module tape;
+
+module powerflow {
+	solver_method NR;
+}
+
+class player {
+	double value;
+}
+
+//Player, for transform
+object player {
+	name base_power_player;
+	file ../data_ZIP_test_base_power.csv;
+}
+
+// Phase Conductor for 601: 556,500 26/7 ACSR
+object overhead_line_conductor {
+	name olc6010;
+	geometric_mean_radius 0.031300;
+	diameter 0.927 in;
+	resistance 0.185900;
+}
+
+// Phase Conductor for 602: 4/0 6/1 ACSR
+object overhead_line_conductor {
+	name olc6020;
+	geometric_mean_radius 0.00814;
+	diameter 0.56 in;
+	resistance 0.592000;
+}
+
+
+// Overhead line configurations
+object line_spacing {
+	name ls500601;	//With capacitance ability
+	distance_AB 2.5;
+	distance_AC 4.5;
+	distance_BC 7.0;
+	distance_BN 5.656854;
+	distance_AN 4.272002;
+	distance_CN 5.0;
+	distance_AE 28.0;
+	distance_BE 28.0;
+	distance_CE 28.0;
+	distance_NE 24.0;
+}
+
+object line_configuration {
+	name lc601;
+	conductor_A olc6010;
+	conductor_B olc6010;
+	conductor_C olc6010;
+	conductor_N olc6020;
+	spacing ls500601;
+}
+
+object transformer_configuration {
+    name "triplex_xformer_cfg";
+    connect_type SINGLE_PHASE_CENTER_TAPPED;
+    install_type POLETOP;
+    primary_voltage 7200.0V;
+    secondary_voltage 120.0V;
+    power_rating 150.0kVA;
+    powerB_rating 150.0kVA;
+    impedance 0.006000+0.013600j;
+    impedance1 0.012000+0.006800j;
+    impedance2 0.012000+0.006800j;
+    shunt_impedance 1728000+691200j;
+}
+
+object overhead_line {
+	phases "ABCN";
+	name node1_to_node2;
+	from node1;
+	to node2;
+	length 10.0 mile; //15.0 mile;
+	configuration lc601;
+}
+
+object transformer {
+	phases BS;
+	from node1;
+	to tpl_load2;
+	configuration triplex_xformer_cfg;
+}
+
+object meter {
+	name node1;
+	phases "ABCN";
+	bustype SWING;
+	voltage_A 2401.7771;
+	voltage_B -1200.8886-2080.000j;
+	voltage_C -1200.8886+2080.000j;
+	nominal_voltage 2401.7771;
+	// object recorder {
+		// property "measured_power_A,measured_power_B,measured_power_C";
+		// interval -1;
+		// file measured_power_out.csv;
+	// };
+	object complex_assert {
+		target measured_power_A;
+		object player {
+			property value;
+			file ../data_zip_measload_phaseA.csv;
+		};
+		within 0.3; // can not meet 0.1;
+	};
+	object complex_assert {
+		target measured_power_B;
+		object player {
+			property value;
+			file ../data_zip_measload_phaseB.csv;
+		};
+		within 0.5; // can not meet 0.1;
+	};
+	object complex_assert {
+		target measured_power_C;
+		object player {
+			property value;
+			file ../data_zip_measload_phaseC.csv;
+		};
+		within 0.3; // can not meet 0.1;
+	};
+}
+
+object load {
+	name node2;
+	phases ABCD; // this phasing is the only difference of input from test_ZIPLoad_ZeroBase_NR.glm
+	nominal_voltage 2401.7771;
+	base_power_A base_power_player.value*1.0;
+	base_power_B base_power_player.value*1.0;
+	base_power_C base_power_player.value*1.0;
+	power_pf_A 0.8;
+	current_pf_A 0.75;
+	impedance_pf_A 0.6;
+	power_pf_B 0.8;
+	current_pf_B 0.75;
+	impedance_pf_B 0.6;
+	power_pf_C 0.8;
+	current_pf_C 0.75;
+	impedance_pf_C 0.6;
+	power_fraction_A 0.5;
+	current_fraction_A 0.25;
+	impedance_fraction_A 0.25;
+	power_fraction_B 0.5;
+	current_fraction_B 0.25;
+	impedance_fraction_B 0.25;
+	power_fraction_C 0.5;
+	current_fraction_C 0.25;
+	impedance_fraction_C 0.25;
+}
+
+object triplex_load {
+	name tpl_load2;
+	phases BS;
+	nominal_voltage 120.0;
+	base_power_1 base_power_player.value*1.0;
+	base_power_2 base_power_player.value*1.0;
+	base_power_12 base_power_player.value*1.0;
+	power_pf_1 0.8;
+	current_pf_1 0.75;
+	impedance_pf_1 0.6;
+	power_pf_2 0.8;
+	current_pf_2 0.75;
+	impedance_pf_2 0.6;
+	power_pf_12 0.8;
+	current_pf_12 0.75;
+	impedance_pf_12 0.6;
+	power_fraction_1 0.5;
+	current_fraction_1 0.25;
+	impedance_fraction_1 0.25;
+	power_fraction_2 0.5;
+	current_fraction_2 0.25;
+	impedance_fraction_2 0.25;
+	power_fraction_12 0.5;
+	current_fraction_12 0.25;
+	impedance_fraction_12 0.25;
+}

--- a/powerflow/load.cpp
+++ b/powerflow/load.cpp
@@ -657,13 +657,13 @@ void load::load_update_fxn(void)
 				// Calculate then shift the constant current to use the posted voltage as the reference angle
         if (has_phase(PHASE_D)) {
           temp_curr = ~complex(real_power,imag_power) / complex(sqrt(3.0)*nominal_voltage,0);
+          temp_angle = temp_curr.Arg() + baseangles[index] + PI/6.0;
         } else {
           temp_curr = ~complex(real_power,imag_power) / complex(nominal_voltage,0);
+          temp_angle = temp_curr.Arg() + baseangles[index];
         }
-
 				//This was "technically correct", but it will break everything else in the system - correcting
 				//temp_angle = temp_curr.Arg() + voltage[index].Arg();
-				temp_angle = temp_curr.Arg() + baseangles[index];
 				temp_curr.SetPolar(temp_curr.Mag(),temp_angle);
 
 				constant_current[index] = temp_curr;

--- a/powerflow/load.cpp
+++ b/powerflow/load.cpp
@@ -655,7 +655,11 @@ void load::load_update_fxn(void)
 				}
 				
 				// Calculate then shift the constant current to use the posted voltage as the reference angle
-				temp_curr = ~complex(real_power,imag_power) / complex(nominal_voltage,0);
+        if (has_phase(PHASE_D)) {
+          temp_curr = ~complex(real_power,imag_power) / complex(sqrt(3.0)*nominal_voltage,0);
+        } else {
+          temp_curr = ~complex(real_power,imag_power) / complex(nominal_voltage,0);
+        }
 
 				//This was "technically correct", but it will break everything else in the system - correcting
 				//temp_angle = temp_curr.Arg() + voltage[index].Arg();
@@ -690,7 +694,11 @@ void load::load_update_fxn(void)
 					imag_power *= -1.0;	//Adjust imaginary portion for negative PF
 				}
 
-				constant_impedance[index] = ~( complex(nominal_voltage * nominal_voltage, 0) / complex(real_power,imag_power) );
+        if (has_phase(PHASE_D)) {
+          constant_impedance[index] = ~( complex(3.0 * nominal_voltage * nominal_voltage, 0) / complex(real_power,imag_power) );
+        } else {
+          constant_impedance[index] = ~( complex(nominal_voltage * nominal_voltage, 0) / complex(real_power,imag_power) );
+        }
 
 			}
 			else

--- a/powerflow/load.cpp
+++ b/powerflow/load.cpp
@@ -655,15 +655,15 @@ void load::load_update_fxn(void)
 				}
 				
 				// Calculate then shift the constant current to use the posted voltage as the reference angle
-        if (has_phase(PHASE_D)) {
-          temp_curr = ~complex(real_power,imag_power) / complex(sqrt(3.0)*nominal_voltage,0);
-          temp_angle = temp_curr.Arg() + baseangles[index] + PI/6.0;
-        } else {
-          temp_curr = ~complex(real_power,imag_power) / complex(nominal_voltage,0);
-          temp_angle = temp_curr.Arg() + baseangles[index];
-        }
-				//This was "technically correct", but it will break everything else in the system - correcting
-				//temp_angle = temp_curr.Arg() + voltage[index].Arg();
+				if (has_phase(PHASE_D)) {
+				  temp_curr = ~complex(real_power,imag_power) / complex(sqrt(3.0)*nominal_voltage,0);
+				  temp_angle = temp_curr.Arg() + baseangles[index] + PI/6.0;
+				} else {
+				  temp_curr = ~complex(real_power,imag_power) / complex(nominal_voltage,0);
+				  temp_angle = temp_curr.Arg() + baseangles[index];
+				}
+
+				//Create the corrected value
 				temp_curr.SetPolar(temp_curr.Mag(),temp_angle);
 
 				constant_current[index] = temp_curr;
@@ -694,12 +694,12 @@ void load::load_update_fxn(void)
 					imag_power *= -1.0;	//Adjust imaginary portion for negative PF
 				}
 
-        if (has_phase(PHASE_D)) {
-          constant_impedance[index] = ~( complex(3.0 * nominal_voltage * nominal_voltage, 0) / complex(real_power,imag_power) );
-        } else {
-          constant_impedance[index] = ~( complex(nominal_voltage * nominal_voltage, 0) / complex(real_power,imag_power) );
-        }
-
+				//Compute the impedance value - adjust for delta-connection, as necessary
+				if (has_phase(PHASE_D)) {
+				  constant_impedance[index] = ~( complex(3.0 * nominal_voltage * nominal_voltage, 0) / complex(real_power,imag_power) );
+				} else {
+				  constant_impedance[index] = ~( complex(nominal_voltage * nominal_voltage, 0) / complex(real_power,imag_power) );
+				}
 			}
 			else
 			{


### PR DESCRIPTION
#### What's this Pull Request do?

When using **current_fraction** or **impedance_fraction**, and the **phases** include **D**, the load current magnitudes were off by a factor of 1.73 or 3.0, respectively. This proposed fix for **D** phasing:

- Multiplies the wye-equivalent constant impedance by 3, so it can be used in a delta-equivalent
- Divides the line current by sqrt(3), and rotates +30 degrees, so it can be used line-to-line

#### Where should the reviewer start?

There are less than a dozen lines changed in **load.cpp**, one modified autotest, and one new autotest.

#### How should this be tested?

- The validation tests all pass
- A new autotest has been created for powerflow, test_ZIPLoad_Delta_NR.glm, with a load that has constant_impedance and constant_current components. It was necessary to loosen the assertion criteria, because the current angle rotation for delta currents is only approximate
- In test_1isochronous_VSI.glm, there is a delta-connected constant-impedance load that was drawing too much power when that test was created. To compensate, its base power has been multiplied by three, so it draws the same power as when the test was created.
- This change has been a significant improvement in the GridAPPS-D and IEEE 9500-node validation efforts.

#### What are the relevant issues?

**baseangles** in load.cpp don't seem to change with actual terminal voltages. This leads to some error in the current angle rotation, more so as the system becomes unbalanced. Even with this approximation, the proposed fix is a significant improvement. 

Note that without using current_fraction, the current angles don't rotate with system conditions, which is unacceptable when delta/wye or wye/delta transformers exist in the model. In other words, constant_current should not be used without the ZIP fractions.

Triplex loads don't have delta phasing, therefore should not require similar adjustments.