### PR TITLE
Unbound memory fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,10 @@ include(cmake/CheckDependencies.cmake)
 include(cmake/BuildNumber.cmake)
 include(cmake/SanitizePaths.cmake)
 
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/lib/static)
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/lib)
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/bin)
+
 option(GLD_USE_EIGEN "[NOT YET SUPPORTED] - Use Eigen package for LU Decomposition in Powerflow" OFF)
 option(GLD_USE_SUPERLU "Use SuperLU package for LU Decomposition in Powerflow" ON)
 option(GLD_USE_HELICS "Link with HELICS" OFF)
@@ -383,7 +387,6 @@ mark_as_advanced(FORCE
         GLD_SHARE
         GLD_CI_BUILD
         )
-
 
 set(FILE_PERMISSIONS PERMISSIONS
         OWNER_EXECUTE OWNER_READ OWNER_WRITE

--- a/generators/autotest/test_1_isochronous_VSI_1_droop_VSI.glm
+++ b/generators/autotest/test_1_isochronous_VSI_1_droop_VSI.glm
@@ -330,7 +330,7 @@ object line_configuration:10012 {
 
 
 //Define line objects 
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 1-2;
      from load:1;
@@ -339,7 +339,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
 
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 1-3;
      from load:1;
@@ -348,7 +348,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 1-7;
      from load:1;
@@ -357,7 +357,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 3-4;
      from node:3;
@@ -366,7 +366,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 3-5;
      from node:3;
@@ -375,7 +375,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 5-6;
      from load:5;
@@ -384,7 +384,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 7-8;
      from load:7;
@@ -393,7 +393,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 8-12;
      from meter:8;
@@ -402,7 +402,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 8-9;
      from meter:8;
@@ -411,7 +411,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 8-13;
      from meter:8;
@@ -420,7 +420,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 1401-14;
      from node:1401;
@@ -429,7 +429,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 13-34;
      from meter:13;
@@ -438,7 +438,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 13-18;
      from meter:13;
@@ -447,7 +447,7 @@ object overhead_line:  {
      configuration line_configuration:1002;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 14-11;
      from node:14;
@@ -456,7 +456,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 14-10;
      from node:14;
@@ -465,7 +465,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 15-16;
      from node:15;
@@ -474,7 +474,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 15-17;
      from node:15;
@@ -483,7 +483,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 18-19;
      from node:18;
@@ -492,7 +492,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 18-21;
      from node:18;
@@ -501,7 +501,7 @@ object overhead_line:  {
      configuration line_configuration:1002;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 19-20;
      from load:19;
@@ -510,7 +510,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 21-22;
      from node:21;
@@ -519,7 +519,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 21-23;
      from node:21;
@@ -528,7 +528,7 @@ object overhead_line:  {
      configuration line_configuration:1002;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 23-24;
      from node:23;
@@ -537,7 +537,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 23-25;
      from node:23;
@@ -546,7 +546,7 @@ object overhead_line:  {
      configuration line_configuration:1002;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ACN";
      name 2601-26;
      from node:2601;
@@ -555,7 +555,7 @@ object overhead_line:  {
      configuration line_configuration:1007;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 25-28;
      from node:25;
@@ -564,7 +564,7 @@ object overhead_line:  {
      configuration line_configuration:1002;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ACN";
      name 26-27;
      from node:26;
@@ -573,7 +573,7 @@ object overhead_line:  {
      configuration line_configuration:1007;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 26-31;
      from node:26;
@@ -582,7 +582,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 27-33;
      from node:27;
@@ -591,7 +591,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 28-29;
      from load:28;
@@ -600,7 +600,7 @@ object overhead_line:  {
      configuration line_configuration:1002;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 29-30;
      from load:29;
@@ -609,7 +609,7 @@ object overhead_line:  {
      configuration line_configuration:1002;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 30-250;
      from load:30;
@@ -618,7 +618,7 @@ object overhead_line:  {
      configuration line_configuration:1002;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 31-32;
      from load:31;
@@ -627,7 +627,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 34-15;
      from load:34;
@@ -636,7 +636,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABN";
      name 35-36;
      from load:35;
@@ -645,7 +645,7 @@ object overhead_line:  {
      configuration line_configuration:1008;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 35-40;
      from load:35;
@@ -654,7 +654,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 36-37;
      from node:36;
@@ -663,7 +663,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 36-38;
      from node:36;
@@ -672,7 +672,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 38-39;
      from load:38;
@@ -681,7 +681,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 40-41;
      from node:40;
@@ -690,7 +690,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 40-42;
      from node:40;
@@ -699,7 +699,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 42-43;
      from load:42;
@@ -708,7 +708,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 42-44;
      from load:42;
@@ -717,7 +717,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 44-45;
      from node:44;
@@ -726,7 +726,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 44-47;
      from node:44;
@@ -735,7 +735,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 45-46;
      from load:45;
@@ -744,7 +744,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 47-48;
      from load:47;
@@ -753,7 +753,7 @@ object overhead_line:  {
      configuration line_configuration:1004;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 47-49;
      from load:47;
@@ -762,7 +762,7 @@ object overhead_line:  {
      configuration line_configuration:1004;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 49-50;
      from load:49;
@@ -771,7 +771,7 @@ object overhead_line:  {
      configuration line_configuration:1004;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 50-51;
      from meter:50;
@@ -780,7 +780,7 @@ object overhead_line:  {
      configuration line_configuration:1004;
 }
 
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";			//undefined line segment
      name 51-151;
      from load:51;
@@ -789,7 +789,7 @@ object overhead_line:  {
      configuration line_configuration:1004;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 52-53;
      from load:52;
@@ -798,7 +798,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 53-54;
      from load:53;
@@ -807,7 +807,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 54-55;
      from node:54;
@@ -816,7 +816,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 54-57;
      from node:54;
@@ -825,7 +825,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 55-56;
      from meter:56; //load:55;
@@ -834,7 +834,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 57-58;
      from meter:57;
@@ -843,7 +843,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 57-60;
      from meter:57;
@@ -852,7 +852,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 58-59;
      from load:58;
@@ -861,7 +861,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 60-61;
      from load:60;
@@ -870,7 +870,7 @@ object overhead_line:  {
      configuration line_configuration:1005;
 }
  
-object underground_line:  {
+object underground_line {
      phases "ABC";
      name 60-62;
      from load:60;
@@ -879,7 +879,7 @@ object underground_line:  {
      configuration line_configuration:10012;
 }
  
-object underground_line:  {
+object underground_line {
      phases "ABC";
      name 62-63;
      from load:62;
@@ -888,7 +888,7 @@ object underground_line:  {
      configuration line_configuration:10012;
 }
  
-object underground_line:  {
+object underground_line {
      phases "ABC";
      name 63-64;
      from load:63;
@@ -897,7 +897,7 @@ object underground_line:  {
      configuration line_configuration:10012;
 }
  
-object underground_line:  {
+object underground_line {
      phases "ABC";
      name 64-65;
      from load:64;
@@ -906,7 +906,7 @@ object underground_line:  {
      configuration line_configuration:10012;
 }
  
-object underground_line:  {
+object underground_line {
      phases "ABC";
      name 65-66;
      from load:65;
@@ -915,7 +915,7 @@ object underground_line:  {
      configuration line_configuration:10012;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 67-68;
      from meter:67;
@@ -924,7 +924,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 67-72;
      from meter:67;
@@ -934,7 +934,7 @@ object overhead_line:  {
 }
 
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 67-97;
      from meter:67;
@@ -943,7 +943,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 68-69;
      from load:68;
@@ -952,7 +952,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 69-70;
      from load:69;
@@ -961,7 +961,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 70-71;
      from load:70;
@@ -970,7 +970,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 72-73;
      from load:72;
@@ -979,7 +979,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 72-76;
      from load:72;
@@ -988,7 +988,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 73-74;
      from load:73;
@@ -997,7 +997,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 74-75;
      from load:74;
@@ -1006,7 +1006,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 76-77;
      from load:76;
@@ -1015,7 +1015,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 76-86;
      from load:76;
@@ -1024,7 +1024,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 77-78;
      from load:77;
@@ -1033,7 +1033,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 78-79;
      from node:78;
@@ -1042,7 +1042,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 78-80;
      from node:78;
@@ -1051,7 +1051,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 80-81;
      from load:80;
@@ -1060,7 +1060,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 81-82;
      from node:81;
@@ -1069,7 +1069,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 81-84;
      from node:81;
@@ -1078,7 +1078,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 82-83;
      from load:82;
@@ -1087,7 +1087,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 84-85;
      from load:84;
@@ -1096,7 +1096,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 86-87;
      from load:86;
@@ -1105,7 +1105,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 87-88;
      from load:87;
@@ -1114,7 +1114,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 87-89;
      from load:87;
@@ -1123,7 +1123,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 89-90;
      from node:89;
@@ -1132,7 +1132,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 89-91;
      from node:89;
@@ -1141,7 +1141,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 91-92;
      from node:91;
@@ -1150,7 +1150,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 91-93;
      from node:91;
@@ -1159,7 +1159,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 93-94;
      from node:93;
@@ -1168,7 +1168,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 93-95;
      from node:93;
@@ -1177,7 +1177,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 95-96;
      from load:95;
@@ -1186,7 +1186,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 97-98;
      from node:97;
@@ -1195,7 +1195,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 98-99;
      from load:98;
@@ -1204,7 +1204,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 99-100;
      from load:99;
@@ -1213,7 +1213,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 100-450;
      from load:100;
@@ -1222,7 +1222,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 101-102;
      from load:101;
@@ -1231,7 +1231,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 101-105;
      from load:101;
@@ -1240,7 +1240,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 102-103;
      from load:102;
@@ -1249,7 +1249,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 103-104;
      from load:103;
@@ -1258,7 +1258,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 105-106;
      from node:105;
@@ -1267,7 +1267,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 105-108;
      from node:105;
@@ -1276,7 +1276,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 106-107;
      from load:106;
@@ -1285,7 +1285,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 108-109;
      from node:108;
@@ -1294,7 +1294,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 108-300;
      from node:108;
@@ -1303,7 +1303,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 109-110;
      from load:109;
@@ -1312,7 +1312,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 110-111;
      from node:110;
@@ -1321,7 +1321,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 110-112;
      from node:110;
@@ -1330,7 +1330,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 112-113;
      from load:112;
@@ -1339,7 +1339,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 113-114;
      from load:113;
@@ -1348,7 +1348,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 135-35;
      from node:135;
@@ -1357,7 +1357,7 @@ object overhead_line:  {
      configuration line_configuration:1004;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 149-1;
      from node:149;
@@ -1366,7 +1366,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 152-52;
      from node:152;
@@ -1375,7 +1375,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 6701-67;
      from node:6701;
@@ -1384,7 +1384,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 197-101;
      from node:197;

--- a/generators/autotest/test_1isochronous_VSI.glm
+++ b/generators/autotest/test_1isochronous_VSI.glm
@@ -332,7 +332,7 @@ object line_configuration:10012 {
 
 
 //Define line objects 
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 1-2;
      from load:1;
@@ -341,7 +341,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
 
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 1-3;
      from load:1;
@@ -350,7 +350,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 1-7;
      from load:1;
@@ -359,7 +359,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 3-4;
      from node:3;
@@ -368,7 +368,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 3-5;
      from node:3;
@@ -377,7 +377,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 5-6;
      from load:5;
@@ -386,7 +386,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 7-8;
      from load:7;
@@ -395,7 +395,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 8-12;
      from meter:8;
@@ -404,7 +404,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 8-9;
      from meter:8;
@@ -413,7 +413,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 8-13;
      from meter:8;
@@ -422,7 +422,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 1401-14;
      from node:1401;
@@ -431,7 +431,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 13-34;
      from meter:13;
@@ -440,7 +440,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 13-18;
      from meter:13;
@@ -449,7 +449,7 @@ object overhead_line:  {
      configuration line_configuration:1002;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 14-11;
      from node:14;
@@ -458,7 +458,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 14-10;
      from node:14;
@@ -467,7 +467,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 15-16;
      from node:15;
@@ -476,7 +476,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 15-17;
      from node:15;
@@ -485,7 +485,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 18-19;
      from node:18;
@@ -494,7 +494,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 18-21;
      from node:18;
@@ -503,7 +503,7 @@ object overhead_line:  {
      configuration line_configuration:1002;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 19-20;
      from load:19;
@@ -512,7 +512,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 21-22;
      from node:21;
@@ -521,7 +521,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 21-23;
      from node:21;
@@ -530,7 +530,7 @@ object overhead_line:  {
      configuration line_configuration:1002;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 23-24;
      from node:23;
@@ -539,7 +539,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 23-25;
      from node:23;
@@ -548,7 +548,7 @@ object overhead_line:  {
      configuration line_configuration:1002;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ACN";
      name 2601-26;
      from node:2601;
@@ -557,7 +557,7 @@ object overhead_line:  {
      configuration line_configuration:1007;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 25-28;
      from node:25;
@@ -566,7 +566,7 @@ object overhead_line:  {
      configuration line_configuration:1002;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ACN";
      name 26-27;
      from node:26;
@@ -575,7 +575,7 @@ object overhead_line:  {
      configuration line_configuration:1007;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 26-31;
      from node:26;
@@ -584,7 +584,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 27-33;
      from node:27;
@@ -593,7 +593,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 28-29;
      from load:28;
@@ -602,7 +602,7 @@ object overhead_line:  {
      configuration line_configuration:1002;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 29-30;
      from load:29;
@@ -611,7 +611,7 @@ object overhead_line:  {
      configuration line_configuration:1002;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 30-250;
      from load:30;
@@ -620,7 +620,7 @@ object overhead_line:  {
      configuration line_configuration:1002;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 31-32;
      from load:31;
@@ -629,7 +629,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 34-15;
      from load:34;
@@ -638,7 +638,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABN";
      name 35-36;
      from load:35;
@@ -647,7 +647,7 @@ object overhead_line:  {
      configuration line_configuration:1008;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 35-40;
      from load:35;
@@ -656,7 +656,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 36-37;
      from node:36;
@@ -665,7 +665,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 36-38;
      from node:36;
@@ -674,7 +674,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 38-39;
      from load:38;
@@ -683,7 +683,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 40-41;
      from node:40;
@@ -692,7 +692,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 40-42;
      from node:40;
@@ -701,7 +701,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 42-43;
      from load:42;
@@ -710,7 +710,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 42-44;
      from load:42;
@@ -719,7 +719,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 44-45;
      from node:44;
@@ -728,7 +728,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 44-47;
      from node:44;
@@ -737,7 +737,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 45-46;
      from load:45;
@@ -746,7 +746,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 47-48;
      from load:47;
@@ -755,7 +755,7 @@ object overhead_line:  {
      configuration line_configuration:1004;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 47-49;
      from load:47;
@@ -764,7 +764,7 @@ object overhead_line:  {
      configuration line_configuration:1004;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 49-50;
      from load:49;
@@ -773,7 +773,7 @@ object overhead_line:  {
      configuration line_configuration:1004;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 50-51;
      from meter:50;
@@ -782,7 +782,7 @@ object overhead_line:  {
      configuration line_configuration:1004;
 }
 
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";			//undefined line segment
      name 51-151;
      from load:51;
@@ -791,7 +791,7 @@ object overhead_line:  {
      configuration line_configuration:1004;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 52-53;
      from load:52;
@@ -800,7 +800,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 53-54;
      from load:53;
@@ -809,7 +809,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 54-55;
      from node:54;
@@ -818,7 +818,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 54-57;
      from node:54;
@@ -827,7 +827,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 55-56;
      from load:55;
@@ -836,7 +836,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 57-58;
      from meter:57;
@@ -845,7 +845,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 57-60;
      from meter:57;
@@ -854,7 +854,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 58-59;
      from load:58;
@@ -863,7 +863,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 60-61;
      from load:60;
@@ -872,7 +872,7 @@ object overhead_line:  {
      configuration line_configuration:1005;
 }
  
-object underground_line:  {
+object underground_line {
      phases "ABC";
      name 60-62;
      from load:60;
@@ -881,7 +881,7 @@ object underground_line:  {
      configuration line_configuration:10012;
 }
  
-object underground_line:  {
+object underground_line {
      phases "ABC";
      name 62-63;
      from load:62;
@@ -890,7 +890,7 @@ object underground_line:  {
      configuration line_configuration:10012;
 }
  
-object underground_line:  {
+object underground_line {
      phases "ABC";
      name 63-64;
      from load:63;
@@ -899,7 +899,7 @@ object underground_line:  {
      configuration line_configuration:10012;
 }
  
-object underground_line:  {
+object underground_line {
      phases "ABC";
      name 64-65;
      from load:64;
@@ -908,7 +908,7 @@ object underground_line:  {
      configuration line_configuration:10012;
 }
  
-object underground_line:  {
+object underground_line {
      phases "ABC";
      name 65-66;
      from load:65;
@@ -917,7 +917,7 @@ object underground_line:  {
      configuration line_configuration:10012;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 67-68;
      from meter:67;
@@ -926,7 +926,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 67-72;
      from meter:67;
@@ -936,7 +936,7 @@ object overhead_line:  {
 }
 
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 67-97;
      from meter:67;
@@ -945,7 +945,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 68-69;
      from load:68;
@@ -954,7 +954,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 69-70;
      from load:69;
@@ -963,7 +963,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 70-71;
      from load:70;
@@ -972,7 +972,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 72-73;
      from load:72;
@@ -981,7 +981,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 72-76;
      from load:72;
@@ -990,7 +990,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 73-74;
      from load:73;
@@ -999,7 +999,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 74-75;
      from load:74;
@@ -1008,7 +1008,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 76-77;
      from load:76;
@@ -1017,7 +1017,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 76-86;
      from load:76;
@@ -1026,7 +1026,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 77-78;
      from load:77;
@@ -1035,7 +1035,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 78-79;
      from node:78;
@@ -1044,7 +1044,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 78-80;
      from node:78;
@@ -1053,7 +1053,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 80-81;
      from load:80;
@@ -1062,7 +1062,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 81-82;
      from node:81;
@@ -1071,7 +1071,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 81-84;
      from node:81;
@@ -1080,7 +1080,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 82-83;
      from load:82;
@@ -1089,7 +1089,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 84-85;
      from load:84;
@@ -1098,7 +1098,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 86-87;
      from load:86;
@@ -1107,7 +1107,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 87-88;
      from load:87;
@@ -1116,7 +1116,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 87-89;
      from load:87;
@@ -1125,7 +1125,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 89-90;
      from node:89;
@@ -1134,7 +1134,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 89-91;
      from node:89;
@@ -1143,7 +1143,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 91-92;
      from node:91;
@@ -1152,7 +1152,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 91-93;
      from node:91;
@@ -1161,7 +1161,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 93-94;
      from node:93;
@@ -1170,7 +1170,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 93-95;
      from node:93;
@@ -1179,7 +1179,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 95-96;
      from load:95;
@@ -1188,7 +1188,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 97-98;
      from node:97;
@@ -1197,7 +1197,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 98-99;
      from load:98;
@@ -1206,7 +1206,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 99-100;
      from load:99;
@@ -1215,7 +1215,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 100-450;
      from load:100;
@@ -1224,7 +1224,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 101-102;
      from load:101;
@@ -1233,7 +1233,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 101-105;
      from load:101;
@@ -1242,7 +1242,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 102-103;
      from load:102;
@@ -1251,7 +1251,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 103-104;
      from load:103;
@@ -1260,7 +1260,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 105-106;
      from node:105;
@@ -1269,7 +1269,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 105-108;
      from node:105;
@@ -1278,7 +1278,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 106-107;
      from load:106;
@@ -1287,7 +1287,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 108-109;
      from node:108;
@@ -1296,7 +1296,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 108-300;
      from node:108;
@@ -1305,7 +1305,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 109-110;
      from load:109;
@@ -1314,7 +1314,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 110-111;
      from node:110;
@@ -1323,7 +1323,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 110-112;
      from node:110;
@@ -1332,7 +1332,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 112-113;
      from load:112;
@@ -1341,7 +1341,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 113-114;
      from load:113;
@@ -1350,7 +1350,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 135-35;
      from node:135;
@@ -1359,7 +1359,7 @@ object overhead_line:  {
      configuration line_configuration:1004;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 149-1;
      from node:149;
@@ -1368,7 +1368,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 152-52;
      from node:152;
@@ -1377,7 +1377,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 6701-67;
      from node:6701;
@@ -1386,7 +1386,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 197-101;
      from node:197;

--- a/generators/autotest/test_1isochronous_dg_1PQconstant_PV.glm
+++ b/generators/autotest/test_1isochronous_dg_1PQconstant_PV.glm
@@ -330,7 +330,7 @@ object line_configuration:10012 {
 
 
 //Define line objects 
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 1-2;
      from load:1;
@@ -339,7 +339,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
 
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 1-3;
      from load:1;
@@ -348,7 +348,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 1-7;
      from load:1;
@@ -357,7 +357,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 3-4;
      from node:3;
@@ -366,7 +366,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 3-5;
      from node:3;
@@ -375,7 +375,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 5-6;
      from load:5;
@@ -384,7 +384,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 7-8;
      from load:7;
@@ -393,7 +393,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 8-12;
      from meter:8;
@@ -402,7 +402,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 8-9;
      from meter:8;
@@ -411,7 +411,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 8-13;
      from meter:8;
@@ -420,7 +420,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 1401-14;
      from node:1401;
@@ -429,7 +429,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 13-34;
      from meter:13;
@@ -438,7 +438,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 13-18;
      from meter:13;
@@ -447,7 +447,7 @@ object overhead_line:  {
      configuration line_configuration:1002;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 14-11;
      from node:14;
@@ -456,7 +456,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 14-10;
      from node:14;
@@ -465,7 +465,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 15-16;
      from node:15;
@@ -474,7 +474,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 15-17;
      from node:15;
@@ -483,7 +483,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 18-19;
      from node:18;
@@ -492,7 +492,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 18-21;
      from node:18;
@@ -501,7 +501,7 @@ object overhead_line:  {
      configuration line_configuration:1002;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 19-20;
      from load:19;
@@ -510,7 +510,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 21-22;
      from node:21;
@@ -519,7 +519,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 21-23;
      from node:21;
@@ -528,7 +528,7 @@ object overhead_line:  {
      configuration line_configuration:1002;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 23-24;
      from node:23;
@@ -537,7 +537,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 23-25;
      from node:23;
@@ -546,7 +546,7 @@ object overhead_line:  {
      configuration line_configuration:1002;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ACN";
      name 2601-26;
      from node:2601;
@@ -555,7 +555,7 @@ object overhead_line:  {
      configuration line_configuration:1007;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 25-28;
      from node:25;
@@ -564,7 +564,7 @@ object overhead_line:  {
      configuration line_configuration:1002;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ACN";
      name 26-27;
      from node:26;
@@ -573,7 +573,7 @@ object overhead_line:  {
      configuration line_configuration:1007;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 26-31;
      from node:26;
@@ -582,7 +582,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 27-33;
      from node:27;
@@ -591,7 +591,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 28-29;
      from load:28;
@@ -600,7 +600,7 @@ object overhead_line:  {
      configuration line_configuration:1002;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 29-30;
      from load:29;
@@ -609,7 +609,7 @@ object overhead_line:  {
      configuration line_configuration:1002;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 30-250;
      from load:30;
@@ -618,7 +618,7 @@ object overhead_line:  {
      configuration line_configuration:1002;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 31-32;
      from load:31;
@@ -627,7 +627,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 34-15;
      from load:34;
@@ -636,7 +636,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABN";
      name 35-36;
      from load:35;
@@ -645,7 +645,7 @@ object overhead_line:  {
      configuration line_configuration:1008;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 35-40;
      from load:35;
@@ -654,7 +654,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 36-37;
      from node:36;
@@ -663,7 +663,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 36-38;
      from node:36;
@@ -672,7 +672,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 38-39;
      from load:38;
@@ -681,7 +681,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 40-41;
      from node:40;
@@ -690,7 +690,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 40-42;
      from node:40;
@@ -699,7 +699,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 42-43;
      from load:42;
@@ -708,7 +708,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 42-44;
      from load:42;
@@ -717,7 +717,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 44-45;
      from node:44;
@@ -726,7 +726,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 44-47;
      from node:44;
@@ -735,7 +735,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 45-46;
      from load:45;
@@ -744,7 +744,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 47-48;
      from load:47;
@@ -753,7 +753,7 @@ object overhead_line:  {
      configuration line_configuration:1004;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 47-49;
      from load:47;
@@ -762,7 +762,7 @@ object overhead_line:  {
      configuration line_configuration:1004;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 49-50;
      from load:49;
@@ -771,7 +771,7 @@ object overhead_line:  {
      configuration line_configuration:1004;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 50-51;
      from meter:50;
@@ -780,7 +780,7 @@ object overhead_line:  {
      configuration line_configuration:1004;
 }
 
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";			//undefined line segment
      name 51-151;
      from load:51;
@@ -789,7 +789,7 @@ object overhead_line:  {
      configuration line_configuration:1004;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 52-53;
      from load:52;
@@ -798,7 +798,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 53-54;
      from load:53;
@@ -807,7 +807,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 54-55;
      from node:54;
@@ -816,7 +816,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 54-57;
      from node:54;
@@ -825,7 +825,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 55-56;
      from load:55;
@@ -834,7 +834,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 57-58;
      from meter:57;
@@ -843,7 +843,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 57-60;
      from meter:57;
@@ -852,7 +852,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 58-59;
      from load:58;
@@ -861,7 +861,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 60-61;
      from load:60;
@@ -870,7 +870,7 @@ object overhead_line:  {
      configuration line_configuration:1005;
 }
  
-object underground_line:  {
+object underground_line {
      phases "ABC";
      name 60-62;
      from load:60;
@@ -879,7 +879,7 @@ object underground_line:  {
      configuration line_configuration:10012;
 }
  
-object underground_line:  {
+object underground_line {
      phases "ABC";
      name 62-63;
      from load:62;
@@ -888,7 +888,7 @@ object underground_line:  {
      configuration line_configuration:10012;
 }
  
-object underground_line:  {
+object underground_line {
      phases "ABC";
      name 63-64;
      from load:63;
@@ -897,7 +897,7 @@ object underground_line:  {
      configuration line_configuration:10012;
 }
  
-object underground_line:  {
+object underground_line {
      phases "ABC";
      name 64-65;
      from load:64;
@@ -906,7 +906,7 @@ object underground_line:  {
      configuration line_configuration:10012;
 }
  
-object underground_line:  {
+object underground_line {
      phases "ABC";
      name 65-66;
      from load:65;
@@ -915,7 +915,7 @@ object underground_line:  {
      configuration line_configuration:10012;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 67-68;
      from meter:67;
@@ -924,7 +924,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 67-72;
      from meter:67;
@@ -934,7 +934,7 @@ object overhead_line:  {
 }
 
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 67-97;
      from meter:67;
@@ -943,7 +943,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 68-69;
      from load:68;
@@ -952,7 +952,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 69-70;
      from load:69;
@@ -961,7 +961,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 70-71;
      from load:70;
@@ -970,7 +970,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 72-73;
      from load:72;
@@ -979,7 +979,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 72-76;
      from load:72;
@@ -988,7 +988,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 73-74;
      from load:73;
@@ -997,7 +997,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 74-75;
      from load:74;
@@ -1006,7 +1006,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 76-77;
      from load:76;
@@ -1015,7 +1015,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 76-86;
      from load:76;
@@ -1024,7 +1024,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 77-78;
      from load:77;
@@ -1033,7 +1033,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 78-79;
      from node:78;
@@ -1042,7 +1042,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 78-80;
      from node:78;
@@ -1051,7 +1051,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 80-81;
      from load:80;
@@ -1060,7 +1060,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 81-82;
      from node:81;
@@ -1069,7 +1069,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 81-84;
      from node:81;
@@ -1078,7 +1078,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 82-83;
      from load:82;
@@ -1087,7 +1087,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 84-85;
      from load:84;
@@ -1096,7 +1096,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 86-87;
      from load:86;
@@ -1105,7 +1105,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 87-88;
      from load:87;
@@ -1114,7 +1114,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 87-89;
      from load:87;
@@ -1123,7 +1123,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 89-90;
      from node:89;
@@ -1132,7 +1132,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 89-91;
      from node:89;
@@ -1141,7 +1141,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 91-92;
      from node:91;
@@ -1150,7 +1150,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 91-93;
      from node:91;
@@ -1159,7 +1159,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 93-94;
      from node:93;
@@ -1168,7 +1168,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 93-95;
      from node:93;
@@ -1177,7 +1177,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 95-96;
      from load:95;
@@ -1186,7 +1186,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 97-98;
      from node:97;
@@ -1195,7 +1195,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 98-99;
      from load:98;
@@ -1204,7 +1204,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 99-100;
      from load:99;
@@ -1213,7 +1213,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 100-450;
      from load:100;
@@ -1222,7 +1222,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 101-102;
      from load:101;
@@ -1231,7 +1231,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 101-105;
      from load:101;
@@ -1240,7 +1240,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 102-103;
      from load:102;
@@ -1249,7 +1249,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 103-104;
      from load:103;
@@ -1258,7 +1258,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 105-106;
      from node:105;
@@ -1267,7 +1267,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 105-108;
      from node:105;
@@ -1276,7 +1276,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 106-107;
      from load:106;
@@ -1285,7 +1285,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 108-109;
      from node:108;
@@ -1294,7 +1294,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 108-300;
      from node:108;
@@ -1303,7 +1303,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 109-110;
      from load:109;
@@ -1312,7 +1312,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 110-111;
      from node:110;
@@ -1321,7 +1321,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 110-112;
      from node:110;
@@ -1330,7 +1330,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 112-113;
      from load:112;
@@ -1339,7 +1339,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 113-114;
      from load:113;
@@ -1348,7 +1348,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 135-35;
      from node:135;
@@ -1357,7 +1357,7 @@ object overhead_line:  {
      configuration line_configuration:1004;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 149-1;
      from node:149;
@@ -1366,7 +1366,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 152-52;
      from node:152;
@@ -1375,7 +1375,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 6701-67;
      from node:6701;
@@ -1384,7 +1384,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 197-101;
      from node:197;

--- a/generators/autotest/test_1isochronous_dg_1PQconstant_battery.glm
+++ b/generators/autotest/test_1isochronous_dg_1PQconstant_battery.glm
@@ -331,7 +331,7 @@ object line_configuration:10012 {
 
 
 //Define line objects 
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 1-2;
      from load:1;
@@ -340,7 +340,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
 
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 1-3;
      from load:1;
@@ -349,7 +349,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 1-7;
      from load:1;
@@ -358,7 +358,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 3-4;
      from node:3;
@@ -367,7 +367,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 3-5;
      from node:3;
@@ -376,7 +376,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 5-6;
      from load:5;
@@ -385,7 +385,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 7-8;
      from load:7;
@@ -394,7 +394,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 8-12;
      from meter:8;
@@ -403,7 +403,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 8-9;
      from meter:8;
@@ -412,7 +412,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 8-13;
      from meter:8;
@@ -421,7 +421,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 1401-14;
      from node:1401;
@@ -430,7 +430,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 13-34;
      from meter:13;
@@ -439,7 +439,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 13-18;
      from meter:13;
@@ -448,7 +448,7 @@ object overhead_line:  {
      configuration line_configuration:1002;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 14-11;
      from node:14;
@@ -457,7 +457,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 14-10;
      from node:14;
@@ -466,7 +466,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 15-16;
      from node:15;
@@ -475,7 +475,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 15-17;
      from node:15;
@@ -484,7 +484,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 18-19;
      from node:18;
@@ -493,7 +493,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 18-21;
      from node:18;
@@ -502,7 +502,7 @@ object overhead_line:  {
      configuration line_configuration:1002;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 19-20;
      from load:19;
@@ -511,7 +511,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 21-22;
      from node:21;
@@ -520,7 +520,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 21-23;
      from node:21;
@@ -529,7 +529,7 @@ object overhead_line:  {
      configuration line_configuration:1002;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 23-24;
      from node:23;
@@ -538,7 +538,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 23-25;
      from node:23;
@@ -547,7 +547,7 @@ object overhead_line:  {
      configuration line_configuration:1002;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ACN";
      name 2601-26;
      from node:2601;
@@ -556,7 +556,7 @@ object overhead_line:  {
      configuration line_configuration:1007;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 25-28;
      from node:25;
@@ -565,7 +565,7 @@ object overhead_line:  {
      configuration line_configuration:1002;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ACN";
      name 26-27;
      from node:26;
@@ -574,7 +574,7 @@ object overhead_line:  {
      configuration line_configuration:1007;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 26-31;
      from node:26;
@@ -583,7 +583,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 27-33;
      from node:27;
@@ -592,7 +592,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 28-29;
      from load:28;
@@ -601,7 +601,7 @@ object overhead_line:  {
      configuration line_configuration:1002;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 29-30;
      from load:29;
@@ -610,7 +610,7 @@ object overhead_line:  {
      configuration line_configuration:1002;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 30-250;
      from load:30;
@@ -619,7 +619,7 @@ object overhead_line:  {
      configuration line_configuration:1002;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 31-32;
      from load:31;
@@ -628,7 +628,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 34-15;
      from load:34;
@@ -637,7 +637,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABN";
      name 35-36;
      from load:35;
@@ -646,7 +646,7 @@ object overhead_line:  {
      configuration line_configuration:1008;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 35-40;
      from load:35;
@@ -655,7 +655,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 36-37;
      from node:36;
@@ -664,7 +664,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 36-38;
      from node:36;
@@ -673,7 +673,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 38-39;
      from load:38;
@@ -682,7 +682,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 40-41;
      from node:40;
@@ -691,7 +691,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 40-42;
      from node:40;
@@ -700,7 +700,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 42-43;
      from load:42;
@@ -709,7 +709,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 42-44;
      from load:42;
@@ -718,7 +718,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 44-45;
      from node:44;
@@ -727,7 +727,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 44-47;
      from node:44;
@@ -736,7 +736,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 45-46;
      from load:45;
@@ -745,7 +745,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 47-48;
      from load:47;
@@ -754,7 +754,7 @@ object overhead_line:  {
      configuration line_configuration:1004;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 47-49;
      from load:47;
@@ -763,7 +763,7 @@ object overhead_line:  {
      configuration line_configuration:1004;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 49-50;
      from load:49;
@@ -772,7 +772,7 @@ object overhead_line:  {
      configuration line_configuration:1004;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 50-51;
      from meter:50;
@@ -781,7 +781,7 @@ object overhead_line:  {
      configuration line_configuration:1004;
 }
 
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";			//undefined line segment
      name 51-151;
      from load:51;
@@ -790,7 +790,7 @@ object overhead_line:  {
      configuration line_configuration:1004;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 52-53;
      from load:52;
@@ -799,7 +799,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 53-54;
      from load:53;
@@ -808,7 +808,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 54-55;
      from node:54;
@@ -817,7 +817,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 54-57;
      from node:54;
@@ -826,7 +826,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 55-56;
      from load:55;
@@ -835,7 +835,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 57-58;
      from meter:57;
@@ -844,7 +844,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 57-60;
      from meter:57;
@@ -853,7 +853,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 58-59;
      from load:58;
@@ -862,7 +862,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 60-61;
      from load:60;
@@ -871,7 +871,7 @@ object overhead_line:  {
      configuration line_configuration:1005;
 }
  
-object underground_line:  {
+object underground_line {
      phases "ABC";
      name 60-62;
      from load:60;
@@ -880,7 +880,7 @@ object underground_line:  {
      configuration line_configuration:10012;
 }
  
-object underground_line:  {
+object underground_line {
      phases "ABC";
      name 62-63;
      from load:62;
@@ -889,7 +889,7 @@ object underground_line:  {
      configuration line_configuration:10012;
 }
  
-object underground_line:  {
+object underground_line {
      phases "ABC";
      name 63-64;
      from load:63;
@@ -898,7 +898,7 @@ object underground_line:  {
      configuration line_configuration:10012;
 }
  
-object underground_line:  {
+object underground_line {
      phases "ABC";
      name 64-65;
      from load:64;
@@ -907,7 +907,7 @@ object underground_line:  {
      configuration line_configuration:10012;
 }
  
-object underground_line:  {
+object underground_line {
      phases "ABC";
      name 65-66;
      from load:65;
@@ -916,7 +916,7 @@ object underground_line:  {
      configuration line_configuration:10012;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 67-68;
      from meter:67;
@@ -925,7 +925,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 67-72;
      from meter:67;
@@ -935,7 +935,7 @@ object overhead_line:  {
 }
 
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 67-97;
      from meter:67;
@@ -944,7 +944,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 68-69;
      from load:68;
@@ -953,7 +953,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 69-70;
      from load:69;
@@ -962,7 +962,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 70-71;
      from load:70;
@@ -971,7 +971,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 72-73;
      from load:72;
@@ -980,7 +980,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 72-76;
      from load:72;
@@ -989,7 +989,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 73-74;
      from load:73;
@@ -998,7 +998,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 74-75;
      from load:74;
@@ -1007,7 +1007,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 76-77;
      from load:76;
@@ -1016,7 +1016,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 76-86;
      from load:76;
@@ -1025,7 +1025,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 77-78;
      from load:77;
@@ -1034,7 +1034,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 78-79;
      from node:78;
@@ -1043,7 +1043,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 78-80;
      from node:78;
@@ -1052,7 +1052,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 80-81;
      from load:80;
@@ -1061,7 +1061,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 81-82;
      from node:81;
@@ -1070,7 +1070,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 81-84;
      from node:81;
@@ -1079,7 +1079,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 82-83;
      from load:82;
@@ -1088,7 +1088,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 84-85;
      from load:84;
@@ -1097,7 +1097,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 86-87;
      from load:86;
@@ -1106,7 +1106,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 87-88;
      from load:87;
@@ -1115,7 +1115,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 87-89;
      from load:87;
@@ -1124,7 +1124,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 89-90;
      from node:89;
@@ -1133,7 +1133,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 89-91;
      from node:89;
@@ -1142,7 +1142,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 91-92;
      from node:91;
@@ -1151,7 +1151,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 91-93;
      from node:91;
@@ -1160,7 +1160,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 93-94;
      from node:93;
@@ -1169,7 +1169,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 93-95;
      from node:93;
@@ -1178,7 +1178,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 95-96;
      from load:95;
@@ -1187,7 +1187,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 97-98;
      from node:97;
@@ -1196,7 +1196,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 98-99;
      from load:98;
@@ -1205,7 +1205,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 99-100;
      from load:99;
@@ -1214,7 +1214,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 100-450;
      from load:100;
@@ -1223,7 +1223,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 101-102;
      from load:101;
@@ -1232,7 +1232,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 101-105;
      from load:101;
@@ -1241,7 +1241,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 102-103;
      from load:102;
@@ -1250,7 +1250,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 103-104;
      from load:103;
@@ -1259,7 +1259,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 105-106;
      from node:105;
@@ -1268,7 +1268,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 105-108;
      from node:105;
@@ -1277,7 +1277,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 106-107;
      from load:106;
@@ -1286,7 +1286,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 108-109;
      from node:108;
@@ -1295,7 +1295,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 108-300;
      from node:108;
@@ -1304,7 +1304,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 109-110;
      from load:109;
@@ -1313,7 +1313,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 110-111;
      from node:110;
@@ -1322,7 +1322,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 110-112;
      from node:110;
@@ -1331,7 +1331,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 112-113;
      from load:112;
@@ -1340,7 +1340,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 113-114;
      from load:113;
@@ -1349,7 +1349,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 135-35;
      from node:135;
@@ -1358,7 +1358,7 @@ object overhead_line:  {
      configuration line_configuration:1004;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 149-1;
      from node:149;
@@ -1367,7 +1367,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 152-52;
      from node:152;
@@ -1376,7 +1376,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 6701-67;
      from node:6701;
@@ -1385,7 +1385,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 197-101;
      from node:197;

--- a/generators/autotest/test_1isochronous_dg_1PQconstant_dg.glm
+++ b/generators/autotest/test_1isochronous_dg_1PQconstant_dg.glm
@@ -334,7 +334,7 @@ object line_configuration:10012 {
 
 
 //Define line objects 
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 1-2;
      from load:1;
@@ -343,7 +343,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
 
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 1-3;
      from load:1;
@@ -352,7 +352,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 1-7;
      from load:1;
@@ -361,7 +361,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 3-4;
      from node:3;
@@ -370,7 +370,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 3-5;
      from node:3;
@@ -379,7 +379,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 5-6;
      from load:5;
@@ -388,7 +388,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 7-8;
      from load:7;
@@ -397,7 +397,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 8-12;
      from meter:8;
@@ -406,7 +406,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 8-9;
      from meter:8;
@@ -415,7 +415,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 8-13;
      from meter:8;
@@ -424,7 +424,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 1401-14;
      from node:1401;
@@ -433,7 +433,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 13-34;
      from meter:13;
@@ -442,7 +442,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 13-18;
      from meter:13;
@@ -451,7 +451,7 @@ object overhead_line:  {
      configuration line_configuration:1002;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 14-11;
      from node:14;
@@ -460,7 +460,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 14-10;
      from node:14;
@@ -469,7 +469,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 15-16;
      from node:15;
@@ -478,7 +478,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 15-17;
      from node:15;
@@ -487,7 +487,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 18-19;
      from node:18;
@@ -496,7 +496,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 18-21;
      from node:18;
@@ -505,7 +505,7 @@ object overhead_line:  {
      configuration line_configuration:1002;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 19-20;
      from load:19;
@@ -514,7 +514,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 21-22;
      from node:21;
@@ -523,7 +523,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 21-23;
      from node:21;
@@ -532,7 +532,7 @@ object overhead_line:  {
      configuration line_configuration:1002;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 23-24;
      from node:23;
@@ -541,7 +541,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 23-25;
      from node:23;
@@ -550,7 +550,7 @@ object overhead_line:  {
      configuration line_configuration:1002;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ACN";
      name 2601-26;
      from node:2601;
@@ -559,7 +559,7 @@ object overhead_line:  {
      configuration line_configuration:1007;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 25-28;
      from node:25;
@@ -568,7 +568,7 @@ object overhead_line:  {
      configuration line_configuration:1002;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ACN";
      name 26-27;
      from node:26;
@@ -577,7 +577,7 @@ object overhead_line:  {
      configuration line_configuration:1007;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 26-31;
      from node:26;
@@ -586,7 +586,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 27-33;
      from node:27;
@@ -595,7 +595,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 28-29;
      from load:28;
@@ -604,7 +604,7 @@ object overhead_line:  {
      configuration line_configuration:1002;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 29-30;
      from load:29;
@@ -613,7 +613,7 @@ object overhead_line:  {
      configuration line_configuration:1002;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 30-250;
      from load:30;
@@ -622,7 +622,7 @@ object overhead_line:  {
      configuration line_configuration:1002;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 31-32;
      from load:31;
@@ -631,7 +631,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 34-15;
      from load:34;
@@ -640,7 +640,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABN";
      name 35-36;
      from load:35;
@@ -649,7 +649,7 @@ object overhead_line:  {
      configuration line_configuration:1008;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 35-40;
      from load:35;
@@ -658,7 +658,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 36-37;
      from node:36;
@@ -667,7 +667,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 36-38;
      from node:36;
@@ -676,7 +676,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 38-39;
      from load:38;
@@ -685,7 +685,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 40-41;
      from node:40;
@@ -694,7 +694,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 40-42;
      from node:40;
@@ -703,7 +703,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 42-43;
      from load:42;
@@ -712,7 +712,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 42-44;
      from load:42;
@@ -721,7 +721,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 44-45;
      from node:44;
@@ -730,7 +730,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 44-47;
      from node:44;
@@ -739,7 +739,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 45-46;
      from load:45;
@@ -748,7 +748,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 47-48;
      from load:47;
@@ -757,7 +757,7 @@ object overhead_line:  {
      configuration line_configuration:1004;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 47-49;
      from load:47;
@@ -766,7 +766,7 @@ object overhead_line:  {
      configuration line_configuration:1004;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 49-50;
      from load:49;
@@ -775,7 +775,7 @@ object overhead_line:  {
      configuration line_configuration:1004;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 50-51;
      from meter:50;
@@ -784,7 +784,7 @@ object overhead_line:  {
      configuration line_configuration:1004;
 }
 
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";			//undefined line segment
      name 51-151;
      from load:51;
@@ -793,7 +793,7 @@ object overhead_line:  {
      configuration line_configuration:1004;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 52-53;
      from load:52;
@@ -802,7 +802,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 53-54;
      from load:53;
@@ -811,7 +811,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 54-55;
      from node:54;
@@ -820,7 +820,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 54-57;
      from node:54;
@@ -829,7 +829,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 55-56;
      from load:55;
@@ -838,7 +838,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 57-58;
      from meter:57;
@@ -847,7 +847,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 57-60;
      from meter:57;
@@ -856,7 +856,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 58-59;
      from load:58;
@@ -865,7 +865,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 60-61;
      from load:60;
@@ -874,7 +874,7 @@ object overhead_line:  {
      configuration line_configuration:1005;
 }
  
-object underground_line:  {
+object underground_line {
      phases "ABC";
      name 60-62;
      from load:60;
@@ -883,7 +883,7 @@ object underground_line:  {
      configuration line_configuration:10012;
 }
  
-object underground_line:  {
+object underground_line {
      phases "ABC";
      name 62-63;
      from load:62;
@@ -892,7 +892,7 @@ object underground_line:  {
      configuration line_configuration:10012;
 }
  
-object underground_line:  {
+object underground_line {
      phases "ABC";
      name 63-64;
      from load:63;
@@ -901,7 +901,7 @@ object underground_line:  {
      configuration line_configuration:10012;
 }
  
-object underground_line:  {
+object underground_line {
      phases "ABC";
      name 64-65;
      from load:64;
@@ -910,7 +910,7 @@ object underground_line:  {
      configuration line_configuration:10012;
 }
  
-object underground_line:  {
+object underground_line {
      phases "ABC";
      name 65-66;
      from load:65;
@@ -919,7 +919,7 @@ object underground_line:  {
      configuration line_configuration:10012;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 67-68;
      from meter:67;
@@ -928,7 +928,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 67-72;
      from meter:67;
@@ -938,7 +938,7 @@ object overhead_line:  {
 }
 
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 67-97;
      from meter:67;
@@ -947,7 +947,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 68-69;
      from load:68;
@@ -956,7 +956,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 69-70;
      from load:69;
@@ -965,7 +965,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 70-71;
      from load:70;
@@ -974,7 +974,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 72-73;
      from load:72;
@@ -983,7 +983,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 72-76;
      from load:72;
@@ -992,7 +992,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 73-74;
      from load:73;
@@ -1001,7 +1001,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 74-75;
      from load:74;
@@ -1010,7 +1010,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 76-77;
      from load:76;
@@ -1019,7 +1019,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 76-86;
      from load:76;
@@ -1028,7 +1028,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 77-78;
      from load:77;
@@ -1037,7 +1037,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 78-79;
      from node:78;
@@ -1046,7 +1046,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 78-80;
      from node:78;
@@ -1055,7 +1055,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 80-81;
      from load:80;
@@ -1064,7 +1064,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 81-82;
      from node:81;
@@ -1073,7 +1073,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 81-84;
      from node:81;
@@ -1082,7 +1082,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 82-83;
      from load:82;
@@ -1091,7 +1091,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 84-85;
      from load:84;
@@ -1100,7 +1100,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 86-87;
      from load:86;
@@ -1109,7 +1109,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 87-88;
      from load:87;
@@ -1118,7 +1118,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 87-89;
      from load:87;
@@ -1127,7 +1127,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 89-90;
      from node:89;
@@ -1136,7 +1136,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 89-91;
      from node:89;
@@ -1145,7 +1145,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 91-92;
      from node:91;
@@ -1154,7 +1154,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 91-93;
      from node:91;
@@ -1163,7 +1163,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 93-94;
      from node:93;
@@ -1172,7 +1172,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 93-95;
      from node:93;
@@ -1181,7 +1181,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 95-96;
      from load:95;
@@ -1190,7 +1190,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 97-98;
      from node:97;
@@ -1199,7 +1199,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 98-99;
      from load:98;
@@ -1208,7 +1208,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 99-100;
      from load:99;
@@ -1217,7 +1217,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 100-450;
      from load:100;
@@ -1226,7 +1226,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 101-102;
      from load:101;
@@ -1235,7 +1235,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 101-105;
      from load:101;
@@ -1244,7 +1244,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 102-103;
      from load:102;
@@ -1253,7 +1253,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 103-104;
      from load:103;
@@ -1262,7 +1262,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 105-106;
      from node:105;
@@ -1271,7 +1271,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 105-108;
      from node:105;
@@ -1280,7 +1280,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 106-107;
      from load:106;
@@ -1289,7 +1289,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 108-109;
      from node:108;
@@ -1298,7 +1298,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 108-300;
      from node:108;
@@ -1307,7 +1307,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 109-110;
      from load:109;
@@ -1316,7 +1316,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 110-111;
      from node:110;
@@ -1325,7 +1325,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 110-112;
      from node:110;
@@ -1334,7 +1334,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 112-113;
      from load:112;
@@ -1343,7 +1343,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 113-114;
      from load:113;
@@ -1352,7 +1352,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 135-35;
      from node:135;
@@ -1361,7 +1361,7 @@ object overhead_line:  {
      configuration line_configuration:1004;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 149-1;
      from node:149;
@@ -1370,7 +1370,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 152-52;
      from node:152;
@@ -1379,7 +1379,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 6701-67;
      from node:6701;
@@ -1388,7 +1388,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 197-101;
      from node:197;

--- a/generators/autotest/test_1isochronous_dg_1Pconstant_Qdroop_PV.glm
+++ b/generators/autotest/test_1isochronous_dg_1Pconstant_Qdroop_PV.glm
@@ -331,7 +331,7 @@ object line_configuration:10012 {
 
 
 //Define line objects 
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 1-2;
      from load:1;
@@ -340,7 +340,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
 
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 1-3;
      from load:1;
@@ -349,7 +349,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 1-7;
      from load:1;
@@ -358,7 +358,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 3-4;
      from node:3;
@@ -367,7 +367,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 3-5;
      from node:3;
@@ -376,7 +376,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 5-6;
      from load:5;
@@ -385,7 +385,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 7-8;
      from load:7;
@@ -394,7 +394,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 8-12;
      from meter:8;
@@ -403,7 +403,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 8-9;
      from meter:8;
@@ -412,7 +412,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 8-13;
      from meter:8;
@@ -421,7 +421,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 1401-14;
      from node:1401;
@@ -430,7 +430,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 13-34;
      from meter:13;
@@ -439,7 +439,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 13-18;
      from meter:13;
@@ -448,7 +448,7 @@ object overhead_line:  {
      configuration line_configuration:1002;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 14-11;
      from node:14;
@@ -457,7 +457,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 14-10;
      from node:14;
@@ -466,7 +466,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 15-16;
      from node:15;
@@ -475,7 +475,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 15-17;
      from node:15;
@@ -484,7 +484,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 18-19;
      from node:18;
@@ -493,7 +493,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 18-21;
      from node:18;
@@ -502,7 +502,7 @@ object overhead_line:  {
      configuration line_configuration:1002;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 19-20;
      from load:19;
@@ -511,7 +511,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 21-22;
      from node:21;
@@ -520,7 +520,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 21-23;
      from node:21;
@@ -529,7 +529,7 @@ object overhead_line:  {
      configuration line_configuration:1002;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 23-24;
      from node:23;
@@ -538,7 +538,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 23-25;
      from node:23;
@@ -547,7 +547,7 @@ object overhead_line:  {
      configuration line_configuration:1002;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ACN";
      name 2601-26;
      from node:2601;
@@ -556,7 +556,7 @@ object overhead_line:  {
      configuration line_configuration:1007;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 25-28;
      from node:25;
@@ -565,7 +565,7 @@ object overhead_line:  {
      configuration line_configuration:1002;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ACN";
      name 26-27;
      from node:26;
@@ -574,7 +574,7 @@ object overhead_line:  {
      configuration line_configuration:1007;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 26-31;
      from node:26;
@@ -583,7 +583,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 27-33;
      from node:27;
@@ -592,7 +592,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 28-29;
      from load:28;
@@ -601,7 +601,7 @@ object overhead_line:  {
      configuration line_configuration:1002;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 29-30;
      from load:29;
@@ -610,7 +610,7 @@ object overhead_line:  {
      configuration line_configuration:1002;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 30-250;
      from load:30;
@@ -619,7 +619,7 @@ object overhead_line:  {
      configuration line_configuration:1002;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 31-32;
      from load:31;
@@ -628,7 +628,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 34-15;
      from load:34;
@@ -637,7 +637,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABN";
      name 35-36;
      from load:35;
@@ -646,7 +646,7 @@ object overhead_line:  {
      configuration line_configuration:1008;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 35-40;
      from load:35;
@@ -655,7 +655,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 36-37;
      from node:36;
@@ -664,7 +664,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 36-38;
      from node:36;
@@ -673,7 +673,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 38-39;
      from load:38;
@@ -682,7 +682,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 40-41;
      from node:40;
@@ -691,7 +691,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 40-42;
      from node:40;
@@ -700,7 +700,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 42-43;
      from load:42;
@@ -709,7 +709,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 42-44;
      from load:42;
@@ -718,7 +718,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 44-45;
      from node:44;
@@ -727,7 +727,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 44-47;
      from node:44;
@@ -736,7 +736,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 45-46;
      from load:45;
@@ -745,7 +745,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 47-48;
      from load:47;
@@ -754,7 +754,7 @@ object overhead_line:  {
      configuration line_configuration:1004;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 47-49;
      from load:47;
@@ -763,7 +763,7 @@ object overhead_line:  {
      configuration line_configuration:1004;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 49-50;
      from load:49;
@@ -772,7 +772,7 @@ object overhead_line:  {
      configuration line_configuration:1004;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 50-51;
      from meter:50;
@@ -781,7 +781,7 @@ object overhead_line:  {
      configuration line_configuration:1004;
 }
 
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";			//undefined line segment
      name 51-151;
      from load:51;
@@ -790,7 +790,7 @@ object overhead_line:  {
      configuration line_configuration:1004;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 52-53;
      from load:52;
@@ -799,7 +799,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 53-54;
      from load:53;
@@ -808,7 +808,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 54-55;
      from node:54;
@@ -817,7 +817,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 54-57;
      from node:54;
@@ -826,7 +826,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 55-56;
      from load:55;
@@ -835,7 +835,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 57-58;
      from meter:57;
@@ -844,7 +844,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 57-60;
      from meter:57;
@@ -853,7 +853,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 58-59;
      from load:58;
@@ -862,7 +862,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 60-61;
      from load:60;
@@ -871,7 +871,7 @@ object overhead_line:  {
      configuration line_configuration:1005;
 }
  
-object underground_line:  {
+object underground_line {
      phases "ABC";
      name 60-62;
      from load:60;
@@ -880,7 +880,7 @@ object underground_line:  {
      configuration line_configuration:10012;
 }
  
-object underground_line:  {
+object underground_line {
      phases "ABC";
      name 62-63;
      from load:62;
@@ -889,7 +889,7 @@ object underground_line:  {
      configuration line_configuration:10012;
 }
  
-object underground_line:  {
+object underground_line {
      phases "ABC";
      name 63-64;
      from load:63;
@@ -898,7 +898,7 @@ object underground_line:  {
      configuration line_configuration:10012;
 }
  
-object underground_line:  {
+object underground_line {
      phases "ABC";
      name 64-65;
      from load:64;
@@ -907,7 +907,7 @@ object underground_line:  {
      configuration line_configuration:10012;
 }
  
-object underground_line:  {
+object underground_line {
      phases "ABC";
      name 65-66;
      from load:65;
@@ -916,7 +916,7 @@ object underground_line:  {
      configuration line_configuration:10012;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 67-68;
      from meter:67;
@@ -925,7 +925,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 67-72;
      from meter:67;
@@ -935,7 +935,7 @@ object overhead_line:  {
 }
 
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 67-97;
      from meter:67;
@@ -944,7 +944,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 68-69;
      from load:68;
@@ -953,7 +953,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 69-70;
      from load:69;
@@ -962,7 +962,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 70-71;
      from load:70;
@@ -971,7 +971,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 72-73;
      from load:72;
@@ -980,7 +980,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 72-76;
      from load:72;
@@ -989,7 +989,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 73-74;
      from load:73;
@@ -998,7 +998,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 74-75;
      from load:74;
@@ -1007,7 +1007,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 76-77;
      from load:76;
@@ -1016,7 +1016,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 76-86;
      from load:76;
@@ -1025,7 +1025,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 77-78;
      from load:77;
@@ -1034,7 +1034,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 78-79;
      from node:78;
@@ -1043,7 +1043,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 78-80;
      from node:78;
@@ -1052,7 +1052,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 80-81;
      from load:80;
@@ -1061,7 +1061,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 81-82;
      from node:81;
@@ -1070,7 +1070,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 81-84;
      from node:81;
@@ -1079,7 +1079,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 82-83;
      from load:82;
@@ -1088,7 +1088,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 84-85;
      from load:84;
@@ -1097,7 +1097,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 86-87;
      from load:86;
@@ -1106,7 +1106,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 87-88;
      from load:87;
@@ -1115,7 +1115,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 87-89;
      from load:87;
@@ -1124,7 +1124,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 89-90;
      from node:89;
@@ -1133,7 +1133,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 89-91;
      from node:89;
@@ -1142,7 +1142,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 91-92;
      from node:91;
@@ -1151,7 +1151,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 91-93;
      from node:91;
@@ -1160,7 +1160,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 93-94;
      from node:93;
@@ -1169,7 +1169,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 93-95;
      from node:93;
@@ -1178,7 +1178,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 95-96;
      from load:95;
@@ -1187,7 +1187,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 97-98;
      from node:97;
@@ -1196,7 +1196,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 98-99;
      from load:98;
@@ -1205,7 +1205,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 99-100;
      from load:99;
@@ -1214,7 +1214,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 100-450;
      from load:100;
@@ -1223,7 +1223,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 101-102;
      from load:101;
@@ -1232,7 +1232,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 101-105;
      from load:101;
@@ -1241,7 +1241,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 102-103;
      from load:102;
@@ -1250,7 +1250,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 103-104;
      from load:103;
@@ -1259,7 +1259,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 105-106;
      from node:105;
@@ -1268,7 +1268,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 105-108;
      from node:105;
@@ -1277,7 +1277,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 106-107;
      from load:106;
@@ -1286,7 +1286,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 108-109;
      from node:108;
@@ -1295,7 +1295,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 108-300;
      from node:108;
@@ -1304,7 +1304,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 109-110;
      from load:109;
@@ -1313,7 +1313,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 110-111;
      from node:110;
@@ -1322,7 +1322,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 110-112;
      from node:110;
@@ -1331,7 +1331,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 112-113;
      from load:112;
@@ -1340,7 +1340,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 113-114;
      from load:113;
@@ -1349,7 +1349,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 135-35;
      from node:135;
@@ -1358,7 +1358,7 @@ object overhead_line:  {
      configuration line_configuration:1004;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 149-1;
      from node:149;
@@ -1367,7 +1367,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 152-52;
      from node:152;
@@ -1376,7 +1376,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 6701-67;
      from node:6701;
@@ -1385,7 +1385,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 197-101;
      from node:197;

--- a/generators/autotest/test_1isochronous_dg_1Pconstant_Qdroop_dg.glm
+++ b/generators/autotest/test_1isochronous_dg_1Pconstant_Qdroop_dg.glm
@@ -334,7 +334,7 @@ object line_configuration:10012 {
 
 
 //Define line objects 
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 1-2;
      from load:1;
@@ -343,7 +343,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
 
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 1-3;
      from load:1;
@@ -352,7 +352,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 1-7;
      from load:1;
@@ -361,7 +361,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 3-4;
      from node:3;
@@ -370,7 +370,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 3-5;
      from node:3;
@@ -379,7 +379,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 5-6;
      from load:5;
@@ -388,7 +388,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 7-8;
      from load:7;
@@ -397,7 +397,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 8-12;
      from meter:8;
@@ -406,7 +406,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 8-9;
      from meter:8;
@@ -415,7 +415,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 8-13;
      from meter:8;
@@ -424,7 +424,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 1401-14;
      from node:1401;
@@ -433,7 +433,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 13-34;
      from meter:13;
@@ -442,7 +442,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 13-18;
      from meter:13;
@@ -451,7 +451,7 @@ object overhead_line:  {
      configuration line_configuration:1002;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 14-11;
      from node:14;
@@ -460,7 +460,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 14-10;
      from node:14;
@@ -469,7 +469,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 15-16;
      from node:15;
@@ -478,7 +478,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 15-17;
      from node:15;
@@ -487,7 +487,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 18-19;
      from node:18;
@@ -496,7 +496,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 18-21;
      from node:18;
@@ -505,7 +505,7 @@ object overhead_line:  {
      configuration line_configuration:1002;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 19-20;
      from load:19;
@@ -514,7 +514,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 21-22;
      from node:21;
@@ -523,7 +523,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 21-23;
      from node:21;
@@ -532,7 +532,7 @@ object overhead_line:  {
      configuration line_configuration:1002;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 23-24;
      from node:23;
@@ -541,7 +541,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 23-25;
      from node:23;
@@ -550,7 +550,7 @@ object overhead_line:  {
      configuration line_configuration:1002;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ACN";
      name 2601-26;
      from node:2601;
@@ -559,7 +559,7 @@ object overhead_line:  {
      configuration line_configuration:1007;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 25-28;
      from node:25;
@@ -568,7 +568,7 @@ object overhead_line:  {
      configuration line_configuration:1002;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ACN";
      name 26-27;
      from node:26;
@@ -577,7 +577,7 @@ object overhead_line:  {
      configuration line_configuration:1007;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 26-31;
      from node:26;
@@ -586,7 +586,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 27-33;
      from node:27;
@@ -595,7 +595,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 28-29;
      from load:28;
@@ -604,7 +604,7 @@ object overhead_line:  {
      configuration line_configuration:1002;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 29-30;
      from load:29;
@@ -613,7 +613,7 @@ object overhead_line:  {
      configuration line_configuration:1002;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 30-250;
      from load:30;
@@ -622,7 +622,7 @@ object overhead_line:  {
      configuration line_configuration:1002;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 31-32;
      from load:31;
@@ -631,7 +631,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 34-15;
      from load:34;
@@ -640,7 +640,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABN";
      name 35-36;
      from load:35;
@@ -649,7 +649,7 @@ object overhead_line:  {
      configuration line_configuration:1008;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 35-40;
      from load:35;
@@ -658,7 +658,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 36-37;
      from node:36;
@@ -667,7 +667,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 36-38;
      from node:36;
@@ -676,7 +676,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 38-39;
      from load:38;
@@ -685,7 +685,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 40-41;
      from node:40;
@@ -694,7 +694,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 40-42;
      from node:40;
@@ -703,7 +703,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 42-43;
      from load:42;
@@ -712,7 +712,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 42-44;
      from load:42;
@@ -721,7 +721,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 44-45;
      from node:44;
@@ -730,7 +730,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 44-47;
      from node:44;
@@ -739,7 +739,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 45-46;
      from load:45;
@@ -748,7 +748,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 47-48;
      from load:47;
@@ -757,7 +757,7 @@ object overhead_line:  {
      configuration line_configuration:1004;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 47-49;
      from load:47;
@@ -766,7 +766,7 @@ object overhead_line:  {
      configuration line_configuration:1004;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 49-50;
      from load:49;
@@ -775,7 +775,7 @@ object overhead_line:  {
      configuration line_configuration:1004;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 50-51;
      from meter:50;
@@ -784,7 +784,7 @@ object overhead_line:  {
      configuration line_configuration:1004;
 }
 
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";			//undefined line segment
      name 51-151;
      from load:51;
@@ -793,7 +793,7 @@ object overhead_line:  {
      configuration line_configuration:1004;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 52-53;
      from load:52;
@@ -802,7 +802,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 53-54;
      from load:53;
@@ -811,7 +811,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 54-55;
      from node:54;
@@ -820,7 +820,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 54-57;
      from node:54;
@@ -829,7 +829,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 55-56;
      from load:55;
@@ -838,7 +838,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 57-58;
      from meter:57;
@@ -847,7 +847,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 57-60;
      from meter:57;
@@ -856,7 +856,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 58-59;
      from load:58;
@@ -865,7 +865,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 60-61;
      from load:60;
@@ -874,7 +874,7 @@ object overhead_line:  {
      configuration line_configuration:1005;
 }
  
-object underground_line:  {
+object underground_line {
      phases "ABC";
      name 60-62;
      from load:60;
@@ -883,7 +883,7 @@ object underground_line:  {
      configuration line_configuration:10012;
 }
  
-object underground_line:  {
+object underground_line {
      phases "ABC";
      name 62-63;
      from load:62;
@@ -892,7 +892,7 @@ object underground_line:  {
      configuration line_configuration:10012;
 }
  
-object underground_line:  {
+object underground_line {
      phases "ABC";
      name 63-64;
      from load:63;
@@ -901,7 +901,7 @@ object underground_line:  {
      configuration line_configuration:10012;
 }
  
-object underground_line:  {
+object underground_line {
      phases "ABC";
      name 64-65;
      from load:64;
@@ -910,7 +910,7 @@ object underground_line:  {
      configuration line_configuration:10012;
 }
  
-object underground_line:  {
+object underground_line {
      phases "ABC";
      name 65-66;
      from load:65;
@@ -919,7 +919,7 @@ object underground_line:  {
      configuration line_configuration:10012;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 67-68;
      from meter:67;
@@ -928,7 +928,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 67-72;
      from meter:67;
@@ -938,7 +938,7 @@ object overhead_line:  {
 }
 
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 67-97;
      from meter:67;
@@ -947,7 +947,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 68-69;
      from load:68;
@@ -956,7 +956,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 69-70;
      from load:69;
@@ -965,7 +965,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 70-71;
      from load:70;
@@ -974,7 +974,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 72-73;
      from load:72;
@@ -983,7 +983,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 72-76;
      from load:72;
@@ -992,7 +992,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 73-74;
      from load:73;
@@ -1001,7 +1001,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 74-75;
      from load:74;
@@ -1010,7 +1010,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 76-77;
      from load:76;
@@ -1019,7 +1019,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 76-86;
      from load:76;
@@ -1028,7 +1028,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 77-78;
      from load:77;
@@ -1037,7 +1037,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 78-79;
      from node:78;
@@ -1046,7 +1046,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 78-80;
      from node:78;
@@ -1055,7 +1055,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 80-81;
      from load:80;
@@ -1064,7 +1064,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 81-82;
      from node:81;
@@ -1073,7 +1073,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 81-84;
      from node:81;
@@ -1082,7 +1082,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 82-83;
      from load:82;
@@ -1091,7 +1091,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 84-85;
      from load:84;
@@ -1100,7 +1100,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 86-87;
      from load:86;
@@ -1109,7 +1109,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 87-88;
      from load:87;
@@ -1118,7 +1118,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 87-89;
      from load:87;
@@ -1127,7 +1127,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 89-90;
      from node:89;
@@ -1136,7 +1136,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 89-91;
      from node:89;
@@ -1145,7 +1145,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 91-92;
      from node:91;
@@ -1154,7 +1154,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 91-93;
      from node:91;
@@ -1163,7 +1163,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 93-94;
      from node:93;
@@ -1172,7 +1172,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 93-95;
      from node:93;
@@ -1181,7 +1181,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 95-96;
      from load:95;
@@ -1190,7 +1190,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 97-98;
      from node:97;
@@ -1199,7 +1199,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 98-99;
      from load:98;
@@ -1208,7 +1208,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 99-100;
      from load:99;
@@ -1217,7 +1217,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 100-450;
      from load:100;
@@ -1226,7 +1226,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 101-102;
      from load:101;
@@ -1235,7 +1235,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 101-105;
      from load:101;
@@ -1244,7 +1244,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 102-103;
      from load:102;
@@ -1253,7 +1253,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 103-104;
      from load:103;
@@ -1262,7 +1262,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 105-106;
      from node:105;
@@ -1271,7 +1271,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 105-108;
      from node:105;
@@ -1280,7 +1280,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 106-107;
      from load:106;
@@ -1289,7 +1289,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 108-109;
      from node:108;
@@ -1298,7 +1298,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 108-300;
      from node:108;
@@ -1307,7 +1307,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 109-110;
      from load:109;
@@ -1316,7 +1316,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 110-111;
      from node:110;
@@ -1325,7 +1325,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 110-112;
      from node:110;
@@ -1334,7 +1334,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 112-113;
      from load:112;
@@ -1343,7 +1343,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 113-114;
      from load:113;
@@ -1352,7 +1352,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 135-35;
      from node:135;
@@ -1361,7 +1361,7 @@ object overhead_line:  {
      configuration line_configuration:1004;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 149-1;
      from node:149;
@@ -1370,7 +1370,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 152-52;
      from node:152;
@@ -1379,7 +1379,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 6701-67;
      from node:6701;
@@ -1388,7 +1388,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 197-101;
      from node:197;

--- a/generators/autotest/test_1isochronous_dg_1Pdroop_Qconstant_PV.glm
+++ b/generators/autotest/test_1isochronous_dg_1Pdroop_Qconstant_PV.glm
@@ -333,7 +333,7 @@ object line_configuration:10012 {
 
 
 //Define line objects 
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 1-2;
      from load:1;
@@ -342,7 +342,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
 
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 1-3;
      from load:1;
@@ -351,7 +351,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 1-7;
      from load:1;
@@ -360,7 +360,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 3-4;
      from node:3;
@@ -369,7 +369,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 3-5;
      from node:3;
@@ -378,7 +378,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 5-6;
      from load:5;
@@ -387,7 +387,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 7-8;
      from load:7;
@@ -396,7 +396,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 8-12;
      from meter:8;
@@ -405,7 +405,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 8-9;
      from meter:8;
@@ -414,7 +414,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 8-13;
      from meter:8;
@@ -423,7 +423,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 1401-14;
      from node:1401;
@@ -432,7 +432,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 13-34;
      from meter:13;
@@ -441,7 +441,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 13-18;
      from meter:13;
@@ -450,7 +450,7 @@ object overhead_line:  {
      configuration line_configuration:1002;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 14-11;
      from node:14;
@@ -459,7 +459,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 14-10;
      from node:14;
@@ -468,7 +468,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 15-16;
      from node:15;
@@ -477,7 +477,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 15-17;
      from node:15;
@@ -486,7 +486,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 18-19;
      from node:18;
@@ -495,7 +495,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 18-21;
      from node:18;
@@ -504,7 +504,7 @@ object overhead_line:  {
      configuration line_configuration:1002;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 19-20;
      from load:19;
@@ -513,7 +513,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 21-22;
      from node:21;
@@ -522,7 +522,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 21-23;
      from node:21;
@@ -531,7 +531,7 @@ object overhead_line:  {
      configuration line_configuration:1002;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 23-24;
      from node:23;
@@ -540,7 +540,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 23-25;
      from node:23;
@@ -549,7 +549,7 @@ object overhead_line:  {
      configuration line_configuration:1002;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ACN";
      name 2601-26;
      from node:2601;
@@ -558,7 +558,7 @@ object overhead_line:  {
      configuration line_configuration:1007;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 25-28;
      from node:25;
@@ -567,7 +567,7 @@ object overhead_line:  {
      configuration line_configuration:1002;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ACN";
      name 26-27;
      from node:26;
@@ -576,7 +576,7 @@ object overhead_line:  {
      configuration line_configuration:1007;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 26-31;
      from node:26;
@@ -585,7 +585,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 27-33;
      from node:27;
@@ -594,7 +594,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 28-29;
      from load:28;
@@ -603,7 +603,7 @@ object overhead_line:  {
      configuration line_configuration:1002;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 29-30;
      from load:29;
@@ -612,7 +612,7 @@ object overhead_line:  {
      configuration line_configuration:1002;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 30-250;
      from load:30;
@@ -621,7 +621,7 @@ object overhead_line:  {
      configuration line_configuration:1002;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 31-32;
      from load:31;
@@ -630,7 +630,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 34-15;
      from load:34;
@@ -639,7 +639,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABN";
      name 35-36;
      from load:35;
@@ -648,7 +648,7 @@ object overhead_line:  {
      configuration line_configuration:1008;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 35-40;
      from load:35;
@@ -657,7 +657,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 36-37;
      from node:36;
@@ -666,7 +666,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 36-38;
      from node:36;
@@ -675,7 +675,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 38-39;
      from load:38;
@@ -684,7 +684,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 40-41;
      from node:40;
@@ -693,7 +693,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 40-42;
      from node:40;
@@ -702,7 +702,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 42-43;
      from load:42;
@@ -711,7 +711,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 42-44;
      from load:42;
@@ -720,7 +720,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 44-45;
      from node:44;
@@ -729,7 +729,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 44-47;
      from node:44;
@@ -738,7 +738,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 45-46;
      from load:45;
@@ -747,7 +747,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 47-48;
      from load:47;
@@ -756,7 +756,7 @@ object overhead_line:  {
      configuration line_configuration:1004;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 47-49;
      from load:47;
@@ -765,7 +765,7 @@ object overhead_line:  {
      configuration line_configuration:1004;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 49-50;
      from load:49;
@@ -774,7 +774,7 @@ object overhead_line:  {
      configuration line_configuration:1004;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 50-51;
      from meter:50;
@@ -783,7 +783,7 @@ object overhead_line:  {
      configuration line_configuration:1004;
 }
 
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";			//undefined line segment
      name 51-151;
      from load:51;
@@ -792,7 +792,7 @@ object overhead_line:  {
      configuration line_configuration:1004;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 52-53;
      from load:52;
@@ -801,7 +801,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 53-54;
      from load:53;
@@ -810,7 +810,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 54-55;
      from node:54;
@@ -819,7 +819,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 54-57;
      from node:54;
@@ -828,7 +828,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 55-56;
      from load:55;
@@ -837,7 +837,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 57-58;
      from meter:57;
@@ -846,7 +846,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 57-60;
      from meter:57;
@@ -855,7 +855,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 58-59;
      from load:58;
@@ -864,7 +864,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 60-61;
      from load:60;
@@ -873,7 +873,7 @@ object overhead_line:  {
      configuration line_configuration:1005;
 }
  
-object underground_line:  {
+object underground_line {
      phases "ABC";
      name 60-62;
      from load:60;
@@ -882,7 +882,7 @@ object underground_line:  {
      configuration line_configuration:10012;
 }
  
-object underground_line:  {
+object underground_line {
      phases "ABC";
      name 62-63;
      from load:62;
@@ -891,7 +891,7 @@ object underground_line:  {
      configuration line_configuration:10012;
 }
  
-object underground_line:  {
+object underground_line {
      phases "ABC";
      name 63-64;
      from load:63;
@@ -900,7 +900,7 @@ object underground_line:  {
      configuration line_configuration:10012;
 }
  
-object underground_line:  {
+object underground_line {
      phases "ABC";
      name 64-65;
      from load:64;
@@ -909,7 +909,7 @@ object underground_line:  {
      configuration line_configuration:10012;
 }
  
-object underground_line:  {
+object underground_line {
      phases "ABC";
      name 65-66;
      from load:65;
@@ -918,7 +918,7 @@ object underground_line:  {
      configuration line_configuration:10012;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 67-68;
      from meter:67;
@@ -927,7 +927,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 67-72;
      from meter:67;
@@ -937,7 +937,7 @@ object overhead_line:  {
 }
 
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 67-97;
      from meter:67;
@@ -946,7 +946,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 68-69;
      from load:68;
@@ -955,7 +955,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 69-70;
      from load:69;
@@ -964,7 +964,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 70-71;
      from load:70;
@@ -973,7 +973,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 72-73;
      from load:72;
@@ -982,7 +982,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 72-76;
      from load:72;
@@ -991,7 +991,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 73-74;
      from load:73;
@@ -1000,7 +1000,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 74-75;
      from load:74;
@@ -1009,7 +1009,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 76-77;
      from load:76;
@@ -1018,7 +1018,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 76-86;
      from load:76;
@@ -1027,7 +1027,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 77-78;
      from load:77;
@@ -1036,7 +1036,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 78-79;
      from node:78;
@@ -1045,7 +1045,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 78-80;
      from node:78;
@@ -1054,7 +1054,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 80-81;
      from load:80;
@@ -1063,7 +1063,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 81-82;
      from node:81;
@@ -1072,7 +1072,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 81-84;
      from node:81;
@@ -1081,7 +1081,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 82-83;
      from load:82;
@@ -1090,7 +1090,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 84-85;
      from load:84;
@@ -1099,7 +1099,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 86-87;
      from load:86;
@@ -1108,7 +1108,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 87-88;
      from load:87;
@@ -1117,7 +1117,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 87-89;
      from load:87;
@@ -1126,7 +1126,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 89-90;
      from node:89;
@@ -1135,7 +1135,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 89-91;
      from node:89;
@@ -1144,7 +1144,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 91-92;
      from node:91;
@@ -1153,7 +1153,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 91-93;
      from node:91;
@@ -1162,7 +1162,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 93-94;
      from node:93;
@@ -1171,7 +1171,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 93-95;
      from node:93;
@@ -1180,7 +1180,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 95-96;
      from load:95;
@@ -1189,7 +1189,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 97-98;
      from node:97;
@@ -1198,7 +1198,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 98-99;
      from load:98;
@@ -1207,7 +1207,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 99-100;
      from load:99;
@@ -1216,7 +1216,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 100-450;
      from load:100;
@@ -1225,7 +1225,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 101-102;
      from load:101;
@@ -1234,7 +1234,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 101-105;
      from load:101;
@@ -1243,7 +1243,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 102-103;
      from load:102;
@@ -1252,7 +1252,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 103-104;
      from load:103;
@@ -1261,7 +1261,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 105-106;
      from node:105;
@@ -1270,7 +1270,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 105-108;
      from node:105;
@@ -1279,7 +1279,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 106-107;
      from load:106;
@@ -1288,7 +1288,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 108-109;
      from node:108;
@@ -1297,7 +1297,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 108-300;
      from node:108;
@@ -1306,7 +1306,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 109-110;
      from load:109;
@@ -1315,7 +1315,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 110-111;
      from node:110;
@@ -1324,7 +1324,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 110-112;
      from node:110;
@@ -1333,7 +1333,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 112-113;
      from load:112;
@@ -1342,7 +1342,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 113-114;
      from load:113;
@@ -1351,7 +1351,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 135-35;
      from node:135;
@@ -1360,7 +1360,7 @@ object overhead_line:  {
      configuration line_configuration:1004;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 149-1;
      from node:149;
@@ -1369,7 +1369,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 152-52;
      from node:152;
@@ -1378,7 +1378,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 6701-67;
      from node:6701;
@@ -1387,7 +1387,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 197-101;
      from node:197;

--- a/generators/autotest/test_1isochronous_dg_1Pdroop_Qconstant_battery.glm
+++ b/generators/autotest/test_1isochronous_dg_1Pdroop_Qconstant_battery.glm
@@ -333,7 +333,7 @@ object line_configuration:10012 {
 
 
 //Define line objects 
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 1-2;
      from load:1;
@@ -342,7 +342,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
 
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 1-3;
      from load:1;
@@ -351,7 +351,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 1-7;
      from load:1;
@@ -360,7 +360,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 3-4;
      from node:3;
@@ -369,7 +369,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 3-5;
      from node:3;
@@ -378,7 +378,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 5-6;
      from load:5;
@@ -387,7 +387,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 7-8;
      from load:7;
@@ -396,7 +396,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 8-12;
      from meter:8;
@@ -405,7 +405,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 8-9;
      from meter:8;
@@ -414,7 +414,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 8-13;
      from meter:8;
@@ -423,7 +423,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 1401-14;
      from node:1401;
@@ -432,7 +432,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 13-34;
      from meter:13;
@@ -441,7 +441,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 13-18;
      from meter:13;
@@ -450,7 +450,7 @@ object overhead_line:  {
      configuration line_configuration:1002;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 14-11;
      from node:14;
@@ -459,7 +459,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 14-10;
      from node:14;
@@ -468,7 +468,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 15-16;
      from node:15;
@@ -477,7 +477,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 15-17;
      from node:15;
@@ -486,7 +486,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 18-19;
      from node:18;
@@ -495,7 +495,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 18-21;
      from node:18;
@@ -504,7 +504,7 @@ object overhead_line:  {
      configuration line_configuration:1002;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 19-20;
      from load:19;
@@ -513,7 +513,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 21-22;
      from node:21;
@@ -522,7 +522,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 21-23;
      from node:21;
@@ -531,7 +531,7 @@ object overhead_line:  {
      configuration line_configuration:1002;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 23-24;
      from node:23;
@@ -540,7 +540,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 23-25;
      from node:23;
@@ -549,7 +549,7 @@ object overhead_line:  {
      configuration line_configuration:1002;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ACN";
      name 2601-26;
      from node:2601;
@@ -558,7 +558,7 @@ object overhead_line:  {
      configuration line_configuration:1007;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 25-28;
      from node:25;
@@ -567,7 +567,7 @@ object overhead_line:  {
      configuration line_configuration:1002;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ACN";
      name 26-27;
      from node:26;
@@ -576,7 +576,7 @@ object overhead_line:  {
      configuration line_configuration:1007;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 26-31;
      from node:26;
@@ -585,7 +585,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 27-33;
      from node:27;
@@ -594,7 +594,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 28-29;
      from load:28;
@@ -603,7 +603,7 @@ object overhead_line:  {
      configuration line_configuration:1002;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 29-30;
      from load:29;
@@ -612,7 +612,7 @@ object overhead_line:  {
      configuration line_configuration:1002;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 30-250;
      from load:30;
@@ -621,7 +621,7 @@ object overhead_line:  {
      configuration line_configuration:1002;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 31-32;
      from load:31;
@@ -630,7 +630,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 34-15;
      from load:34;
@@ -639,7 +639,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABN";
      name 35-36;
      from load:35;
@@ -648,7 +648,7 @@ object overhead_line:  {
      configuration line_configuration:1008;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 35-40;
      from load:35;
@@ -657,7 +657,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 36-37;
      from node:36;
@@ -666,7 +666,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 36-38;
      from node:36;
@@ -675,7 +675,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 38-39;
      from load:38;
@@ -684,7 +684,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 40-41;
      from node:40;
@@ -693,7 +693,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 40-42;
      from node:40;
@@ -702,7 +702,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 42-43;
      from load:42;
@@ -711,7 +711,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 42-44;
      from load:42;
@@ -720,7 +720,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 44-45;
      from node:44;
@@ -729,7 +729,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 44-47;
      from node:44;
@@ -738,7 +738,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 45-46;
      from load:45;
@@ -747,7 +747,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 47-48;
      from load:47;
@@ -756,7 +756,7 @@ object overhead_line:  {
      configuration line_configuration:1004;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 47-49;
      from load:47;
@@ -765,7 +765,7 @@ object overhead_line:  {
      configuration line_configuration:1004;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 49-50;
      from load:49;
@@ -774,7 +774,7 @@ object overhead_line:  {
      configuration line_configuration:1004;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 50-51;
      from meter:50;
@@ -783,7 +783,7 @@ object overhead_line:  {
      configuration line_configuration:1004;
 }
 
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";			//undefined line segment
      name 51-151;
      from load:51;
@@ -792,7 +792,7 @@ object overhead_line:  {
      configuration line_configuration:1004;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 52-53;
      from load:52;
@@ -801,7 +801,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 53-54;
      from load:53;
@@ -810,7 +810,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 54-55;
      from node:54;
@@ -819,7 +819,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 54-57;
      from node:54;
@@ -828,7 +828,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 55-56;
      from load:55;
@@ -837,7 +837,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 57-58;
      from meter:57;
@@ -846,7 +846,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 57-60;
      from meter:57;
@@ -855,7 +855,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 58-59;
      from load:58;
@@ -864,7 +864,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 60-61;
      from load:60;
@@ -873,7 +873,7 @@ object overhead_line:  {
      configuration line_configuration:1005;
 }
  
-object underground_line:  {
+object underground_line {
      phases "ABC";
      name 60-62;
      from load:60;
@@ -882,7 +882,7 @@ object underground_line:  {
      configuration line_configuration:10012;
 }
  
-object underground_line:  {
+object underground_line {
      phases "ABC";
      name 62-63;
      from load:62;
@@ -891,7 +891,7 @@ object underground_line:  {
      configuration line_configuration:10012;
 }
  
-object underground_line:  {
+object underground_line {
      phases "ABC";
      name 63-64;
      from load:63;
@@ -900,7 +900,7 @@ object underground_line:  {
      configuration line_configuration:10012;
 }
  
-object underground_line:  {
+object underground_line {
      phases "ABC";
      name 64-65;
      from load:64;
@@ -909,7 +909,7 @@ object underground_line:  {
      configuration line_configuration:10012;
 }
  
-object underground_line:  {
+object underground_line {
      phases "ABC";
      name 65-66;
      from load:65;
@@ -918,7 +918,7 @@ object underground_line:  {
      configuration line_configuration:10012;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 67-68;
      from meter:67;
@@ -927,7 +927,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 67-72;
      from meter:67;
@@ -937,7 +937,7 @@ object overhead_line:  {
 }
 
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 67-97;
      from meter:67;
@@ -946,7 +946,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 68-69;
      from load:68;
@@ -955,7 +955,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 69-70;
      from load:69;
@@ -964,7 +964,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 70-71;
      from load:70;
@@ -973,7 +973,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 72-73;
      from load:72;
@@ -982,7 +982,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 72-76;
      from load:72;
@@ -991,7 +991,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 73-74;
      from load:73;
@@ -1000,7 +1000,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 74-75;
      from load:74;
@@ -1009,7 +1009,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 76-77;
      from load:76;
@@ -1018,7 +1018,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 76-86;
      from load:76;
@@ -1027,7 +1027,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 77-78;
      from load:77;
@@ -1036,7 +1036,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 78-79;
      from node:78;
@@ -1045,7 +1045,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 78-80;
      from node:78;
@@ -1054,7 +1054,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 80-81;
      from load:80;
@@ -1063,7 +1063,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 81-82;
      from node:81;
@@ -1072,7 +1072,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 81-84;
      from node:81;
@@ -1081,7 +1081,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 82-83;
      from load:82;
@@ -1090,7 +1090,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 84-85;
      from load:84;
@@ -1099,7 +1099,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 86-87;
      from load:86;
@@ -1108,7 +1108,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 87-88;
      from load:87;
@@ -1117,7 +1117,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 87-89;
      from load:87;
@@ -1126,7 +1126,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 89-90;
      from node:89;
@@ -1135,7 +1135,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 89-91;
      from node:89;
@@ -1144,7 +1144,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 91-92;
      from node:91;
@@ -1153,7 +1153,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 91-93;
      from node:91;
@@ -1162,7 +1162,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 93-94;
      from node:93;
@@ -1171,7 +1171,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 93-95;
      from node:93;
@@ -1180,7 +1180,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 95-96;
      from load:95;
@@ -1189,7 +1189,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 97-98;
      from node:97;
@@ -1198,7 +1198,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 98-99;
      from load:98;
@@ -1207,7 +1207,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 99-100;
      from load:99;
@@ -1216,7 +1216,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 100-450;
      from load:100;
@@ -1225,7 +1225,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 101-102;
      from load:101;
@@ -1234,7 +1234,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 101-105;
      from load:101;
@@ -1243,7 +1243,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 102-103;
      from load:102;
@@ -1252,7 +1252,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 103-104;
      from load:103;
@@ -1261,7 +1261,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 105-106;
      from node:105;
@@ -1270,7 +1270,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 105-108;
      from node:105;
@@ -1279,7 +1279,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 106-107;
      from load:106;
@@ -1288,7 +1288,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 108-109;
      from node:108;
@@ -1297,7 +1297,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 108-300;
      from node:108;
@@ -1306,7 +1306,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 109-110;
      from load:109;
@@ -1315,7 +1315,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 110-111;
      from node:110;
@@ -1324,7 +1324,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 110-112;
      from node:110;
@@ -1333,7 +1333,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 112-113;
      from load:112;
@@ -1342,7 +1342,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 113-114;
      from load:113;
@@ -1351,7 +1351,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 135-35;
      from node:135;
@@ -1360,7 +1360,7 @@ object overhead_line:  {
      configuration line_configuration:1004;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 149-1;
      from node:149;
@@ -1369,7 +1369,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 152-52;
      from node:152;
@@ -1378,7 +1378,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 6701-67;
      from node:6701;
@@ -1387,7 +1387,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 197-101;
      from node:197;

--- a/generators/autotest/test_1isochronous_dg_1Pdroop_Qconstant_dg.glm
+++ b/generators/autotest/test_1isochronous_dg_1Pdroop_Qconstant_dg.glm
@@ -334,7 +334,7 @@ object line_configuration:10012 {
 
 
 //Define line objects 
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 1-2;
      from load:1;
@@ -343,7 +343,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
 
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 1-3;
      from load:1;
@@ -352,7 +352,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 1-7;
      from load:1;
@@ -361,7 +361,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 3-4;
      from node:3;
@@ -370,7 +370,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 3-5;
      from node:3;
@@ -379,7 +379,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 5-6;
      from load:5;
@@ -388,7 +388,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 7-8;
      from load:7;
@@ -397,7 +397,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 8-12;
      from meter:8;
@@ -406,7 +406,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 8-9;
      from meter:8;
@@ -415,7 +415,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 8-13;
      from meter:8;
@@ -424,7 +424,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 1401-14;
      from node:1401;
@@ -433,7 +433,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 13-34;
      from meter:13;
@@ -442,7 +442,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 13-18;
      from meter:13;
@@ -451,7 +451,7 @@ object overhead_line:  {
      configuration line_configuration:1002;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 14-11;
      from node:14;
@@ -460,7 +460,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 14-10;
      from node:14;
@@ -469,7 +469,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 15-16;
      from node:15;
@@ -478,7 +478,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 15-17;
      from node:15;
@@ -487,7 +487,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 18-19;
      from node:18;
@@ -496,7 +496,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 18-21;
      from node:18;
@@ -505,7 +505,7 @@ object overhead_line:  {
      configuration line_configuration:1002;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 19-20;
      from load:19;
@@ -514,7 +514,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 21-22;
      from node:21;
@@ -523,7 +523,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 21-23;
      from node:21;
@@ -532,7 +532,7 @@ object overhead_line:  {
      configuration line_configuration:1002;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 23-24;
      from node:23;
@@ -541,7 +541,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 23-25;
      from node:23;
@@ -550,7 +550,7 @@ object overhead_line:  {
      configuration line_configuration:1002;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ACN";
      name 2601-26;
      from node:2601;
@@ -559,7 +559,7 @@ object overhead_line:  {
      configuration line_configuration:1007;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 25-28;
      from node:25;
@@ -568,7 +568,7 @@ object overhead_line:  {
      configuration line_configuration:1002;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ACN";
      name 26-27;
      from node:26;
@@ -577,7 +577,7 @@ object overhead_line:  {
      configuration line_configuration:1007;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 26-31;
      from node:26;
@@ -586,7 +586,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 27-33;
      from node:27;
@@ -595,7 +595,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 28-29;
      from load:28;
@@ -604,7 +604,7 @@ object overhead_line:  {
      configuration line_configuration:1002;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 29-30;
      from load:29;
@@ -613,7 +613,7 @@ object overhead_line:  {
      configuration line_configuration:1002;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 30-250;
      from load:30;
@@ -622,7 +622,7 @@ object overhead_line:  {
      configuration line_configuration:1002;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 31-32;
      from load:31;
@@ -631,7 +631,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 34-15;
      from load:34;
@@ -640,7 +640,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABN";
      name 35-36;
      from load:35;
@@ -649,7 +649,7 @@ object overhead_line:  {
      configuration line_configuration:1008;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 35-40;
      from load:35;
@@ -658,7 +658,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 36-37;
      from node:36;
@@ -667,7 +667,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 36-38;
      from node:36;
@@ -676,7 +676,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 38-39;
      from load:38;
@@ -685,7 +685,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 40-41;
      from node:40;
@@ -694,7 +694,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 40-42;
      from node:40;
@@ -703,7 +703,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 42-43;
      from load:42;
@@ -712,7 +712,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 42-44;
      from load:42;
@@ -721,7 +721,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 44-45;
      from node:44;
@@ -730,7 +730,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 44-47;
      from node:44;
@@ -739,7 +739,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 45-46;
      from load:45;
@@ -748,7 +748,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 47-48;
      from load:47;
@@ -757,7 +757,7 @@ object overhead_line:  {
      configuration line_configuration:1004;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 47-49;
      from load:47;
@@ -766,7 +766,7 @@ object overhead_line:  {
      configuration line_configuration:1004;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 49-50;
      from load:49;
@@ -775,7 +775,7 @@ object overhead_line:  {
      configuration line_configuration:1004;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 50-51;
      from meter:50;
@@ -784,7 +784,7 @@ object overhead_line:  {
      configuration line_configuration:1004;
 }
 
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";			//undefined line segment
      name 51-151;
      from load:51;
@@ -793,7 +793,7 @@ object overhead_line:  {
      configuration line_configuration:1004;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 52-53;
      from load:52;
@@ -802,7 +802,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 53-54;
      from load:53;
@@ -811,7 +811,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 54-55;
      from node:54;
@@ -820,7 +820,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 54-57;
      from node:54;
@@ -829,7 +829,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 55-56;
      from load:55;
@@ -838,7 +838,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 57-58;
      from meter:57;
@@ -847,7 +847,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 57-60;
      from meter:57;
@@ -856,7 +856,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 58-59;
      from load:58;
@@ -865,7 +865,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 60-61;
      from load:60;
@@ -874,7 +874,7 @@ object overhead_line:  {
      configuration line_configuration:1005;
 }
  
-object underground_line:  {
+object underground_line {
      phases "ABC";
      name 60-62;
      from load:60;
@@ -883,7 +883,7 @@ object underground_line:  {
      configuration line_configuration:10012;
 }
  
-object underground_line:  {
+object underground_line {
      phases "ABC";
      name 62-63;
      from load:62;
@@ -892,7 +892,7 @@ object underground_line:  {
      configuration line_configuration:10012;
 }
  
-object underground_line:  {
+object underground_line {
      phases "ABC";
      name 63-64;
      from load:63;
@@ -901,7 +901,7 @@ object underground_line:  {
      configuration line_configuration:10012;
 }
  
-object underground_line:  {
+object underground_line {
      phases "ABC";
      name 64-65;
      from load:64;
@@ -910,7 +910,7 @@ object underground_line:  {
      configuration line_configuration:10012;
 }
  
-object underground_line:  {
+object underground_line {
      phases "ABC";
      name 65-66;
      from load:65;
@@ -919,7 +919,7 @@ object underground_line:  {
      configuration line_configuration:10012;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 67-68;
      from meter:67;
@@ -928,7 +928,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 67-72;
      from meter:67;
@@ -938,7 +938,7 @@ object overhead_line:  {
 }
 
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 67-97;
      from meter:67;
@@ -947,7 +947,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 68-69;
      from load:68;
@@ -956,7 +956,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 69-70;
      from load:69;
@@ -965,7 +965,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 70-71;
      from load:70;
@@ -974,7 +974,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 72-73;
      from load:72;
@@ -983,7 +983,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 72-76;
      from load:72;
@@ -992,7 +992,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 73-74;
      from load:73;
@@ -1001,7 +1001,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 74-75;
      from load:74;
@@ -1010,7 +1010,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 76-77;
      from load:76;
@@ -1019,7 +1019,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 76-86;
      from load:76;
@@ -1028,7 +1028,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 77-78;
      from load:77;
@@ -1037,7 +1037,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 78-79;
      from node:78;
@@ -1046,7 +1046,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 78-80;
      from node:78;
@@ -1055,7 +1055,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 80-81;
      from load:80;
@@ -1064,7 +1064,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 81-82;
      from node:81;
@@ -1073,7 +1073,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 81-84;
      from node:81;
@@ -1082,7 +1082,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 82-83;
      from load:82;
@@ -1091,7 +1091,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 84-85;
      from load:84;
@@ -1100,7 +1100,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 86-87;
      from load:86;
@@ -1109,7 +1109,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 87-88;
      from load:87;
@@ -1118,7 +1118,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 87-89;
      from load:87;
@@ -1127,7 +1127,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 89-90;
      from node:89;
@@ -1136,7 +1136,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 89-91;
      from node:89;
@@ -1145,7 +1145,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 91-92;
      from node:91;
@@ -1154,7 +1154,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 91-93;
      from node:91;
@@ -1163,7 +1163,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 93-94;
      from node:93;
@@ -1172,7 +1172,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 93-95;
      from node:93;
@@ -1181,7 +1181,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 95-96;
      from load:95;
@@ -1190,7 +1190,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 97-98;
      from node:97;
@@ -1199,7 +1199,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 98-99;
      from load:98;
@@ -1208,7 +1208,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 99-100;
      from load:99;
@@ -1217,7 +1217,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 100-450;
      from load:100;
@@ -1226,7 +1226,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 101-102;
      from load:101;
@@ -1235,7 +1235,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 101-105;
      from load:101;
@@ -1244,7 +1244,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 102-103;
      from load:102;
@@ -1253,7 +1253,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 103-104;
      from load:103;
@@ -1262,7 +1262,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 105-106;
      from node:105;
@@ -1271,7 +1271,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 105-108;
      from node:105;
@@ -1280,7 +1280,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 106-107;
      from load:106;
@@ -1289,7 +1289,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 108-109;
      from node:108;
@@ -1298,7 +1298,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 108-300;
      from node:108;
@@ -1307,7 +1307,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 109-110;
      from load:109;
@@ -1316,7 +1316,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 110-111;
      from node:110;
@@ -1325,7 +1325,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 110-112;
      from node:110;
@@ -1334,7 +1334,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 112-113;
      from load:112;
@@ -1343,7 +1343,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 113-114;
      from load:113;
@@ -1352,7 +1352,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 135-35;
      from node:135;
@@ -1361,7 +1361,7 @@ object overhead_line:  {
      configuration line_configuration:1004;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 149-1;
      from node:149;
@@ -1370,7 +1370,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 152-52;
      from node:152;
@@ -1379,7 +1379,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 6701-67;
      from node:6701;
@@ -1388,7 +1388,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 197-101;
      from node:197;

--- a/generators/autotest/test_inverter_dyn_1547_single_phase.glm
+++ b/generators/autotest/test_inverter_dyn_1547_single_phase.glm
@@ -48,7 +48,7 @@ object meter {
 	};
 }
 
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name intermed_line;
      from subtation_bus;
@@ -81,7 +81,7 @@ object node {
 	nominal_voltage 7200;
 }
 
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name lA;
      from feeder_head;
@@ -90,7 +90,7 @@ object overhead_line:  {
      configuration olcAN;
 }
 
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name lB;
      from feeder_head;
@@ -99,7 +99,7 @@ object overhead_line:  {
      configuration olcBN;
 }
 
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name lC;
      from feeder_head;

--- a/gldcore/autotest/test_largeid.glm
+++ b/gldcore/autotest/test_largeid.glm
@@ -1,0 +1,26 @@
+// Test large ID behavior
+
+clock {
+	timezone PST+8PDT;
+	starttime '2000-01-01 0:00:00 PST';
+	stoptime '2000-01-02 0:00:00 PST';
+}
+
+module residential {
+	implicit_enduses NONE;
+}
+
+// Create house with ID large enough to allocate 10 PB in old system
+object house:11258999068426240 {
+	groupid A;
+}
+
+module tape;
+
+object collector {
+	group "class=house AND groupid=A";
+	property "count(floor_area)";
+	limit 10;
+	interval 3600;
+	file output.csv;
+}

--- a/gldcore/autotest/test_missing_id_err.glm
+++ b/gldcore/autotest/test_missing_id_err.glm
@@ -1,0 +1,40 @@
+// Test large ID behavior
+
+clock {
+	timezone PST+8PDT;
+	starttime '2000-01-01 0:00:00 PST';
+	stoptime '2000-01-02 0:00:00 PST';
+}
+
+module residential {
+	implicit_enduses NONE;
+}
+
+// This is a syntax error. The colon is for assigning IDs, and should be omitted from anonymous objects.
+// The correct version of this behavior is shown below in the comment.
+object house: {
+	groupid A;
+}
+
+object house: {
+	groupid B;
+}
+
+// This is the correct behavior for anonymous objects
+// object house {
+//      groupid A;
+// }
+//
+// object house {
+// 	    groupid B;
+// }
+
+module tape;
+
+object collector {
+	group "class=house AND groupid=A";
+	property "count(floor_area)";
+	limit 10;
+	interval 3600;
+	file output.csv;
+}

--- a/models/taxonomy_feeder_R1-12.47-1.glm
+++ b/models/taxonomy_feeder_R1-12.47-1.glm
@@ -20838,7 +20838,7 @@ object triplex_line:3082 {
 }
 
 
-object triplex_line_conductor: {
+object triplex_line_conductor {
 	name triplex_1/0 AA;
 	resistance 0.97;
 	geometric_mean_radius 0.0111;

--- a/obsolete_test_case/gldcore_test/namespace.glm
+++ b/obsolete_test_case/gldcore_test/namespace.glm
@@ -41,7 +41,7 @@ namespace space2 {
 	object mytest {
 		namespace space1 {
 			object mytest {
-				test `{namespace}:{class}:{id}`;
+				test `{namespace} {class} {id}`;
 			};
 		};
 	};

--- a/obsolete_test_case/plc_test/feeder2plc.glm
+++ b/obsolete_test_case/plc_test/feeder2plc.glm
@@ -201,7 +201,7 @@ object load:8 {
 	sync_V_limit 0.001;
 }
 
-object switch_object: {
+object switch_object {
 	name Switch12;
 	from DummyNode1;
 	to node:2;
@@ -209,7 +209,7 @@ object switch_object: {
 	phases "ABCN";
 	}
 
-object switch_object: {
+object switch_object {
     name Switch56;
     from DummyNode5;
     to node:6;
@@ -217,7 +217,7 @@ object switch_object: {
     status CLOSED;
 }
 
-#object switch_object: {
+#object switch_object {
 #	name Switch37;
 #	from node:7;
 #	to DummyNode3;

--- a/obsolete_test_case/powerflow_test/123node/IEEE-123.glm
+++ b/obsolete_test_case/powerflow_test/123node/IEEE-123.glm
@@ -263,7 +263,7 @@ object line_configuration:10012 {
 
 
 //Define line objects 
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 1-2;
      from load:1;
@@ -272,7 +272,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
 
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 1-3;
      from load:1;
@@ -281,7 +281,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 1-7;
      from load:1;
@@ -290,7 +290,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 3-4;
      from node:3;
@@ -299,7 +299,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 3-5;
      from node:3;
@@ -308,7 +308,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 5-6;
      from load:5;
@@ -317,7 +317,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 7-8;
      from load:7;
@@ -326,7 +326,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 8-12;
      from node:8;
@@ -335,7 +335,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 8-9;
      from node:8;
@@ -344,7 +344,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 8-13;
      from node:8;
@@ -353,7 +353,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 1401-14;
      from node:1401;
@@ -362,7 +362,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 13-34;
      from node:13;
@@ -371,7 +371,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 13-18;
      from node:13;
@@ -380,7 +380,7 @@ object overhead_line:  {
      configuration line_configuration:1002;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 14-11;
      from node:14;
@@ -389,7 +389,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 14-10;
      from node:14;
@@ -398,7 +398,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 15-16;
      from node:15;
@@ -407,7 +407,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 15-17;
      from node:15;
@@ -416,7 +416,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 18-19;
      from node:18;
@@ -425,7 +425,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 18-21;
      from node:18;
@@ -434,7 +434,7 @@ object overhead_line:  {
      configuration line_configuration:1002;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 19-20;
      from load:19;
@@ -443,7 +443,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 21-22;
      from node:21;
@@ -452,7 +452,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 21-23;
      from node:21;
@@ -461,7 +461,7 @@ object overhead_line:  {
      configuration line_configuration:1002;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 23-24;
      from node:23;
@@ -470,7 +470,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 23-25;
      from node:23;
@@ -479,7 +479,7 @@ object overhead_line:  {
      configuration line_configuration:1002;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ACN";
      name 2601-26;
      from node:2601;
@@ -488,7 +488,7 @@ object overhead_line:  {
      configuration line_configuration:1007;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 25-28;
      from node:25;
@@ -497,7 +497,7 @@ object overhead_line:  {
      configuration line_configuration:1002;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ACN";
      name 26-27;
      from node:26;
@@ -506,7 +506,7 @@ object overhead_line:  {
      configuration line_configuration:1007;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 26-31;
      from node:26;
@@ -515,7 +515,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 27-33;
      from node:27;
@@ -524,7 +524,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 28-29;
      from load:28;
@@ -533,7 +533,7 @@ object overhead_line:  {
      configuration line_configuration:1002;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 29-30;
      from load:29;
@@ -542,7 +542,7 @@ object overhead_line:  {
      configuration line_configuration:1002;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 30-250;
      from load:30;
@@ -551,7 +551,7 @@ object overhead_line:  {
      configuration line_configuration:1002;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 31-32;
      from load:31;
@@ -560,7 +560,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 34-15;
      from load:34;
@@ -569,7 +569,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABN";
      name 35-36;
      from load:35;
@@ -578,7 +578,7 @@ object overhead_line:  {
      configuration line_configuration:1008;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 35-40;
      from load:35;
@@ -587,7 +587,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 36-37;
      from node:36;
@@ -596,7 +596,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 36-38;
      from node:36;
@@ -605,7 +605,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 38-39;
      from load:38;
@@ -614,7 +614,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 40-41;
      from node:40;
@@ -623,7 +623,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 40-42;
      from node:40;
@@ -632,7 +632,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 42-43;
      from load:42;
@@ -641,7 +641,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 42-44;
      from load:42;
@@ -650,7 +650,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 44-45;
      from node:44;
@@ -659,7 +659,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 44-47;
      from node:44;
@@ -668,7 +668,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 45-46;
      from load:45;
@@ -677,7 +677,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 47-48;
      from load:47;
@@ -686,7 +686,7 @@ object overhead_line:  {
      configuration line_configuration:1004;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 47-49;
      from load:47;
@@ -695,7 +695,7 @@ object overhead_line:  {
      configuration line_configuration:1004;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 49-50;
      from load:49;
@@ -704,7 +704,7 @@ object overhead_line:  {
      configuration line_configuration:1004;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 50-51;
      from load:50;
@@ -713,7 +713,7 @@ object overhead_line:  {
      configuration line_configuration:1004;
 }
 
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";			//undefined line segment
      name 51-151;
      from load:51;
@@ -722,7 +722,7 @@ object overhead_line:  {
      configuration line_configuration:1004;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 52-53;
      from load:52;
@@ -731,7 +731,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 53-54;
      from load:53;
@@ -740,7 +740,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 54-55;
      from node:54;
@@ -749,7 +749,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 54-57;
      from node:54;
@@ -758,7 +758,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 55-56;
      from load:55;
@@ -767,7 +767,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 57-58;
      from node:57;
@@ -776,7 +776,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 57-60;
      from node:57;
@@ -785,7 +785,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 58-59;
      from load:58;
@@ -794,7 +794,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 60-61;
      from load:60;
@@ -803,7 +803,7 @@ object overhead_line:  {
      configuration line_configuration:1005;
 }
  
-object underground_line:  {
+object underground_line {
      phases "ABC";
      name 60-62;
      from load:60;
@@ -812,7 +812,7 @@ object underground_line:  {
      configuration line_configuration:10012;
 }
  
-object underground_line:  {
+object underground_line {
      phases "ABC";
      name 62-63;
      from load:62;
@@ -821,7 +821,7 @@ object underground_line:  {
      configuration line_configuration:10012;
 }
  
-object underground_line:  {
+object underground_line {
      phases "ABC";
      name 63-64;
      from load:63;
@@ -830,7 +830,7 @@ object underground_line:  {
      configuration line_configuration:10012;
 }
  
-object underground_line:  {
+object underground_line {
      phases "ABC";
      name 64-65;
      from load:64;
@@ -839,7 +839,7 @@ object underground_line:  {
      configuration line_configuration:10012;
 }
  
-object underground_line:  {
+object underground_line {
      phases "ABC";
      name 65-66;
      from load:65;
@@ -848,7 +848,7 @@ object underground_line:  {
      configuration line_configuration:10012;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 67-68;
      from node:67;
@@ -857,7 +857,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 67-72;
      from node:67;
@@ -866,7 +866,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 67-97;
      from node:67;
@@ -875,7 +875,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 68-69;
      from load:68;
@@ -884,7 +884,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 69-70;
      from load:69;
@@ -893,7 +893,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 70-71;
      from load:70;
@@ -902,7 +902,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 72-73;
      from node:72;
@@ -911,7 +911,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 72-76;
      from node:72;
@@ -920,7 +920,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 73-74;
      from load:73;
@@ -929,7 +929,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 74-75;
      from load:74;
@@ -938,7 +938,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 76-77;
      from load:76;
@@ -947,7 +947,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 76-86;
      from load:76;
@@ -956,7 +956,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 77-78;
      from load:77;
@@ -965,7 +965,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 78-79;
      from node:78;
@@ -974,7 +974,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 78-80;
      from node:78;
@@ -983,7 +983,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 80-81;
      from load:80;
@@ -992,7 +992,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 81-82;
      from node:81;
@@ -1001,7 +1001,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 81-84;
      from node:81;
@@ -1010,7 +1010,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 82-83;
      from load:82;
@@ -1019,7 +1019,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 84-85;
      from load:84;
@@ -1028,7 +1028,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 86-87;
      from load:86;
@@ -1037,7 +1037,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 87-88;
      from load:87;
@@ -1046,7 +1046,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 87-89;
      from load:87;
@@ -1055,7 +1055,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 89-90;
      from node:89;
@@ -1064,7 +1064,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 89-91;
      from node:89;
@@ -1073,7 +1073,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 91-92;
      from node:91;
@@ -1082,7 +1082,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 91-93;
      from node:91;
@@ -1091,7 +1091,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 93-94;
      from node:93;
@@ -1100,7 +1100,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 93-95;
      from node:93;
@@ -1109,7 +1109,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 95-96;
      from load:95;
@@ -1118,7 +1118,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 97-98;
      from node:97;
@@ -1127,7 +1127,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 98-99;
      from load:98;
@@ -1136,7 +1136,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 99-100;
      from load:99;
@@ -1145,7 +1145,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 100-450;
      from load:100;
@@ -1154,7 +1154,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 101-102;
      from node:101;
@@ -1163,7 +1163,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 101-105;
      from node:101;
@@ -1172,7 +1172,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 102-103;
      from load:102;
@@ -1181,7 +1181,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 103-104;
      from load:103;
@@ -1190,7 +1190,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 105-106;
      from node:105;
@@ -1199,7 +1199,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 105-108;
      from node:105;
@@ -1208,7 +1208,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 106-107;
      from load:106;
@@ -1217,7 +1217,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 108-109;
      from node:108;
@@ -1226,7 +1226,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 108-300;
      from node:108;
@@ -1235,7 +1235,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 109-110;
      from load:109;
@@ -1244,7 +1244,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 110-111;
      from node:110;
@@ -1253,7 +1253,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 110-112;
      from node:110;
@@ -1262,7 +1262,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 112-113;
      from load:112;
@@ -1271,7 +1271,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 113-114;
      from load:113;
@@ -1280,7 +1280,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 135-35;
      from node:135;
@@ -1289,7 +1289,7 @@ object overhead_line:  {
      configuration line_configuration:1004;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 149-1;
      from node:149;
@@ -1298,7 +1298,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 152-52;
      from node:152;
@@ -1307,7 +1307,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 6701-67;
      from node:6701;
@@ -1316,7 +1316,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 197-101;
      from node:197;

--- a/obsolete_test_case/powerflow_test/123node/IEEE-123No-regulator.glm
+++ b/obsolete_test_case/powerflow_test/123node/IEEE-123No-regulator.glm
@@ -262,7 +262,7 @@ object line_configuration:10012 {
 
 
 //Define line objects 
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 1-2;
      from load:1;
@@ -271,7 +271,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
 
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 1-3;
      from load:1;
@@ -280,7 +280,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 1-7;
      from load:1;
@@ -289,7 +289,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 3-4;
      from node:3;
@@ -298,7 +298,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 3-5;
      from node:3;
@@ -307,7 +307,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 5-6;
      from load:5;
@@ -316,7 +316,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 7-8;
      from load:7;
@@ -325,7 +325,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 8-12;
      from node:8;
@@ -334,7 +334,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 8-9;
      from node:8;
@@ -343,7 +343,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 8-13;
      from node:8;
@@ -352,7 +352,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 9-14;
      from load:9;
@@ -361,7 +361,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 13-34;
      from node:13;
@@ -370,7 +370,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 13-18;
      from node:13;
@@ -379,7 +379,7 @@ object overhead_line:  {
      configuration line_configuration:1002;
 }
 
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 13-152;
      from node:13;
@@ -388,7 +388,7 @@ object overhead_line:  {
      configuration line_configuration:1002;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 14-11;
      from node:14;
@@ -397,7 +397,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 14-10;
      from node:14;
@@ -406,7 +406,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 15-16;
      from node:15;
@@ -415,7 +415,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 15-17;
      from node:15;
@@ -424,7 +424,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 18-19;
      from node:18;
@@ -433,7 +433,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 18-21;
      from node:18;
@@ -442,7 +442,7 @@ object overhead_line:  {
      configuration line_configuration:1002;
 }
 
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 18-135;
      from node:18;
@@ -451,7 +451,7 @@ object overhead_line:  {
      configuration line_configuration:1002;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 19-20;
      from load:19;
@@ -460,7 +460,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 21-22;
      from node:21;
@@ -469,7 +469,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 21-23;
      from node:21;
@@ -478,7 +478,7 @@ object overhead_line:  {
      configuration line_configuration:1002;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 23-24;
      from node:23;
@@ -487,7 +487,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 23-25;
      from node:23;
@@ -496,7 +496,7 @@ object overhead_line:  {
      configuration line_configuration:1002;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ACN";
      name 25-26;
      from node:25;
@@ -505,7 +505,7 @@ object overhead_line:  {
      configuration line_configuration:1007;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 25-28;
      from node:25;
@@ -514,7 +514,7 @@ object overhead_line:  {
      configuration line_configuration:1002;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ACN";
      name 26-27;
      from node:26;
@@ -523,7 +523,7 @@ object overhead_line:  {
      configuration line_configuration:1007;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 26-31;
      from node:26;
@@ -532,7 +532,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 27-33;
      from node:27;
@@ -541,7 +541,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 28-29;
      from load:28;
@@ -550,7 +550,7 @@ object overhead_line:  {
      configuration line_configuration:1002;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 29-30;
      from load:29;
@@ -559,7 +559,7 @@ object overhead_line:  {
      configuration line_configuration:1002;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 30-250;
      from load:30;
@@ -568,7 +568,7 @@ object overhead_line:  {
      configuration line_configuration:1002;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 31-32;
      from load:31;
@@ -577,7 +577,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 34-15;
      from load:34;
@@ -586,7 +586,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABN";
      name 35-36;
      from load:35;
@@ -595,7 +595,7 @@ object overhead_line:  {
      configuration line_configuration:1008;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 35-40;
      from load:35;
@@ -604,7 +604,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 36-37;
      from node:36;
@@ -613,7 +613,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 36-38;
      from node:36;
@@ -622,7 +622,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 38-39;
      from load:38;
@@ -631,7 +631,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 40-41;
      from node:40;
@@ -640,7 +640,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 40-42;
      from node:40;
@@ -649,7 +649,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 42-43;
      from load:42;
@@ -658,7 +658,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 42-44;
      from load:42;
@@ -667,7 +667,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 44-45;
      from node:44;
@@ -676,7 +676,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 44-47;
      from node:44;
@@ -685,7 +685,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 45-46;
      from load:45;
@@ -694,7 +694,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 47-48;
      from load:47;
@@ -703,7 +703,7 @@ object overhead_line:  {
      configuration line_configuration:1004;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 47-49;
      from load:47;
@@ -712,7 +712,7 @@ object overhead_line:  {
      configuration line_configuration:1004;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 49-50;
      from load:49;
@@ -721,7 +721,7 @@ object overhead_line:  {
      configuration line_configuration:1004;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 50-51;
      from load:50;
@@ -730,7 +730,7 @@ object overhead_line:  {
      configuration line_configuration:1004;
 }
 
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";			//undefined line segment
      name 51-151;
      from load:51;
@@ -739,7 +739,7 @@ object overhead_line:  {
      configuration line_configuration:1004;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 52-53;
      from load:52;
@@ -748,7 +748,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 53-54;
      from load:53;
@@ -757,7 +757,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 54-55;
      from node:54;
@@ -766,7 +766,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 54-57;
      from node:54;
@@ -775,7 +775,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 55-56;
      from load:55;
@@ -784,7 +784,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 57-58;
      from node:57;
@@ -793,7 +793,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 57-60;
      from node:57;
@@ -802,7 +802,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 58-59;
      from load:58;
@@ -811,7 +811,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 60-61;
      from load:60;
@@ -820,7 +820,7 @@ object overhead_line:  {
      configuration line_configuration:1005;
 }
 
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 60-160;
      from load:60;
@@ -829,7 +829,7 @@ object overhead_line:  {
      configuration line_configuration:1005;
 }
  
-object underground_line:  {
+object underground_line {
      phases "ABC";
      name 60-62;
      from load:60;
@@ -838,7 +838,7 @@ object underground_line:  {
      configuration line_configuration:10012;
 }
  
-object underground_line:  {
+object underground_line {
      phases "ABC";
      name 62-63;
      from load:62;
@@ -847,7 +847,7 @@ object underground_line:  {
      configuration line_configuration:10012;
 }
  
-object underground_line:  {
+object underground_line {
      phases "ABC";
      name 63-64;
      from load:63;
@@ -856,7 +856,7 @@ object underground_line:  {
      configuration line_configuration:10012;
 }
  
-object underground_line:  {
+object underground_line {
      phases "ABC";
      name 64-65;
      from load:64;
@@ -865,7 +865,7 @@ object underground_line:  {
      configuration line_configuration:10012;
 }
  
-object underground_line:  {
+object underground_line {
      phases "ABC";
      name 65-66;
      from load:65;
@@ -874,7 +874,7 @@ object underground_line:  {
      configuration line_configuration:10012;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 67-68;
      from node:67;
@@ -883,7 +883,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 67-72;
      from node:67;
@@ -892,7 +892,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 67-97;
      from node:67;
@@ -901,7 +901,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 68-69;
      from load:68;
@@ -910,7 +910,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 69-70;
      from load:69;
@@ -919,7 +919,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 70-71;
      from load:70;
@@ -928,7 +928,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 72-73;
      from node:72;
@@ -937,7 +937,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 72-76;
      from node:72;
@@ -946,7 +946,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 73-74;
      from load:73;
@@ -955,7 +955,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 74-75;
      from load:74;
@@ -964,7 +964,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 76-77;
      from load:76;
@@ -973,7 +973,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 76-86;
      from load:76;
@@ -982,7 +982,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 77-78;
      from load:77;
@@ -991,7 +991,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 78-79;
      from node:78;
@@ -1000,7 +1000,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 78-80;
      from node:78;
@@ -1009,7 +1009,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 80-81;
      from load:80;
@@ -1018,7 +1018,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 81-82;
      from node:81;
@@ -1027,7 +1027,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 81-84;
      from node:81;
@@ -1036,7 +1036,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 82-83;
      from load:82;
@@ -1045,7 +1045,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 84-85;
      from load:84;
@@ -1054,7 +1054,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 86-87;
      from load:86;
@@ -1063,7 +1063,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 87-88;
      from load:87;
@@ -1072,7 +1072,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 87-89;
      from load:87;
@@ -1081,7 +1081,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 89-90;
      from node:89;
@@ -1090,7 +1090,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 89-91;
      from node:89;
@@ -1099,7 +1099,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 91-92;
      from node:91;
@@ -1108,7 +1108,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 91-93;
      from node:91;
@@ -1117,7 +1117,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 93-94;
      from node:93;
@@ -1126,7 +1126,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 93-95;
      from node:93;
@@ -1135,7 +1135,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 95-96;
      from load:95;
@@ -1144,7 +1144,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 97-98;
      from node:97;
@@ -1153,7 +1153,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
 
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 97-197;
      from node:97;
@@ -1162,7 +1162,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 98-99;
      from load:98;
@@ -1171,7 +1171,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 99-100;
      from load:99;
@@ -1180,7 +1180,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 100-450;
      from load:100;
@@ -1189,7 +1189,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 101-102;
      from node:101;
@@ -1198,7 +1198,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 101-105;
      from node:101;
@@ -1207,7 +1207,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 102-103;
      from load:102;
@@ -1216,7 +1216,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 103-104;
      from load:103;
@@ -1225,7 +1225,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 105-106;
      from node:105;
@@ -1234,7 +1234,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 105-108;
      from node:105;
@@ -1243,7 +1243,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 106-107;
      from load:106;
@@ -1252,7 +1252,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 108-109;
      from node:108;
@@ -1261,7 +1261,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 108-300;
      from node:108;
@@ -1270,7 +1270,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 109-110;
      from load:109;
@@ -1279,7 +1279,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 110-111;
      from node:110;
@@ -1288,7 +1288,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 110-112;
      from node:110;
@@ -1297,7 +1297,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 112-113;
      from load:112;
@@ -1306,7 +1306,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 113-114;
      from load:113;
@@ -1315,7 +1315,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 135-35;
      from node:135;
@@ -1324,7 +1324,7 @@ object overhead_line:  {
      configuration line_configuration:1004;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 150-1;
      from node:150;
@@ -1333,7 +1333,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 152-52;
      from node:152;
@@ -1342,7 +1342,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 160-67;
      from node:160;
@@ -1351,7 +1351,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 197-101;
      from node:197;

--- a/obsolete_test_case/powerflow_test/input.glm
+++ b/obsolete_test_case/powerflow_test/input.glm
@@ -13,7 +13,7 @@ clock {
 module powerflow;
 
 
-object triplex_line_conductor: {
+object triplex_line_conductor {
 	name 1/0 AA triplex;
 	resistance 0.97;
 	geometric_mean_radius 0.0111;

--- a/powerflow/autotest/test_IEEE-123_FBS.glm
+++ b/powerflow/autotest/test_IEEE-123_FBS.glm
@@ -267,7 +267,7 @@ object line_configuration:10012 {
 
 
 //Define line objects 
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 1-2;
      from load:1;
@@ -276,7 +276,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
 
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 1-3;
      from load:1;
@@ -285,7 +285,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 1-7;
      from load:1;
@@ -294,7 +294,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 3-4;
      from node:3;
@@ -303,7 +303,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 3-5;
      from node:3;
@@ -312,7 +312,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 5-6;
      from load:5;
@@ -321,7 +321,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 7-8;
      from load:7;
@@ -330,7 +330,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 8-12;
      from node:8;
@@ -339,7 +339,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 8-9;
      from node:8;
@@ -348,7 +348,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 8-13;
      from node:8;
@@ -357,7 +357,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 1401-14;
      from node:1401;
@@ -366,7 +366,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 13-34;
      from node:13;
@@ -375,7 +375,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 13-18;
      from node:13;
@@ -384,7 +384,7 @@ object overhead_line:  {
      configuration line_configuration:1002;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 14-11;
      from node:14;
@@ -393,7 +393,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 14-10;
      from node:14;
@@ -402,7 +402,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 15-16;
      from node:15;
@@ -411,7 +411,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 15-17;
      from node:15;
@@ -420,7 +420,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 18-19;
      from node:18;
@@ -429,7 +429,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 18-21;
      from node:18;
@@ -438,7 +438,7 @@ object overhead_line:  {
      configuration line_configuration:1002;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 19-20;
      from load:19;
@@ -447,7 +447,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 21-22;
      from node:21;
@@ -456,7 +456,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 21-23;
      from node:21;
@@ -465,7 +465,7 @@ object overhead_line:  {
      configuration line_configuration:1002;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 23-24;
      from node:23;
@@ -474,7 +474,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 23-25;
      from node:23;
@@ -483,7 +483,7 @@ object overhead_line:  {
      configuration line_configuration:1002;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ACN";
      name 2601-26;
      from node:2601;
@@ -492,7 +492,7 @@ object overhead_line:  {
      configuration line_configuration:1007;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 25-28;
      from node:25;
@@ -501,7 +501,7 @@ object overhead_line:  {
      configuration line_configuration:1002;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ACN";
      name 26-27;
      from node:26;
@@ -510,7 +510,7 @@ object overhead_line:  {
      configuration line_configuration:1007;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 26-31;
      from node:26;
@@ -519,7 +519,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 27-33;
      from node:27;
@@ -528,7 +528,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 28-29;
      from load:28;
@@ -537,7 +537,7 @@ object overhead_line:  {
      configuration line_configuration:1002;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 29-30;
      from load:29;
@@ -546,7 +546,7 @@ object overhead_line:  {
      configuration line_configuration:1002;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 30-250;
      from load:30;
@@ -555,7 +555,7 @@ object overhead_line:  {
      configuration line_configuration:1002;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 31-32;
      from load:31;
@@ -564,7 +564,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 34-15;
      from load:34;
@@ -573,7 +573,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABN";
      name 35-36;
      from load:35;
@@ -582,7 +582,7 @@ object overhead_line:  {
      configuration line_configuration:1008;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 35-40;
      from load:35;
@@ -591,7 +591,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 36-37;
      from node:36;
@@ -600,7 +600,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 36-38;
      from node:36;
@@ -609,7 +609,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 38-39;
      from load:38;
@@ -618,7 +618,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 40-41;
      from node:40;
@@ -627,7 +627,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 40-42;
      from node:40;
@@ -636,7 +636,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 42-43;
      from load:42;
@@ -645,7 +645,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 42-44;
      from load:42;
@@ -654,7 +654,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 44-45;
      from node:44;
@@ -663,7 +663,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 44-47;
      from node:44;
@@ -672,7 +672,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 45-46;
      from load:45;
@@ -681,7 +681,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 47-48;
      from load:47;
@@ -690,7 +690,7 @@ object overhead_line:  {
      configuration line_configuration:1004;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 47-49;
      from load:47;
@@ -699,7 +699,7 @@ object overhead_line:  {
      configuration line_configuration:1004;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 49-50;
      from load:49;
@@ -708,7 +708,7 @@ object overhead_line:  {
      configuration line_configuration:1004;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 50-51;
      from load:50;
@@ -717,7 +717,7 @@ object overhead_line:  {
      configuration line_configuration:1004;
 }
 
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";			//undefined line segment
      name 51-151;
      from load:51;
@@ -726,7 +726,7 @@ object overhead_line:  {
      configuration line_configuration:1004;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 52-53;
      from load:52;
@@ -735,7 +735,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 53-54;
      from load:53;
@@ -744,7 +744,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 54-55;
      from node:54;
@@ -753,7 +753,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 54-57;
      from node:54;
@@ -762,7 +762,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 55-56;
      from load:55;
@@ -771,7 +771,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 57-58;
      from node:57;
@@ -780,7 +780,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 57-60;
      from node:57;
@@ -789,7 +789,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 58-59;
      from load:58;
@@ -798,7 +798,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 60-61;
      from load:60;
@@ -807,7 +807,7 @@ object overhead_line:  {
      configuration line_configuration:1005;
 }
  
-object underground_line:  {
+object underground_line {
      phases "ABC";
      name 60-62;
      from load:60;
@@ -816,7 +816,7 @@ object underground_line:  {
      configuration line_configuration:10012;
 }
  
-object underground_line:  {
+object underground_line {
      phases "ABC";
      name 62-63;
      from load:62;
@@ -825,7 +825,7 @@ object underground_line:  {
      configuration line_configuration:10012;
 }
  
-object underground_line:  {
+object underground_line {
      phases "ABC";
      name 63-64;
      from load:63;
@@ -834,7 +834,7 @@ object underground_line:  {
      configuration line_configuration:10012;
 }
  
-object underground_line:  {
+object underground_line {
      phases "ABC";
      name 64-65;
      from load:64;
@@ -843,7 +843,7 @@ object underground_line:  {
      configuration line_configuration:10012;
 }
  
-object underground_line:  {
+object underground_line {
      phases "ABC";
      name 65-66;
      from load:65;
@@ -852,7 +852,7 @@ object underground_line:  {
      configuration line_configuration:10012;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 67-68;
      from node:67;
@@ -861,7 +861,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 67-72;
      from node:67;
@@ -870,7 +870,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 67-97;
      from node:67;
@@ -879,7 +879,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 68-69;
      from load:68;
@@ -888,7 +888,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 69-70;
      from load:69;
@@ -897,7 +897,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 70-71;
      from load:70;
@@ -906,7 +906,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 72-73;
      from node:72;
@@ -915,7 +915,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 72-76;
      from node:72;
@@ -924,7 +924,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 73-74;
      from load:73;
@@ -933,7 +933,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 74-75;
      from load:74;
@@ -942,7 +942,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 76-77;
      from load:76;
@@ -951,7 +951,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 76-86;
      from load:76;
@@ -960,7 +960,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 77-78;
      from load:77;
@@ -969,7 +969,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 78-79;
      from node:78;
@@ -978,7 +978,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 78-80;
      from node:78;
@@ -987,7 +987,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 80-81;
      from load:80;
@@ -996,7 +996,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 81-82;
      from node:81;
@@ -1005,7 +1005,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 81-84;
      from node:81;
@@ -1014,7 +1014,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 82-83;
      from load:82;
@@ -1023,7 +1023,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 84-85;
      from load:84;
@@ -1032,7 +1032,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 86-87;
      from load:86;
@@ -1041,7 +1041,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 87-88;
      from load:87;
@@ -1050,7 +1050,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 87-89;
      from load:87;
@@ -1059,7 +1059,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 89-90;
      from node:89;
@@ -1068,7 +1068,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 89-91;
      from node:89;
@@ -1077,7 +1077,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 91-92;
      from node:91;
@@ -1086,7 +1086,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 91-93;
      from node:91;
@@ -1095,7 +1095,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 93-94;
      from node:93;
@@ -1104,7 +1104,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 93-95;
      from node:93;
@@ -1113,7 +1113,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 95-96;
      from load:95;
@@ -1122,7 +1122,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 97-98;
      from node:97;
@@ -1131,7 +1131,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 98-99;
      from load:98;
@@ -1140,7 +1140,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 99-100;
      from load:99;
@@ -1149,7 +1149,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 100-450;
      from load:100;
@@ -1158,7 +1158,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 101-102;
      from node:101;
@@ -1167,7 +1167,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 101-105;
      from node:101;
@@ -1176,7 +1176,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 102-103;
      from load:102;
@@ -1185,7 +1185,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "CN";
      name 103-104;
      from load:103;
@@ -1194,7 +1194,7 @@ object overhead_line:  {
      configuration line_configuration:10011;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 105-106;
      from node:105;
@@ -1203,7 +1203,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 105-108;
      from node:105;
@@ -1212,7 +1212,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "BN";
      name 106-107;
      from load:106;
@@ -1221,7 +1221,7 @@ object overhead_line:  {
      configuration line_configuration:10010;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 108-109;
      from node:108;
@@ -1230,7 +1230,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 108-300;
      from node:108;
@@ -1239,7 +1239,7 @@ object overhead_line:  {
      configuration line_configuration:1003;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 109-110;
      from load:109;
@@ -1248,7 +1248,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 110-111;
      from node:110;
@@ -1257,7 +1257,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 110-112;
      from node:110;
@@ -1266,7 +1266,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 112-113;
      from load:112;
@@ -1275,7 +1275,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "AN";
      name 113-114;
      from load:113;
@@ -1284,7 +1284,7 @@ object overhead_line:  {
      configuration line_configuration:1009;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 135-35;
      from node:135;
@@ -1293,7 +1293,7 @@ object overhead_line:  {
      configuration line_configuration:1004;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 149-1;
      from node:149;
@@ -1302,7 +1302,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 152-52;
      from node:152;
@@ -1311,7 +1311,7 @@ object overhead_line:  {
      configuration line_configuration:1001;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 6701-67;
      from node:6701;
@@ -1320,7 +1320,7 @@ object overhead_line:  {
      configuration line_configuration:1006;
 }
  
-object overhead_line:  {
+object overhead_line {
      phases "ABCN";
      name 197-101;
      from node:197;

--- a/taxonomy_feeders/autotest/test_R1-12.47-1.glm
+++ b/taxonomy_feeders/autotest/test_R1-12.47-1.glm
@@ -20836,7 +20836,7 @@ object triplex_line:3082 {
 }
 
 
-object triplex_line_conductor: {
+object triplex_line_conductor {
 	name triplex_1/0 AA;
 	resistance 0.97;
 	geometric_mean_radius 0.0111;

--- a/taxonomy_feeders/autotest/test_R1-12.47-1_NR.glm
+++ b/taxonomy_feeders/autotest/test_R1-12.47-1_NR.glm
@@ -20836,7 +20836,7 @@ object triplex_line:3082 {
 }
 
 
-object triplex_line_conductor: {
+object triplex_line_conductor {
 	name triplex_1/0 AA;
 	resistance 0.97;
 	geometric_mean_radius 0.0111;

--- a/taxonomy_feeders/autotest/test_R1-12.47-2.glm
+++ b/taxonomy_feeders/autotest/test_R1-12.47-2.glm
@@ -10282,7 +10282,7 @@ object triplex_line:1416 {
 }
 
 
-object triplex_line_conductor: {
+object triplex_line_conductor {
 	name TLC 1/0 AA triplex;
 	resistance 0.97;
 	geometric_mean_radius 0.0111;

--- a/taxonomy_feeders/autotest/test_R1-12.47-2_NR.glm
+++ b/taxonomy_feeders/autotest/test_R1-12.47-2_NR.glm
@@ -10281,7 +10281,7 @@ object triplex_line:1416 {
 }
 
 
-object triplex_line_conductor: {
+object triplex_line_conductor {
 	name TLC 1/0 AA triplex;
 	resistance 0.97;
 	geometric_mean_radius 0.0111;

--- a/taxonomy_feeders/autotest/test_R1-12.47-3.glm
+++ b/taxonomy_feeders/autotest/test_R1-12.47-3.glm
@@ -2255,7 +2255,7 @@ object triplex_line:131 {
 }
 
 
-object triplex_line_conductor: {
+object triplex_line_conductor {
 	name TLC 1/0 AA triplex;
 	resistance 0.97;
 	geometric_mean_radius 0.0111;

--- a/taxonomy_feeders/autotest/test_R1-12.47-3_NR.glm
+++ b/taxonomy_feeders/autotest/test_R1-12.47-3_NR.glm
@@ -2255,7 +2255,7 @@ object triplex_line:131 {
 }
 
 
-object triplex_line_conductor: {
+object triplex_line_conductor {
 	name TLC 1/0 AA triplex;
 	resistance 0.97;
 	geometric_mean_radius 0.0111;

--- a/taxonomy_feeders/autotest/test_R1-12.47-4.glm
+++ b/taxonomy_feeders/autotest/test_R1-12.47-4.glm
@@ -4888,7 +4888,7 @@ object triplex_line:494 {
 }
 
 
-object triplex_line_conductor: {
+object triplex_line_conductor {
 	name TLC 1/0 AA triplex;
 	resistance 0.97;
 	geometric_mean_radius 0.0111;

--- a/taxonomy_feeders/autotest/test_R1-12.47-4_NR.glm
+++ b/taxonomy_feeders/autotest/test_R1-12.47-4_NR.glm
@@ -4888,7 +4888,7 @@ object triplex_line:494 {
 }
 
 
-object triplex_line_conductor: {
+object triplex_line_conductor {
 	name TLC 1/0 AA triplex;
 	resistance 0.97;
 	geometric_mean_radius 0.0111;

--- a/taxonomy_feeders/autotest/test_R1-25.00-1.glm
+++ b/taxonomy_feeders/autotest/test_R1-25.00-1.glm
@@ -8338,7 +8338,7 @@ object triplex_line:661 {
 }
 
 
-object triplex_line_conductor: {
+object triplex_line_conductor {
 	name triplex_1/0 AA;
 	resistance 0.97;
 	geometric_mean_radius 0.0111;

--- a/taxonomy_feeders/autotest/test_R1-25.00-1_NR.glm
+++ b/taxonomy_feeders/autotest/test_R1-25.00-1_NR.glm
@@ -8338,7 +8338,7 @@ object triplex_line:661 {
 }
 
 
-object triplex_line_conductor: {
+object triplex_line_conductor {
 	name triplex_1/0 AA;
 	resistance 0.97;
 	geometric_mean_radius 0.0111;

--- a/taxonomy_feeders/autotest/test_R2-12.47-1.glm
+++ b/taxonomy_feeders/autotest/test_R2-12.47-1.glm
@@ -12184,7 +12184,7 @@ object triplex_line:1086 {
 }
 
 
-object triplex_line_conductor: {
+object triplex_line_conductor {
 	name TLC 1/0 AA triplex;
 	resistance 0.97;
 	geometric_mean_radius 0.0111;

--- a/taxonomy_feeders/autotest/test_R2-12.47-1_NR.glm
+++ b/taxonomy_feeders/autotest/test_R2-12.47-1_NR.glm
@@ -12184,7 +12184,7 @@ object triplex_line:1086 {
 }
 
 
-object triplex_line_conductor: {
+object triplex_line_conductor {
 	name TLC 1/0 AA triplex;
 	resistance 0.97;
 	geometric_mean_radius 0.0111;

--- a/taxonomy_feeders/autotest/test_R2-12.47-2.glm
+++ b/taxonomy_feeders/autotest/test_R2-12.47-2.glm
@@ -8997,7 +8997,7 @@ object triplex_line:1100 {
 }
 
 
-object triplex_line_conductor: {
+object triplex_line_conductor {
 	name TLC 1/0 AA triplex;
 	resistance 0.97;
 	geometric_mean_radius 0.0111;

--- a/taxonomy_feeders/autotest/test_R2-12.47-2_NR.glm
+++ b/taxonomy_feeders/autotest/test_R2-12.47-2_NR.glm
@@ -8996,7 +8996,7 @@ object triplex_line:1100 {
 }
 
 
-object triplex_line_conductor: {
+object triplex_line_conductor {
 	name TLC 1/0 AA triplex;
 	resistance 0.97;
 	geometric_mean_radius 0.0111;

--- a/taxonomy_feeders/autotest/test_R2-12.47-3.glm
+++ b/taxonomy_feeders/autotest/test_R2-12.47-3.glm
@@ -18427,7 +18427,7 @@ object triplex_line:2859 {
 }
 
 
-object triplex_line_conductor: {
+object triplex_line_conductor {
 	name TLC 1/0 AA triplex;
 	resistance 0.97;
 	geometric_mean_radius 0.0111;

--- a/taxonomy_feeders/autotest/test_R2-12.47-3_NR.glm
+++ b/taxonomy_feeders/autotest/test_R2-12.47-3_NR.glm
@@ -18425,7 +18425,7 @@ object triplex_line:2859 {
 }
 
 
-object triplex_line_conductor: {
+object triplex_line_conductor {
 	name TLC 1/0 AA triplex;
 	resistance 0.97;
 	geometric_mean_radius 0.0111;

--- a/taxonomy_feeders/autotest/test_R2-25.00-1.glm
+++ b/taxonomy_feeders/autotest/test_R2-25.00-1.glm
@@ -12392,7 +12392,7 @@ object triplex_line:1328 {
      configuration triplex_line_configuration:1; 
 } 
 
-object triplex_line_conductor: { 
+object triplex_line_conductor {
      name TLC 1/0 AA triplex; 
      resistance 0.97; 
      geometric_mean_radius 0.0111; 

--- a/taxonomy_feeders/autotest/test_R2-25.00-1_NR.glm
+++ b/taxonomy_feeders/autotest/test_R2-25.00-1_NR.glm
@@ -12392,7 +12392,7 @@ object triplex_line:1328 {
      configuration triplex_line_configuration:1; 
 } 
 
-object triplex_line_conductor: { 
+object triplex_line_conductor {
      name TLC 1/0 AA triplex; 
      resistance 0.97; 
      geometric_mean_radius 0.0111; 

--- a/taxonomy_feeders/autotest/test_R2-35.00-1.glm
+++ b/taxonomy_feeders/autotest/test_R2-35.00-1.glm
@@ -33967,7 +33967,7 @@ object triplex_line:2671 {
 }
 
 
-object triplex_line_conductor: {
+object triplex_line_conductor {
 	name TLC 1/0 AA triplex;
 	resistance 0.97;
 	geometric_mean_radius 0.0111;

--- a/taxonomy_feeders/autotest/test_R2-35.00-1_NR.glm
+++ b/taxonomy_feeders/autotest/test_R2-35.00-1_NR.glm
@@ -33965,7 +33965,7 @@ object triplex_line:2671 {
 }
 
 
-object triplex_line_conductor: {
+object triplex_line_conductor {
 	name TLC 1/0 AA triplex;
 	resistance 0.97;
 	geometric_mean_radius 0.0111;

--- a/taxonomy_feeders/autotest/test_R3-12.47-1.glm
+++ b/taxonomy_feeders/autotest/test_R3-12.47-1.glm
@@ -19124,7 +19124,7 @@ object triplex_line:2456 {
 }
 
 
-object triplex_line_conductor: {
+object triplex_line_conductor {
 	name TLC 1/0 AA triplex;
 	resistance 0.97;
 	geometric_mean_radius 0.0111;

--- a/taxonomy_feeders/autotest/test_R3-12.47-1_NR.glm
+++ b/taxonomy_feeders/autotest/test_R3-12.47-1_NR.glm
@@ -19124,7 +19124,7 @@ object triplex_line:2456 {
 }
 
 
-object triplex_line_conductor: {
+object triplex_line_conductor {
 	name TLC 1/0 AA triplex;
 	resistance 0.97;
 	geometric_mean_radius 0.0111;

--- a/taxonomy_feeders/autotest/test_R3-12.47-2.glm
+++ b/taxonomy_feeders/autotest/test_R3-12.47-2.glm
@@ -6293,7 +6293,7 @@ object transformer_configuration:456 {
       shunt_impedance 1851.960+1814.886j;
 } 
 
-object triplex_line_conductor: { 
+object triplex_line_conductor {
      name TLC 1/0 AA triplex; 
      resistance 0.97; 
      geometric_mean_radius 0.0111; 

--- a/taxonomy_feeders/autotest/test_R3-12.47-2_NR.glm
+++ b/taxonomy_feeders/autotest/test_R3-12.47-2_NR.glm
@@ -6293,7 +6293,7 @@ object transformer_configuration:456 {
       shunt_impedance 1851.960+1814.886j;
 } 
 
-object triplex_line_conductor: { 
+object triplex_line_conductor {
      name TLC 1/0 AA triplex; 
      resistance 0.97; 
      geometric_mean_radius 0.0111; 

--- a/taxonomy_feeders/autotest/test_R3-12.47-3.glm
+++ b/taxonomy_feeders/autotest/test_R3-12.47-3.glm
@@ -34470,7 +34470,7 @@ object overhead_line:12432 {
 	length 250.500;
 	configuration line_configuration:25;
 }
-object overhead_line:10716 {
+object overhead_line:107161 {
 	name R3-12-47-3_ol_1511;
 	phases ABCN;
 	from R3-12-47-3_node_122;
@@ -64128,7 +64128,7 @@ object triplex_line:8785 {
 }
 
 
-object triplex_line_conductor: {
+object triplex_line_conductor {
 	name TLC 1/0 AA triplex;
 	resistance 0.97;
 	geometric_mean_radius 0.0111;

--- a/taxonomy_feeders/autotest/test_R3-12.47-3_NR.glm
+++ b/taxonomy_feeders/autotest/test_R3-12.47-3_NR.glm
@@ -34470,7 +34470,7 @@ object overhead_line:12432 {
 	length 250.500;
 	configuration line_configuration:25;
 }
-object overhead_line:10716 {
+object overhead_line:107161 {
 	name R3-12-47-3_ol_1511;
 	phases ABCN;
 	from R3-12-47-3_node_122;
@@ -64128,7 +64128,7 @@ object triplex_line:8785 {
 }
 
 
-object triplex_line_conductor: {
+object triplex_line_conductor {
 	name TLC 1/0 AA triplex;
 	resistance 0.97;
 	geometric_mean_radius 0.0111;

--- a/taxonomy_feeders/autotest/test_R4-12.47-1.glm
+++ b/taxonomy_feeders/autotest/test_R4-12.47-1.glm
@@ -21250,7 +21250,7 @@ object triplex_line:2674 {
 }
 
 
-object triplex_line_conductor: {
+object triplex_line_conductor {
 	name TLC 1/0 AA triplex;
 	resistance 0.97;
 	geometric_mean_radius 0.0111;

--- a/taxonomy_feeders/autotest/test_R4-12.47-1_NR.glm
+++ b/taxonomy_feeders/autotest/test_R4-12.47-1_NR.glm
@@ -21225,7 +21225,7 @@ object triplex_line:2674 {
 }
 
 
-object triplex_line_conductor: {
+object triplex_line_conductor {
 	name TLC 1/0 AA triplex;
 	resistance 0.97;
 	geometric_mean_radius 0.0111;

--- a/taxonomy_feeders/autotest/test_R4-12.47-2.glm
+++ b/taxonomy_feeders/autotest/test_R4-12.47-2.glm
@@ -7982,7 +7982,7 @@ object triplex_line:1071 {
 }
 
 
-object triplex_line_conductor: {
+object triplex_line_conductor {
 	name TLC 1/0 AA triplex;
 	resistance 0.97;
 	geometric_mean_radius 0.0111;

--- a/taxonomy_feeders/autotest/test_R4-12.47-2_NR.glm
+++ b/taxonomy_feeders/autotest/test_R4-12.47-2_NR.glm
@@ -7982,7 +7982,7 @@ object triplex_line:1071 {
 }
 
 
-object triplex_line_conductor: {
+object triplex_line_conductor {
 	name TLC 1/0 AA triplex;
 	resistance 0.97;
 	geometric_mean_radius 0.0111;

--- a/taxonomy_feeders/autotest/test_R4-25.00-1.glm
+++ b/taxonomy_feeders/autotest/test_R4-25.00-1.glm
@@ -6665,7 +6665,7 @@ object triplex_line:820 {
 }
 
 
-object triplex_line_conductor: {
+object triplex_line_conductor {
 	name TLC 1/0 AA triplex;
 	resistance 0.97;
 	geometric_mean_radius 0.0111;

--- a/taxonomy_feeders/autotest/test_R4-25.00-1_NR.glm
+++ b/taxonomy_feeders/autotest/test_R4-25.00-1_NR.glm
@@ -6665,7 +6665,7 @@ object triplex_line:820 {
 }
 
 
-object triplex_line_conductor: {
+object triplex_line_conductor {
 	name TLC 1/0 AA triplex;
 	resistance 0.97;
 	geometric_mean_radius 0.0111;

--- a/taxonomy_feeders/autotest/test_R5-12.47-1.glm
+++ b/taxonomy_feeders/autotest/test_R5-12.47-1.glm
@@ -10425,7 +10425,7 @@ object triplex_line:1157 {
 }
 
 
-object triplex_line_conductor: {
+object triplex_line_conductor {
 	name TLC 1/0 AA triplex;
 	resistance 0.97;
 	geometric_mean_radius 0.0111;

--- a/taxonomy_feeders/autotest/test_R5-12.47-1_NR.glm
+++ b/taxonomy_feeders/autotest/test_R5-12.47-1_NR.glm
@@ -10424,7 +10424,7 @@ object triplex_line:1157 {
 }
 
 
-object triplex_line_conductor: {
+object triplex_line_conductor {
 	name TLC 1/0 AA triplex;
 	resistance 0.97;
 	geometric_mean_radius 0.0111;

--- a/taxonomy_feeders/autotest/test_R5-12.47-2.glm
+++ b/taxonomy_feeders/autotest/test_R5-12.47-2.glm
@@ -10025,7 +10025,7 @@ object triplex_line:1011 {
      configuration triplex_line_configuration:1; 
 } 
 
-object triplex_line_conductor: { 
+object triplex_line_conductor {
      name TLC 1/0 AA triplex; 
      resistance 0.97; 
      geometric_mean_radius 0.0111; 

--- a/taxonomy_feeders/autotest/test_R5-12.47-2_NR.glm
+++ b/taxonomy_feeders/autotest/test_R5-12.47-2_NR.glm
@@ -10025,7 +10025,7 @@ object triplex_line:1011 {
      configuration triplex_line_configuration:1; 
 } 
 
-object triplex_line_conductor: { 
+object triplex_line_conductor {
      name TLC 1/0 AA triplex; 
      resistance 0.97; 
      geometric_mean_radius 0.0111; 

--- a/taxonomy_feeders/autotest/test_R5-12.47-3.glm
+++ b/taxonomy_feeders/autotest/test_R5-12.47-3.glm
@@ -50853,7 +50853,7 @@ clock{
       configuration triplex_line_configuration:1;
  }
 
- object triplex_line_conductor: {
+ object triplex_line_conductor {
       name TLC 1/0 AA triplex;
       resistance 0.97;
       geometric_mean_radius 0.0111;

--- a/taxonomy_feeders/autotest/test_R5-12.47-3_NR.glm
+++ b/taxonomy_feeders/autotest/test_R5-12.47-3_NR.glm
@@ -50852,7 +50852,7 @@ clock{
       configuration triplex_line_configuration:1;
  }
 
- object triplex_line_conductor: {
+ object triplex_line_conductor {
       name TLC 1/0 AA triplex;
       resistance 0.97;
       geometric_mean_radius 0.0111;

--- a/taxonomy_feeders/autotest/test_R5-12.47-4.glm
+++ b/taxonomy_feeders/autotest/test_R5-12.47-4.glm
@@ -13992,7 +13992,7 @@ object triplex_line:1481 {
      configuration triplex_line_configuration:1; 
 } 
 
-object triplex_line_conductor: { 
+object triplex_line_conductor {
      name TLC 1/0 AA triplex; 
      resistance 0.97; 
      geometric_mean_radius 0.0111; 

--- a/taxonomy_feeders/autotest/test_R5-12.47-4_NR.glm
+++ b/taxonomy_feeders/autotest/test_R5-12.47-4_NR.glm
@@ -13992,7 +13992,7 @@ object triplex_line:1481 {
      configuration triplex_line_configuration:1; 
 } 
 
-object triplex_line_conductor: { 
+object triplex_line_conductor {
      name TLC 1/0 AA triplex; 
      resistance 0.97; 
      geometric_mean_radius 0.0111; 

--- a/taxonomy_feeders/autotest/test_R5-12.47-5.glm
+++ b/taxonomy_feeders/autotest/test_R5-12.47-5.glm
@@ -23399,7 +23399,7 @@ object triplex_line:2622 {
      configuration triplex_line_configuration:1; 
 } 
 
-object triplex_line_conductor: { 
+object triplex_line_conductor {
      name TLC 1/0 AA triplex; 
      resistance 0.97; 
      geometric_mean_radius 0.0111; 

--- a/taxonomy_feeders/autotest/test_R5-12.47-5_NR.glm
+++ b/taxonomy_feeders/autotest/test_R5-12.47-5_NR.glm
@@ -23399,7 +23399,7 @@ object triplex_line:2622 {
      configuration triplex_line_configuration:1; 
 } 
 
-object triplex_line_conductor: { 
+object triplex_line_conductor {
      name TLC 1/0 AA triplex; 
      resistance 0.97; 
      geometric_mean_radius 0.0111; 

--- a/taxonomy_feeders/autotest/test_R5-25.00-1.glm
+++ b/taxonomy_feeders/autotest/test_R5-25.00-1.glm
@@ -21125,7 +21125,7 @@ object triplex_line:2524 {
      configuration triplex_line_configuration:1; 
 } 
 
-object triplex_line_conductor: { 
+object triplex_line_conductor {
      name TLC 1/0 AA triplex; 
      resistance 0.97; 
      geometric_mean_radius 0.0111; 

--- a/taxonomy_feeders/autotest/test_R5-25.00-1_NR.glm
+++ b/taxonomy_feeders/autotest/test_R5-25.00-1_NR.glm
@@ -21125,7 +21125,7 @@ object triplex_line:2524 {
      configuration triplex_line_configuration:1; 
 } 
 
-object triplex_line_conductor: { 
+object triplex_line_conductor {
      name TLC 1/0 AA triplex; 
      resistance 0.97; 
      geometric_mean_radius 0.0111; 

--- a/taxonomy_feeders/autotest/test_R5-35.00-1.glm
+++ b/taxonomy_feeders/autotest/test_R5-35.00-1.glm
@@ -8904,7 +8904,7 @@ object triplex_line:1227 {
      configuration triplex_line_configuration:1; 
 } 
 
-object triplex_line_conductor: { 
+object triplex_line_conductor {
      name TLC 1/0 AA triplex; 
      resistance 0.97; 
      geometric_mean_radius 0.0111; 

--- a/taxonomy_feeders/autotest/test_R5-35.00-1_NR.glm
+++ b/taxonomy_feeders/autotest/test_R5-35.00-1_NR.glm
@@ -8904,7 +8904,7 @@ object triplex_line:1227 {
      configuration triplex_line_configuration:1; 
 } 
 
-object triplex_line_conductor: { 
+object triplex_line_conductor {
      name TLC 1/0 AA triplex; 
      resistance 0.97; 
      geometric_mean_radius 0.0111; 


### PR DESCRIPTION
#### What's this Pull Request do?
Fixes the unbound memory allocation issue present in current GridLAB-D's load behavior.

#### Where should the reviewer start?
Confirm the behavior noted in #1225 is now fixed, and no longer causing out of memory issues.

#### How should this be tested?
Cross check a variety of cases which make use of both automatic and manual object ID specification.

#### What are the relevant issues?
Resolves #1225, Resolves #1228
