### PR TITLE
Merge of "all_generator_delta" capability of #1343

### DIFF
--- a/generators/battery.cpp
+++ b/generators/battery.cpp
@@ -240,6 +240,12 @@ int battery::init(OBJECT *parent)
 		}
 	}
 
+	//See if the global flag is set - if so, add the object flag
+	if (all_generator_delta)
+	{
+		obj->flags |= OF_DELTAMODE;
+	}
+
 	//Set the deltamode flag, if desired
 	if ((obj->flags & OF_DELTAMODE) == OF_DELTAMODE)
 	{

--- a/generators/controller_dg.cpp
+++ b/generators/controller_dg.cpp
@@ -92,6 +92,12 @@ int controller_dg::init(OBJECT *parent)
 	gld_property *temp_prop;
 	gld_object *temp_from, *temp_to;
 
+	//See if the global flag is set - if so, add the object flag
+	if (all_generator_delta)
+	{
+		obj->flags |= OF_DELTAMODE;
+	}
+
 	//Set the deltamode flag, if desired
 	if ((thisobj->flags & OF_DELTAMODE) == OF_DELTAMODE)
 	{

--- a/generators/diesel_dg.cpp
+++ b/generators/diesel_dg.cpp
@@ -695,6 +695,12 @@ int diesel_dg::init(OBJECT *parent)
 	double nominal_voltage_value, nom_test_val;
 	set temp_phases;
 
+	//See if the global flag is set - if so, add the object flag
+	if (all_generator_delta)
+	{
+		obj->flags |= OF_DELTAMODE;
+	}
+
 	//Set the deltamode flag, if desired
 	if ((obj->flags & OF_DELTAMODE) == OF_DELTAMODE)
 	{

--- a/generators/generators.h
+++ b/generators/generators.h
@@ -33,6 +33,7 @@
 #define TSNVRDBL 9223372036854775808.0
 
 GLOBAL bool enable_subsecond_models INIT(false); /* normally not operating in delta mode */
+GLOBAL bool all_generator_delta INIT(false);			/* Flag to make all generator objects participate in deltamode (that are capable) -- otherwise is individually flagged per object */
 GLOBAL unsigned long deltamode_timestep INIT(10000000); /* 10 ms timestep */
 GLOBAL double deltamode_timestep_publish INIT(10000000.0); /* 10 ms timestep */
 GLOBAL OBJECT **delta_objects INIT(NULL);				/* Array pointer objects that need deltamode interupdate calls */

--- a/generators/init.cpp
+++ b/generators/init.cpp
@@ -35,6 +35,7 @@ EXPORT CLASS *init(CALLBACKS *fntable, MODULE *module, int argc, char *argv[])
 	/* Publish external global variables */
 	gl_global_create("generators::default_line_voltage",PT_double,&default_line_voltage,PT_UNITS,"V",PT_DESCRIPTION,"line voltage (L-N) to use when no circuit is attached",NULL);
 	gl_global_create("generators::enable_subsecond_models", PT_bool, &enable_subsecond_models,PT_DESCRIPTION,"Enable deltamode capabilities within the generators module",NULL);
+	gl_global_create("generators::all_generator_delta", PT_bool, &all_generator_delta, PT_DESCRIPTION, "Forces all generator objects that are capable to participate in deltamode",NULL);
 	gl_global_create("generators::deltamode_timestep", PT_double, &deltamode_timestep_publish,PT_UNITS,"ns",PT_DESCRIPTION,"Desired minimum timestep for deltamode-related simulations",NULL);
 	gl_global_create("generators::default_temperature_value", PT_double, &default_temperature_value,PT_UNITS,"degF",PT_DESCRIPTION,"Temperature when no climate module is detected",NULL);
 

--- a/generators/inverter.cpp
+++ b/generators/inverter.cpp
@@ -662,6 +662,12 @@ int inverter::init(OBJECT *parent)
 	std::string tempV, tempQ, tempf, tempP;
 	std::string VoltVArSchedInput, freq_pwrSchedInput;
 
+	//See if the global flag is set - if so, add the object flag
+	if (all_generator_delta)
+	{
+		obj->flags |= OF_DELTAMODE;
+	}
+
 	//Set the deltamode flag, if desired
 	if ((obj->flags & OF_DELTAMODE) == OF_DELTAMODE)
 	{

--- a/generators/inverter_dyn.cpp
+++ b/generators/inverter_dyn.cpp
@@ -391,6 +391,12 @@ int inverter_dyn::init(OBJECT *parent)
 		*/
 	}
 
+	//See if the global flag is set - if so, add the object flag
+	if (all_generator_delta)
+	{
+		obj->flags |= OF_DELTAMODE;
+	}
+
 	//Set the deltamode flag, if desired
 	if ((obj->flags & OF_DELTAMODE) == OF_DELTAMODE)
 	{

--- a/generators/solar.cpp
+++ b/generators/solar.cpp
@@ -1028,6 +1028,12 @@ int solar::init(OBJECT *parent)
 		*/
 	}
 
+	//See if the global flag is set - if so, add the object flag
+	if (all_generator_delta)
+	{
+		obj->flags |= OF_DELTAMODE;
+	}
+
 	//Set the deltamode flag, if desired
 	if ((obj->flags & OF_DELTAMODE) == OF_DELTAMODE)
 	{


### PR DESCRIPTION
#### What's this Pull Request do?
Creates the module global `all_generator_delta` to make all deltamode-capable generator objects use deltamode functions.  Prevents needing to do `flags DELTAMODE;` on all the relevant objects.

#### Where should the reviewer start?
Pull the code, compile.  No autotest or anything, since it is just a user functionality improvement.

#### How should this be tested?
You can edit the `test_1isochronous_dg_1PQconstant_dg.glm` file to remove the `flags DELTAMODE;` from the inverter and diesel_dg objects, add the `all_generator_delta` flag to the module, and then run it.  The autotest should still pass like normal.

#### Any background context you want to provide?
Mostly a UX improvement
#### What are the relevant issues?
#1343 
#### Screenshots (if appropriate)
N/A
#### Questions:
- [ ] Does this add new dependencies?
- [ ] Is there appropriate logging included?
