### PR TITLE
Avoids my_bool conflict with mariadb 10

### DIFF
--- a/mysql/database.h
+++ b/mysql/database.h
@@ -28,7 +28,7 @@
 
 #include <mysql.h>
 #ifdef MYSQL_VERSION_ID
-#if MYSQL_VERSION_ID > 80000
+#if !defined(MARIADB_VERSION_ID) && MYSQL_VERSION_ID > 80000
 typedef bool my_bool;
 #endif
 #endif


### PR DESCRIPTION
#### What's this Pull Request do?

Avoids compiler errors when compiling `gridlab-d` on a Debian system (e.g. `debian:bullseye-slim` based docker image)

#### Where should the reviewer start?

`mysql` removed the `my_bool` tyepdef in version 8 (`MYSQL_VERSION_ID > 80000`). 2e9cf4c added a work-around to that to re-introduce a `my_bool` typedef.

However, it re-introduced it as a `bool` type, where as `mysql` previously defined this as a `char` type and `mariadb` 10 continues to define `my_bool` as a `char`.

#### How should this be tested?

Here's a gist of our Dockerfile using a cherry-pick of this commit:

https://gist.github.com/devanubis/453e046f2b7b9fe1e256a2b9a4b97cb3

I'm sure you'll have no problem building this branch on a standard `Ubuntu` based system with `mysql` either.


#### Questions:
- [ ] Does this add new dependencies?
  - No
- [ ] Is there appropriate logging included?
  - N/A