### PR TITLE
Merge of Issue/1333 (fix for default solar insolation)

### DIFF
--- a/generators/autotest/test_solar_climate_default_playerval.glm
+++ b/generators/autotest/test_solar_climate_default_playerval.glm
@@ -1,12 +1,9 @@
 // Test that climate defaults are implemented when climate object is absent. 
 // Test that climate data may be input via players (for Insolation, wind speed, ambient temperature -- use solar_tilt_model PLAYERVALUE)
 
-// GridLab-D output has been validated against SAM output. See "Incorporation of NREL Solar Advisor Model Photovoltaic Capabilities with GridLAB-D" (Tuffner et al. 2012). 
-
 #set profiler=1;
 
 clock {
-     //timezone PST+8PDT;
 	 timezone PST8;
      starttime '2009-01-01 00:00:00';
      stoptime '2010-01-01 00:00:00';
@@ -19,7 +16,7 @@ module assert;
 module powerflow {
      solver_method NR;
      NR_iteration_limit 50;
-};
+}
 
 object triplex_meter {
 	name trip_swing;
@@ -98,16 +95,15 @@ object solar { // no climate object available -- using default values
 	area 29.6296 m^2;
 	efficiency 0.135;
 	orientation_azimuth 180; //equator-facing (South)
-	SOLAR_TILT_MODEL SOLPOS;
-	SOLAR_POWER_MODEL FLATPLATE;
+	//BASEEFFICIENCY and DEFAULT tilt model
 	object double_assert {
 		target Insolation;
-		value 190.214; 
+		value 92.902; 
 		within 0.01;
 	};
 	object double_assert {
 		target P_Out;
-		value 3433.18;	
+		value 3589;	//Derated by baseline efficiency model
 		within 0.01; 
 	};
 	// object recorder {

--- a/generators/solar.cpp
+++ b/generators/solar.cpp
@@ -1195,10 +1195,8 @@ TIMESTAMP solar::sync(TIMESTAMP t0, TIMESTAMP t1)
 		{
 			if (weather == NULL)
 			{
-				//Original equation the pointed to statics (and weather, but how would it get here?)
-				//Insolation = shading_factor*(*pSolarD) + *pSolarH + *pSolarG*(1 - cos(tilt_angle))*(*pAlbedo)/2.0;
-				//Old static - static double tout=59.0, rhout=0.75, solar=92.902, wsout=0.0, albdefault=0.2;
-				Insolation = 92.902 * (shading_factor + 1.0 + 0.1 * (1.0 - cos(tilt_angle)));
+				//If no weather, just assume this is the Rated_Insolation (defaults to 1000 W/m^2) by the shading factor.
+				Insolation = Rated_Insolation * shading_factor;
 			}
 			else
 			{


### PR DESCRIPTION
#### What's this Pull Request do?
Fixes the default insolation value in solar.cpp when no weather object is present.  Makes it more sensible.

#### Where should the reviewer start?
Pull the code, run the autotests.  Verify that the selected fix (just use rated_insolation) makes sense.

#### How should this be tested?
Autotests.  test_solar_climate_default_playerval.glm under generators has a default solar object in it.

#### What are the relevant issues?
#1333 
