### PR TITLE
Issue/1411

### DIFF
--- a/powerflow/autotest/test_IEEE_13_NR_child_delta_phases.glm
+++ b/powerflow/autotest/test_IEEE_13_NR_child_delta_phases.glm
@@ -1,0 +1,763 @@
+//IEEE 13-node with "vaguely phased" children
+//Basically tests the issue/fix with delta-connected children
+//found in issue/1411
+
+#set iteration_limit=100000;
+
+clock {
+	timezone EST+5EDT;
+	starttime '2000-01-01 0:00:00';
+	stoptime '2000-01-01 0:00:01';
+}
+
+module powerflow {
+	solver_method NR;
+	line_capacitance true;
+	}
+module assert;
+
+object voltdump {
+    filename IEEE_13_NR_voltage.csv;
+	mode POLAR;
+}
+
+// Phase Conductor for 601: 556,500 26/7 ACSR
+object overhead_line_conductor {
+	name olc6010;
+	geometric_mean_radius 0.031300;
+	diameter 0.927 in;
+	resistance 0.185900;
+}
+
+// Phase Conductor for 602: 4/0 6/1 ACSR
+object overhead_line_conductor {
+	name olc6020;
+	geometric_mean_radius 0.00814;
+	diameter 0.56 in;
+	resistance 0.592000;
+}
+
+// Phase Conductor for 603, 604, 605: 1/0 ACSR
+object overhead_line_conductor {
+	name olc6030;
+	geometric_mean_radius 0.004460;
+	diameter 0.4 in;
+	resistance 1.120000;
+}
+
+
+// Phase Conductor for 606: 250,000 AA,CN
+object underground_line_conductor { 
+	 name ulc6060;
+	 outer_diameter 1.290000;
+	 conductor_gmr 0.017100;
+	 conductor_diameter 0.567000;
+	 conductor_resistance 0.410000;
+	 neutral_gmr 0.0020800; 
+	 neutral_resistance 14.87200;  
+	 neutral_diameter 0.0640837;
+	 neutral_strands 13.000000;
+	 insulation_relative_permitivitty 2.3;
+	 shield_gmr 0.000000;
+	 shield_resistance 0.000000;
+}
+
+// Phase Conductor for 607: 1/0 AA,TS N: 1/0 Cu
+object underground_line_conductor { 
+	 name ulc6070;
+	 outer_diameter 1.060000;
+	 conductor_gmr 0.011100;
+	 conductor_diameter 0.368000;
+	 conductor_resistance 0.970000;
+	 neutral_gmr 0.011100;
+	 neutral_resistance 0.970000; // Unsure whether this is correct
+	 neutral_diameter 0.0640837;
+	 neutral_strands 6.000000;
+	 insulation_relative_permitivitty 2.3;
+	 shield_gmr 0.000000;
+	 shield_resistance 0.000000;
+}
+
+// Overhead line configurations
+object line_spacing {
+	name ls500601;
+	distance_AB 2.5;
+	distance_AC 4.5;
+	distance_BC 7.0;
+	distance_BN 5.656854;
+	distance_AN 4.272002;
+	distance_CN 5.0;
+	distance_AE 28.0;
+	distance_BE 28.0;
+	distance_CE 28.0;
+	distance_NE 24.0;
+}
+
+// Overhead line configurations
+object line_spacing {
+	name ls500602;
+	distance_AC 2.5;
+	distance_AB 4.5;
+	distance_BC 7.0;
+	distance_CN 5.656854;
+	distance_AN 4.272002;
+	distance_BN 5.0;
+	distance_AE 28.0;
+	distance_BE 28.0;
+	distance_CE 28.0;
+	distance_NE 24.0;
+}
+
+object line_spacing {
+	name ls505603;
+	distance_BC 7.0;
+	distance_CN 5.656854;
+	distance_BN 5.0;
+	distance_BE 28.0;
+	distance_CE 28.0;
+	distance_NE 24.0;
+}
+
+object line_spacing {
+	name ls505604;
+	distance_AC 7.0;
+	distance_AN 5.656854;
+	distance_CN 5.0;
+	distance_AE 28.0;
+	distance_CE 28.0;
+	distance_NE 24.0;
+}
+
+object line_spacing {
+	name ls510;
+	distance_CN 5.0;
+	distance_CE 28.0;
+	distance_NE 24.0;
+}
+
+object line_configuration {
+	name lc601;
+	conductor_A olc6010;
+	conductor_B olc6010;
+	conductor_C olc6010;
+	conductor_N olc6020;
+	spacing ls500601;
+}
+
+object line_configuration {
+	name lc602;
+	conductor_A olc6020;
+	conductor_B olc6020;
+	conductor_C olc6020;
+	conductor_N olc6020;
+	spacing ls500602;
+}
+
+object line_configuration {
+	name lc603;
+	conductor_B olc6030;
+	conductor_C olc6030;
+	conductor_N olc6030;
+	spacing ls505603;
+}
+
+object line_configuration {
+	name lc604;
+	conductor_A olc6030;
+	conductor_C olc6030;
+	conductor_N olc6030;
+	spacing ls505604;
+}
+
+object line_configuration {
+	name lc605;
+	conductor_C olc6030;
+	conductor_N olc6030;
+	spacing ls510;
+}
+
+//Underground line configuration
+object line_spacing {
+	 name ls515;
+	 distance_AB 0.500000;
+	 distance_BC 0.500000;
+	 distance_AC 1.000000;
+}
+
+object line_spacing {
+	 name ls520;
+	 distance_AN 0.083333;
+}
+
+object line_configuration {
+	 name lc606;
+	 conductor_A ulc6060;
+	 conductor_B ulc6060;
+	 conductor_C ulc6060;
+	 spacing ls515;
+}
+
+object line_configuration {
+	 name lc607;
+	 conductor_A ulc6070;
+	 conductor_N ulc6070;
+	 spacing ls520;
+}
+
+// Define line objects
+object overhead_line {
+     phases "BCN";
+     name line_632-645;
+     from n632;
+     to l645;
+     length 500;
+     configuration lc603;
+}
+
+object overhead_line {
+     phases "BCN";
+     name line_645-646;
+    from l645;
+     to l646;
+     length 300;
+     configuration lc603;
+}
+
+object overhead_line { //630632 {
+     phases "ABCN";
+     name line_630-632;
+     from n630;
+     to n632;
+     length 2000;
+     configuration lc601;
+}
+
+//Split line for distributed load
+object overhead_line { //6326321 {
+     phases "ABCN";
+     name line_632-6321;
+     from n632;
+     to l6321;
+     length 500;
+     configuration lc601;
+}
+
+object overhead_line { //6321671 {
+     phases "ABCN";
+     name line_6321-671;
+    from l6321;
+     to l671;
+     length 1500;
+     configuration lc601;
+}
+//End split line
+
+object overhead_line { //671680 {
+     phases "ABCN";
+     name line_671-680;
+    from l671;
+     to n680;
+     length 1000;
+     configuration lc601;
+}
+
+object overhead_line { //671684 {
+     phases "ACN";
+     name line_671-684;
+    from l671;
+     to n684;
+     length 300;
+     configuration lc604;
+}
+
+ object overhead_line { //684611 {
+      phases "CN";
+      name line_684-611;
+      from n684;
+      to l611;
+      length 300;
+      configuration lc605;
+}
+
+object underground_line { //684652 {
+      phases "AN";
+      name line_684-652;
+      from n684;
+      to l652;
+      length 800;
+      configuration lc607;
+}
+
+object underground_line { //692675 {
+     phases "ABC";
+     name line_692-675;
+    from l692;
+     to l675;
+     length 500;
+     configuration lc606;
+}
+
+object overhead_line { //632633 {
+     phases "ABCN";
+     name line_632-633;
+     from n632;
+     to n633;
+     length 500;
+     configuration lc602;
+}
+
+// Create node objects
+object node { //633 {
+     name n633;
+     phases "ABCN";
+     voltage_A 2401.7771;
+     voltage_B -1200.8886-2080.000j;
+     voltage_C -1200.8886+2080.000j;
+     nominal_voltage 2401.7771;
+	 object complex_assert {
+		target voltage_A;
+		value 2445.01-2.56d;
+		within 2;
+	 };	 object complex_assert {
+		target voltage_B;
+		value 2498.15-121.77d;
+		within 2;
+	 };	 object complex_assert {
+		target voltage_C;
+		value 2437.54+117.83d;
+		within 2;
+	 };
+}
+
+object node { //630 {
+     name n630;
+     phases "ABCN";
+     voltage_A 2401.7771+0j;
+     voltage_B -1200.8886-2080.000j;
+     voltage_C -1200.8886+2080.000j;
+     nominal_voltage 2401.7771;
+}
+ 
+object node { //632 {
+     name n632;
+     phases "ABCN";
+     voltage_A 2401.7771;
+     voltage_B -1200.8886-2080.000j;
+     voltage_C -1200.8886+2080.000j;
+     nominal_voltage 2401.7771;
+	 object complex_assert {
+		target voltage_A;
+		value 2452.29-2.49d;
+		within 2;
+	 };	 object complex_assert {
+		target voltage_B;
+		value 2502.70-121.72d;
+		within 2;
+	 };	 object complex_assert {
+		target voltage_C;
+		value 2443.82+117.83d;
+		within 2;
+	 };
+}
+
+object node { //650 {
+      name n650;
+      phases "ABCN";
+      bustype SWING;
+      voltage_A 2401.7771;
+      voltage_B -1200.8886-2080.000j;
+      voltage_C -1200.8886+2080.000j;
+      nominal_voltage 2401.7771;
+	 object complex_assert {
+		target voltage_A;
+		value 2401.7771;
+		within 2;
+	 };	 object complex_assert {
+		target voltage_B;
+		value 2401.7771-120.0d;
+		within 2;
+	 };	 object complex_assert {
+		target voltage_C;
+		value 2401.7771+120.0d;
+		within 2;
+	 };
+} 
+ 
+object node { //680 {
+       name n680;
+       phases "ABCN";
+       voltage_A 2401.7771;
+       voltage_B -1200.8886-2080.000j;
+       voltage_C -1200.8886+2080.000j;
+       nominal_voltage 2401.7771;
+		object complex_assert {
+			target voltage_A;
+			value 2377.78-5.3d;
+			within 2;
+		};	 
+		object complex_assert {
+			target voltage_B;
+			value 2528.94-122.34d;
+			within 2;
+		};	
+		object complex_assert {
+			target voltage_C;
+			value 2348.63+116.03d;
+			within 10;  //@note: V_C not exactly matching with IEEE 13-node test feeder
+		};
+}
+ 
+ 
+object node { //684 {
+      name n684;
+      phases "ACN";
+      voltage_A 2401.7771;
+      voltage_B -1200.8886-2080.000j;
+      voltage_C -1200.8886+2080.000j;
+      nominal_voltage 2401.7771;
+	object complex_assert {
+		target voltage_A;
+		value 2373.11-5.32d;
+		within 2;
+	};	 
+	object complex_assert {
+		target voltage_C; 
+		value 2343.80+115.93d;
+		within 2;  
+	};
+} 
+ 
+ 
+ 
+// Create load objects 
+object node {
+	name node634;
+	phases ABC;
+	nominal_voltage 480.000;
+}
+
+object load { //634 {
+     name l634;
+	 parent node634;
+     phases "ABCN";
+     voltage_A 480.000+0j;
+     voltage_B -240.000-415.6922j;
+     voltage_C -240.000+415.6922j;
+     constant_power_A 160000+110000j;
+     constant_power_B 120000+90000j;
+     constant_power_C 120000+90000j;
+     nominal_voltage 480.000;
+	object complex_assert {
+		target voltage_A;
+		within 2;
+		value 275.47-3.23d;
+	};
+	object complex_assert {
+		target voltage_B;
+		within 2;
+		value 283.16-122.22d;
+	};
+	object complex_assert {
+		target voltage_C;
+		within 2;
+		value 276.04+117.35d;
+	};
+}
+ 
+object node {
+	name node645;
+	phases BC;
+	nominal_voltage 2401.7771;
+}
+
+//Childed load to test item in issue/1411 
+object load { //645 {
+     name l645;
+	 parent node645;
+     phases "BCN";
+     voltage_A 2401.7771;
+     voltage_B -1200.8886-2080.000j;
+     voltage_C -1200.8886+2080.000j;
+     constant_power_B 170000+125000j;
+     nominal_voltage 2401.7771;
+	object complex_assert {
+		target voltage_B;
+		within 2;
+		value 2480.67-121.90d;
+	};
+	object complex_assert {
+		target voltage_C;
+		within 2;
+		value 2439.07+117.86d;
+	};
+}
+
+object node {
+	name node646;
+	phases BC;
+	nominal_voltage 2401.7771;
+}
+
+object load { //646 {
+     name l646;
+	 parent node646;
+     phases "BCD";
+     voltage_B -1200.8886-2080.000j;
+     voltage_C -1200.8886+2080.000j;
+     constant_impedance_B 56.5993+32.4831j;
+     nominal_voltage 2401.7771;
+    	object complex_assert {
+    		target voltage_B;
+    		within 2;
+    		value 2476.50-121.98d;
+    	};
+    	object complex_assert {
+    		target voltage_C;
+    		within 2;
+    		value 2434.12+117.90d;
+	};
+}
+ 
+object node {
+	name node652;
+	phases A;
+	nominal_voltage 2401.7771;
+}
+
+object load { //652 {
+     name l652;
+	 parent node652;
+     phases "AN";
+     voltage_A 2401.7771;
+     voltage_B -1200.8886-2080.000j;
+     voltage_C -1200.8886+2080.000j;
+     constant_impedance_A 31.0501+20.8618j;
+     nominal_voltage 2401.7771;
+    	object complex_assert {
+    		target voltage_A;
+    		within 2;
+    		value 2363.35-5.21d;
+    	};
+}
+
+object node {
+	name node671;
+	phases ABC;
+	nominal_voltage 2401.7771;
+}
+
+object load { //671 {
+     name l671;
+	 parent node671;
+     phases "ABCD";
+     voltage_A 2401.7771;
+     voltage_B -1200.8886-2080.000j;
+     voltage_C -1200.8886+2080.000j;
+     constant_power_A 385000+220000j;
+     constant_power_B 385000+220000j;
+     constant_power_C 385000+220000j;
+     nominal_voltage 2401.7771;
+    	object complex_assert {
+    		target voltage_A;
+    		within 2;
+    		value 2377.78-5.3d;
+    	};
+    	object complex_assert {
+    		target voltage_B;
+    		within 2;
+    		value 2528.94-122.34d;
+    	};
+    	object complex_assert {
+    		target voltage_C;
+    		within 8;
+    		value 2348.63+116.02d;
+	};
+}
+
+object node {
+	name node675;
+	phases ABC;
+	nominal_voltage 2401.7771;
+}
+
+object load { //675 {
+     name l675;
+	 parent node675;
+     phases "ABC";
+     voltage_A 2401.7771;
+     voltage_B -1200.8886-2080.000j;
+     voltage_C -1200.8886+2080.000j;
+     constant_power_A 485000+190000j;
+     constant_power_B 68000+60000j;
+     constant_power_C 290000+212000j;
+     constant_impedance_A 0.00-28.8427j;          //Shunt Capacitors
+     constant_impedance_B 0.00-28.8427j;
+     constant_impedance_C 0.00-28.8427j;
+     nominal_voltage 2401.7771;
+    	object complex_assert {
+    		target voltage_A;
+    		within 2;
+    		value 2362.16-5.55d;
+    	};
+    	object complex_assert {
+    		target voltage_B;
+    		within 2;
+    		value 2534.68-122.52d;
+    	};
+    	object complex_assert {
+    		target voltage_C;
+    		within 8;
+    		value 2344.04+116.04d;
+	};
+}
+
+object node {
+	name node692;
+	phases ABC;
+	nominal_voltage 2401.7771;
+}
+ 
+object load { //692 {
+     name l692;
+	 parent node692;
+     phases "ABCD";
+     voltage_A 2401.7771;
+     voltage_B -1200.8886-2080.000j;
+     voltage_C -1200.8886+2080.000j;
+     constant_current_A 0+0j;
+     constant_current_B 0+0j;
+     constant_current_C -17.2414+51.8677j;
+     nominal_voltage 2401.7771;
+	object complex_assert {
+		target voltage_A;
+		within 2;
+		value 2377.78-5.30d;
+	};
+	object complex_assert {
+		target voltage_B;
+		within 2;
+		value 2528.94-122.34d;
+	};
+	object complex_assert {
+		target voltage_C;
+		within 8;
+		value 2348.63+116.02d;
+	};
+}
+
+object node {
+	name node611;
+	phases C;
+	nominal_voltage 2401.7771;
+}
+ 
+object load { //611 {
+     name l611;
+	 parent node611;
+     phases "CN";
+     voltage_A 2401.7771;
+     voltage_B -1200.8886-2080.000j;
+     voltage_C -1200.8886+2080.000j;
+     constant_current_C -6.5443+77.9524j;
+     constant_impedance_C 0.00-57.6854j;         //Shunt Capacitor
+     nominal_voltage 2401.7771;
+	object complex_assert {
+		target voltage_C;
+		within 8;
+		value 2339.00+115.78d;
+	};
+}
+ 
+// distributed load between node 632 and 671
+// 2/3 of load 1/4 of length down line: Kersting p.56
+object load { //6711 {
+     name l6711;
+     parent l671;
+     phases "ABC";
+     voltage_A 2401.7771;
+     voltage_B -1200.8886-2080.000j;
+     voltage_C -1200.8886+2080.000j;
+     constant_power_A 5666.6667+3333.3333j;
+     constant_power_B 22000+12666.6667j;
+     constant_power_C 39000+22666.6667j;
+     nominal_voltage 2401.7771;
+}
+
+object load { //6321 {
+     name l6321;
+     phases "ABCN";
+     voltage_A 2401.7771;
+     voltage_B -1200.8886-2080.000j;
+     voltage_C -1200.8886+2080.000j;
+     constant_power_A 11333.333+6666.6667j;
+     constant_power_B 44000+25333.3333j;
+     constant_power_C 78000+45333.3333j;
+     nominal_voltage 2401.7771;
+}
+ 
+
+ 
+// Switch
+object switch {
+     phases "ABCN";
+     name switch_671-692;
+    from l671;
+     to l692;
+     status CLOSED;
+}
+ 
+// Transformer
+object transformer_configuration {
+	name tc400;
+	connect_type WYE_WYE;
+  	install_type PADMOUNT;
+  	power_rating 500;
+  	primary_voltage 4160;
+  	secondary_voltage 480;
+  	resistance 0.011;
+  	reactance 0.02;
+}
+  
+object transformer {
+  	phases "ABCN";
+  	name transformer_633-634;
+  	from n633;
+  	to l634;
+  	configuration tc400;
+}
+  
+ 
+// Regulator
+object regulator_configuration {
+	name regconfig6506321;
+	connect_type 1;
+	band_center 122.000;
+	band_width 2.0;
+	time_delay 30.0;
+	raise_taps 16;
+	lower_taps 16;
+	current_transducer_ratio 700;
+	power_transducer_ratio 20;
+	compensator_r_setting_A 3.0;
+	compensator_r_setting_B 3.0;
+	compensator_r_setting_C 3.0;
+	compensator_x_setting_A 9.0;
+	compensator_x_setting_B 9.0;
+	compensator_x_setting_C 9.0;
+	CT_phase "ABC";
+	PT_phase "ABC";
+	regulation 0.10;
+	Control MANUAL;
+	Type A;
+	tap_pos_A 10;
+	tap_pos_B 8;
+	tap_pos_C 11;
+}
+  
+object regulator {
+	 name fregn650n630;
+	 phases "ABC";
+	 from n650;
+	 to n630;
+	 configuration regconfig6506321;
+}

--- a/powerflow/load.cpp
+++ b/powerflow/load.cpp
@@ -401,6 +401,41 @@ int load::init(OBJECT *parent)
 		//Default else - not needed
 	}
 
+	//Simple Check to see if phases are there - only works for GLM-specified values (instead of players)
+	if (has_phase(PHASE_D))
+	{
+		//Crude phase checks
+		if (((constant_power[0].Mag() > 0.0) || (constant_current[0].Mag() > 0.0) || (constant_impedance[0].Mag() > 0.0) || (fabs(base_power[0]) > 0.0)) && !has_phase(PHASE_A|PHASE_B))
+		{
+			gl_warning("load:%d %s - delta-connected load components for xxx_A need phases AB to be present",obj->id,(obj->name?obj->name:"Unnamed"));
+			/*   TROUBLESHOOT
+			A load object has a delta connection implied in the phase, but the load specified requires more phases than are present on the object.
+			e.g., constant_power_A for a delta connection implies phases must include AB, but one of these is missing.  This load value will not
+			be calculated correctly and/or excluded from the powerflow.
+			*/
+		}
+
+		if (((constant_power[1].Mag() > 0.0) || (constant_current[1].Mag() > 0.0) || (constant_impedance[1].Mag() > 0.0) || (fabs(base_power[1]) > 0.0)) && !has_phase(PHASE_B|PHASE_C))
+		{
+			gl_warning("load:%d %s - delta-connected load components for xxx_B need phases BC to be present",obj->id,(obj->name?obj->name:"Unnamed"));
+			/*   TROUBLESHOOT
+			A load object has a delta connection implied in the phase, but the load specified requires more phases than are present on the object.
+			e.g., constant_power_B for a delta connection implies phases must include BC, but one of these is missing.  This load value will not
+			be calculated correctly and/or excluded from the powerflow.
+			*/
+		}
+
+		if (((constant_power[2].Mag() > 0.0) || (constant_current[2].Mag() > 0.0) || (constant_impedance[2].Mag() > 0.0) || (fabs(base_power[2]) > 0.0)) && !has_phase(PHASE_C|PHASE_A))
+		{
+			gl_warning("load:%d %s - delta-connected load components for xxx_C need phases CA to be present",obj->id,(obj->name?obj->name:"Unnamed"));
+			/*   TROUBLESHOOT
+			A load object has a delta connection implied in the phase, but the load specified requires more phases than are present on the object.
+			e.g., constant_power_C for a delta connection implies phases must include CA, but one of these is missing.  This load value will not
+			be calculated correctly and/or excluded from the powerflow.
+			*/
+		}
+	}
+
 	return ret_value;
 }
 

--- a/powerflow/node.cpp
+++ b/powerflow/node.cpp
@@ -738,23 +738,14 @@ int node::init(OBJECT *parent)
 			//Do same for child
 			if ((phases & PHASE_D) == PHASE_D)
 			{
-				//Delta-connected - technically represents "two phases"
-				if ((phases & PHASE_A) == PHASE_A)
-				{
-					//AD = AB
-					c_phase_to_check |= (PHASE_A | PHASE_B);
-				}
-
-				if ((phases & PHASE_B) == PHASE_B)
-				{
-					//BD = BC
-					c_phase_to_check |= (PHASE_B | PHASE_C);
-				}
-
-				if ((phases & PHASE_C) == PHASE_C)
-				{
-					//CD = CA
-					c_phase_to_check |= (PHASE_A | PHASE_C);
+				if ((phases & PHASE_ABC) == PHASE_ABC) { // all three phases, or one pair of two phases
+					c_phase_to_check = PHASE_ABC;
+				} else if ((phases & (PHASE_A | PHASE_B)) == (PHASE_A | PHASE_B)) {
+					c_phase_to_check = (PHASE_A | PHASE_B);
+				} else if ((phases & (PHASE_B | PHASE_C)) == (PHASE_B | PHASE_C)) {
+					c_phase_to_check = (PHASE_B | PHASE_C);
+				} else if ((phases & (PHASE_C | PHASE_A)) == (PHASE_C | PHASE_A)) {
+					c_phase_to_check = (PHASE_C | PHASE_A);
 				}
 			}
 			else

--- a/powerflow/node.cpp
+++ b/powerflow/node.cpp
@@ -709,49 +709,10 @@ int node::init(OBJECT *parent)
 			}
 
 			//Create base phase set for parent
-			if ((parNode->phases & PHASE_D) == PHASE_D)
-			{
-				//Delta-connected - technically represents "two phases"
-				if ((parNode->phases & PHASE_A) == PHASE_A)
-				{
-					//AD = AB
-					p_phase_to_check |= (PHASE_A | PHASE_B);
-				}
-
-				if ((parNode->phases & PHASE_B) == PHASE_B)
-				{
-					//BD = BC
-					p_phase_to_check |= (PHASE_B | PHASE_C);
-				}
-
-				if ((parNode->phases & PHASE_C) == PHASE_C)
-				{
-					//CD = CA
-					p_phase_to_check |= (PHASE_A | PHASE_C);
-				}
-			}
-			else
-			{
-				p_phase_to_check = (parNode->phases & PHASE_ABC);
-			}
+			p_phase_to_check = (parNode->phases & PHASE_ABC);
 
 			//Do same for child
-			if ((phases & PHASE_D) == PHASE_D)
-			{
-				if ((phases & PHASE_ABC) == PHASE_ABC) { // all three phases, or one pair of two phases
-					c_phase_to_check = PHASE_ABC;
-				} else if ((phases & (PHASE_A | PHASE_B)) == (PHASE_A | PHASE_B)) {
-					c_phase_to_check = (PHASE_A | PHASE_B);
-				} else if ((phases & (PHASE_B | PHASE_C)) == (PHASE_B | PHASE_C)) {
-					c_phase_to_check = (PHASE_B | PHASE_C);
-				} else if ((phases & (PHASE_C | PHASE_A)) == (PHASE_C | PHASE_A)) {
-					c_phase_to_check = (PHASE_C | PHASE_A);
-				}
-			}
-			else
-			{
-				c_phase_to_check = (parNode->phases & PHASE_ABC);
-			}
+			c_phase_to_check = (phases & PHASE_ABC);
 
 			//Fundamental check - see if we're even base compatible
 			if ((p_phase_to_check & c_phase_to_check) != c_phase_to_check)	//Our parent is lacking, fail


### PR DESCRIPTION
This fixes the parent-child phasing checks for line-to-line (D) loads, where the parent has (N). The existing logic was susceptible to fall-through errors #1411. The proposed logic supports either three-phase D loads, or one D load (AB, BC, or CA) in a single object.  This is compatible with usage in the IEEE 13-bus autotest suite.  However, there still isn't a clear way to specify two line-to-line loads in the same load object.

- All 646/646 autotests pass on Ubuntu 20 with gcc 9.4.
- The [CIMHub test](https://github.com/GRIDAPPSD/CIMHub/tree/feature/SETO/tests), which used to pass with GridLAB-D v4.3, now passes with the proposed change to v5.
