### PR TITLE
Bug fix in Cblock coefficient calculation

### DIFF
--- a/generators/cblock.cpp
+++ b/generators/cblock.cpp
@@ -22,7 +22,7 @@ Cblock::~Cblock(void)
 void Cblock::setcoeffs(double *a,double *b)
 {
   p_A[0] = -a[1]/a[0];
-  p_B[0] = (b[1] - a[1]*b[0])/a[0];
+  p_B[0] = b[1]/a[0] - a[1]*b[0]/(a[0]*a[0]);
   p_C[0] = 1.0;
   p_D[0] = b[0]/a[0];
 }


### PR DESCRIPTION
#### What's this Pull Request do?
Updates the coefficient calculation for Cblock class
#### Where should the reviewer start?
src/generators/cblock.cpp
#### How should this be tested?
Tests for inverter_dyn moddel
#### Any background context you want to provide?
The expression for`B` coefficient of the `Cblock` class was incorrect. This change fixes this expression. 
#### What are the relevant issues?
#### Screenshots (if appropriate)
#### Questions:
- [ ] Does this add new dependencies?
- [ ] Is there appropriate logging included?
