### PR TITLE
Update group_recorder for deltamode interval 0, -1

### DIFF
--- a/tape/group_recorder.h
+++ b/tape/group_recorder.h
@@ -41,7 +41,7 @@ public:
 	int create();
 	int init(OBJECT *);
 	int isa(char *);
-	TIMESTAMP commit(TIMESTAMP);
+	TIMESTAMP postsync(TIMESTAMP, TIMESTAMP);
 
 	int commit(TIMESTAMP t1, double t1dbl, bool deltacall);
 
@@ -57,6 +57,8 @@ public:
     GL_ATOMIC(double, dInterval)
     GL_ATOMIC(double, dFlush_interval)
 
+	//Public this property, so it can access itself in scope
+	TIMESTAMP write_interval;
 private:
 	int write_header();
 	int read_line();
@@ -73,7 +75,6 @@ private:
 	TIMESTAMP next_write;
 	TIMESTAMP last_write;
 	TIMESTAMP last_flush;
-	TIMESTAMP write_interval;
 	TIMESTAMP flush_interval;
 	int32 write_ct;
 	TAPESTATUS tape_status; // TS_INIT/OPEN/DONE/ERROR


### PR DESCRIPTION
#### What's this Pull Request do?
Makes it so interval 0 and interval -1 works with group_recorder in deltamode.
Also put a fix in so -1 works in QSTS too (apparently was broken).
#### Where should the reviewer start?
See the attached file (generator autotest).  The `group_recorder` is on the bottom if you want to try different intervals.
[test_deltamode_diesel_dg.glm.txt](https://github.com/gridlab-d/gridlab-d/files/9465702/test_deltamode_diesel_dg.glm.txt)
#### How should this be tested?
Make sure nothings fails, and try the file uploaded (but again, has to be in generators/autotest/subfolder)
#### Any background context you want to provide?
N/A
#### What are the relevant issues?
#1354 
#### Screenshots (if appropriate)
N/A
#### Questions:
- [ ] Does this add new dependencies?
- [ ] Is there appropriate logging included?
