### PR TITLE
Merge fixes in #1432 to add checks/error catch for three-phase to triplex connections

### DIFF
--- a/powerflow/autotest/test_transformer_not_SPCT_err.glm
+++ b/powerflow/autotest/test_transformer_not_SPCT_err.glm
@@ -1,0 +1,104 @@
+// Test to check "failure" for a single-phase
+// transformer and triplex phasing/connections
+// This should error out, per the checks added
+// as part of #1432
+
+module powerflow 
+{
+	solver_method NR;
+}   
+
+// Phase Conductor 556,500 26/7 ACSR
+object overhead_line_conductor 
+{
+	name conductor1; 
+	geometric_mean_radius 0.031300;
+	resistance 0.185900;
+}
+
+// Phase Conductor 4/0 6/1 ACSR
+object overhead_line_conductor 
+{
+	name conductor2;
+	geometric_mean_radius 0.00814;
+	resistance 0.592000;
+}
+
+// Overhead line spacings
+
+// ID-500abcn
+object line_spacing 
+{
+	name line_spacing1;
+	distance_AB 2.5;
+	distance_AC 4.5;
+	distance_BC 7.0;
+	distance_BN 5.656854;
+	distance_AN 4.272002;
+	distance_CN 5.0;
+}
+
+// Line configurations
+// Configuration 601
+object line_configuration 
+{
+	name line_configuration1;
+	conductor_A conductor1;
+	conductor_B conductor1;
+	conductor_C conductor1;
+	conductor_N conductor2;
+	spacing line_spacing1;
+}
+
+object overhead_line 
+{
+	 name overhead_line3;
+	 phases "ABCN";
+	 from Swing_node;
+	 to three_phase_node;
+	 length 2000;
+	 configuration line_configuration1;
+}
+
+// Create node objects
+object node 
+{
+	name Swing_node;
+	bustype SWING;
+	phases "ABCN";
+	nominal_voltage 2401.7771;
+}
+
+object node 
+{
+	name three_phase_node;
+	phases "ABCN";
+	nominal_voltage 2401.7771;
+}
+
+//Added objects that would fail for #1432
+object transformer_configuration {
+	name "xfrmcfg_ABCN_480";
+	primary_voltage 480.0 V;
+	secondary_voltage 120 V;
+	connect_type SINGLE_PHASE;
+	// connect_type SINGLE_PHASE_CENTER_TAPPED;	//Correct transformer
+	resistance 0.01 Ohm;
+	reactance 0.06 Ohm;
+	install_type "PADMOUNT";
+	power_rating 80000.0;
+}
+object transformer {
+	name "broken_transformer";
+	from "three_phase_node";
+	to "node_5";
+	phases C;
+	// phases CS;	//Correct phases, with correct transformer
+	configuration "xfrmcfg_ABCN_480";
+}
+
+object triplex_node {
+	name "node_5";
+	phases CS;
+	nominal_voltage 120 V;
+}

--- a/powerflow/transformer.cpp
+++ b/powerflow/transformer.cpp
@@ -132,6 +132,8 @@ void transformer::fetch_double(double **prop, const char *name, OBJECT *parent){
 int transformer::init(OBJECT *parent)
 {
 	int idex;
+	gld_property *tphases_ref;
+	set tphases;
 
 	if (!configuration)
 		GL_THROW("no transformer configuration specified.");
@@ -179,6 +181,25 @@ int transformer::init(OBJECT *parent)
 		return 2;	//Return the deferment - no sense doing everything else!
 
 	OBJECT *obj = OBJECTHDR(this);
+
+	//map and pull the phases
+	tphases_ref = new gld_property(to,"phases");
+
+	//Check it
+	if (!tphases_ref->is_set() || !tphases_ref->is_valid())
+	{
+		GL_THROW("Transformer:%s failed to map the phases of the \"to\" node",obj->name?obj->name:"unnamed");
+		/*  TROUBLESHOOT
+		While attempting to map the phases property of the "to" node of the transformer, an error occurred.  Ensure that object
+		actually is a powerflow node and try again.  If the error persists, please submit an issue in issue tracker.
+		*/
+	}
+
+	//Map them back
+	tphases = tphases_ref->get_set();
+
+	//Remove it
+	delete tphases_ref;
 
 	V_base = config->V_secondary;
 	voltage_ratio = nt = config->V_primary / config->V_secondary;
@@ -234,6 +255,17 @@ int transformer::init(OBJECT *parent)
 			{
 				nt_c = inv_nt_c = 0.0;
 				zt_c = gld::complex(0,0);
+			}
+
+			//General phase check - prevents issue that popped up in issue 1432
+			if (has_phase(PHASE_S) || ((tphases & PHASE_S) == PHASE_S))
+			{
+				GL_THROW("Transformer:%s has a triplex phase or a triplex \"to\" node, but it is not an SPCT transformer",obj->name?obj->name:"unnamed");
+				/*  TROUBLESHOOT
+				A transformer has triplex characteristics (S phase or a triplex_node attached), but it is not
+				configured as an SPCT transformer.  Please check your transformer configuration or attached
+				node.
+				*/
 			}
 			
 			if (solver_method==SM_FBS)
@@ -496,6 +528,13 @@ int transformer::init(OBJECT *parent)
 			break;
 		case transformer_configuration::DELTA_DELTA:
 
+			//General phase check - prevents issue that popped up in issue 1432
+			if (has_phase(PHASE_S) || ((tphases & PHASE_S) == PHASE_S))
+			{
+				GL_THROW("Transformer:%s has a triplex phase or a triplex \"to\" node, but it is not an SPCT transformer",obj->name?obj->name:"unnamed");
+				//Defined above
+			}
+
 			if (solver_method==SM_FBS)
 			{
 				a_mat[0][0] = a_mat[1][1] = a_mat[2][2] = nt * 2.0 / 3.0;
@@ -546,7 +585,14 @@ int transformer::init(OBJECT *parent)
 			}
 			break;
 		case transformer_configuration::DELTA_GWYE:
-			
+
+			//General phase check - prevents issue that popped up in issue 1432
+			if (has_phase(PHASE_S) || ((tphases & PHASE_S) == PHASE_S))
+			{
+				GL_THROW("Transformer:%s has a triplex phase or a triplex \"to\" node, but it is not an SPCT transformer",obj->name?obj->name:"unnamed");
+				//Defined above
+			}
+
 			if (solver_method==SM_FBS)
 			{
 				if (nt>1.0)//step down transformer

--- a/powerflow/triplex_node.cpp
+++ b/powerflow/triplex_node.cpp
@@ -173,10 +173,12 @@ int triplex_node::init(OBJECT *parent)
 	if ( !(has_phase(PHASE_S)) )
 	{
 		OBJECT *obj = OBJECTHDR(this);
-		gl_warning("Init() triplex_node (name:%s, id:%d): Phases specified did not include phase S. Adding phase S.", obj->name,obj->id);
+		gl_warning("Init() triplex_node (name:%s, id:%d): Phases specified did not include phase S. Adding phase S. Check upstream devices.", obj->name,obj->id);
 		/* TROUBLESHOOT
 		Triplex nodes and meters require a single phase and a phase S component (for split-phase).
-		This particular triplex object did not include it, so it is being added.
+		This particular triplex object did not include it, so it is being added.  Check upstream devices
+		(mostly tranformers) to make sure they are appropriate.  A duplicate NR admittance entry can occur
+		if the upstream transformer is incorrect too.
 		*/
 		phases = (phases | PHASE_S);
 	}


### PR DESCRIPTION
#### What's this Pull Request do?
Resolves the issues in #1432 by adding additional checks to make sure triplex nodes aren't connected via the wrong transformer type.

#### Where should the reviewer start?
Pull down the code, compile it, and examine the behavior in the "new autotest".

#### What are the relevant issues?
#1432, as well as [slacgismo/1277](https://github.com/slacgismo/gridlabd/issues/1277)
