### PR TITLE
fix for Issue 1386

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,12 @@
 [submodule "third_party/jsoncpp_lib"]
 	path = third_party/jsoncpp_lib
 	url = https://github.com/open-source-parsers/jsoncpp.git
+	ignore = dirty
 [submodule "third_party/dlfcn-win32"]
 	path = third_party/dlfcn-win32
 	url = https://github.com/dlfcn-win32/dlfcn-win32.git
+	ignore = dirty
 [submodule "third_party/SuperLU"]
 	path = third_party/SuperLU
 	url = https://github.com/xiaoyeli/superlu.git
+	ignore = dirty


### PR DESCRIPTION
fix for #1386. Adds ignore = dirty to each submodule found in .gitmodules. Now untracked changes due to git submodule update --init will be ignored by git status.
