### PR TITLE
Add metric for multilayer waterheater model

### DIFF
--- a/tape/autotest/test_metrics_collector.glm
+++ b/tape/autotest/test_metrics_collector.glm
@@ -1,0 +1,493 @@
+clock {
+     timezone EST+5EDT;
+     timestamp '2010-08-15 00:00:00';
+     stoptime '2010-08-16 00:12:00';
+}
+
+#set double_format=%+.12lg
+#set randomseed=10;
+#set relax_naming_rules=1;
+//#set minimum_timestep=60;
+#include "../water_and_setpoint_schedule_v3.glm";
+
+module tape;
+module residential {
+     implicit_enduses NONE;
+};
+module powerflow {
+     solver_method FBS;
+     NR_iteration_limit 100;
+};
+
+object metrics_collector_writer {
+  interval 300;
+  interim 3600;
+  filename sub_;
+  alternate yes;
+  extension json;
+}
+
+object transformer_configuration {
+     name substation_config;
+     connect_type WYE_WYE;
+     install_type PADMOUNT;
+     primary_voltage 7200 V;
+     secondary_voltage 7200 V;
+     power_rating 75;
+     powerA_rating 25;
+     powerB_rating 25;
+     powerC_rating 25;
+     impedance 0.0015+0.00675j;
+}
+
+object transformer_configuration {
+     name default_transformer_A;
+     connect_type SINGLE_PHASE_CENTER_TAPPED;
+     install_type PADMOUNT;
+     primary_voltage 7200 V;
+     secondary_voltage 124 V;
+     power_rating 25;
+     powerA_rating 25;
+     impedance 0.015+0.0675j;
+}
+
+object transformer_configuration {
+     name default_transformer_B;
+     connect_type SINGLE_PHASE_CENTER_TAPPED;
+     install_type PADMOUNT;
+     primary_voltage 7200 V;
+     secondary_voltage 124 V;
+     power_rating 25;
+     powerB_rating 25;
+     impedance 0.015+0.0675j;
+}
+
+object transformer_configuration {
+     name default_transformer_C;
+     connect_type SINGLE_PHASE_CENTER_TAPPED;
+     install_type PADMOUNT;
+     primary_voltage 7200 V;
+     secondary_voltage 124 V;
+     power_rating 25;
+     powerC_rating 25;
+     impedance 0.015+0.0675j;
+}
+
+object triplex_line_conductor {
+     name Name_1_0_AA_triplex;
+     resistance 0.57;
+     geometric_mean_radius 0.0111;
+}
+
+object triplex_line_configuration {
+     name TLCFG;
+     conductor_1 Name_1_0_AA_triplex;
+     conductor_2 Name_1_0_AA_triplex;
+     conductor_N Name_1_0_AA_triplex;
+     insulation_thickness 0.08;
+     diameter 0.368;
+}
+
+object meter {
+     bustype SWING;
+     name ROOT;
+     phases ABCN;
+     nominal_voltage 7200;
+}
+
+object transformer {
+     phases ABCN;
+     groupid _Network_Trans;
+     name _Transformer1;
+     from ROOT;
+     to _transformer_meter;
+     configuration substation_config;
+     object recorder {
+          property power_out_real;
+          limit 100000000;
+          interval 60;
+          file totalload_5_houses_Aug.csv;
+     };
+}
+
+object meter {
+     name _transformer_meter;
+     phases ABCN;
+     nominal_voltage 7200;
+}
+
+object transformer {
+     name _center_tap_transformer_A;
+     phases AS;
+     from _transformer_meter;
+     to _triplex_node_A;
+     configuration default_transformer_A;
+}
+
+object transformer {
+     name _center_tap_transformer_B;
+     phases BS;
+     from _transformer_meter;
+     to _triplex_node_B;
+     configuration default_transformer_B;
+}
+
+object transformer {
+     name _center_tap_transformer_C;
+     phases CS;
+     from _transformer_meter;
+     to _triplex_node_C;
+     configuration default_transformer_C;
+}
+
+object triplex_meter {
+     name _triplex_node_A;
+     phases AS;
+     nominal_voltage 124.00;
+}
+
+object triplex_meter {
+     name _triplex_node_B;
+     phases BS;
+     nominal_voltage 124.00;
+}
+
+object triplex_meter {
+     name _triplex_node_C;
+     phases CS;
+     nominal_voltage 124.00;
+}
+
+object triplex_line {
+     from _triplex_node_A;
+     to _tpm_flatrate_A1;
+     groupid _Triplex_Line;
+     phases AS;
+     length 10;
+     configuration TLCFG;
+}
+
+object triplex_meter {
+     nominal_voltage 124;
+     phases AS;
+     name _tpm_flatrate_A1;
+     groupid _flatrate_meter;
+}
+
+object triplex_meter {
+     nominal_voltage 124;
+     phases AS;
+     name _tpm_rt_A1;
+     groupid _rt_meter;
+     parent _tpm_flatrate_A1;
+}
+
+object house {
+     name H_1;
+     //Residential_2
+     parent _tpm_rt_A1;
+     schedule_skew -685;
+     Rroof 33.69;
+     Rwall 17.71;
+     Rfloor 17.02;
+     Rdoors 5;
+     Rwindows 1.81;
+     airchange_per_hour 0.80;
+     hvac_power_factor 0.97;
+     cooling_system_type ELECTRIC;
+     heating_system_type RESISTANCE;
+     fan_type ONE_SPEED;
+     hvac_breaker_rating 200;
+     total_thermal_mass_per_floor_area 3.01;
+     motor_efficiency AVERAGE;
+     motor_model BASIC;
+     cooling_COP 3.90;
+     floor_area 1040;
+     number_of_doors 2;
+     air_temperature 71.9;
+     mass_temperature 71.9;
+    object waterheater {
+      name wh_1;
+      schedule_skew -5660;
+      heating_element_capacity 4.0 kW;
+      thermostat_deadband 1.0;
+      location INSIDE;
+      tank_diameter 1.5;
+      tank_UA 3.6;
+      water_demand 4.02;
+      tank_volume 50;
+      waterheater_model MULTILAYER;
+      discrete_step_size 60.0;
+      lower_tank_setpoint 117.3;
+      upper_tank_setpoint 127.3;
+      T_mixing_valve 122.3;
+      object metrics_collector {
+        interval 300;
+      };
+    };
+    object metrics_collector {
+      interval 300;
+    };
+}
+
+object triplex_line {
+     from _triplex_node_B;
+     to _tpm_flatrate_B2;
+     groupid _Triplex_Line;
+     phases BS;
+     length 10;
+     configuration TLCFG;
+}
+
+object triplex_meter {
+     nominal_voltage 124;
+     phases BS;
+     name _tpm_flatrate_B2;
+     groupid _flatrate_meter;
+}
+
+object triplex_meter {
+     nominal_voltage 124;
+     phases BS;
+     name _tpm_rt_B2;
+     groupid _rt_meter;
+     parent _tpm_flatrate_B2;
+}
+
+object house {
+     name H_2;
+     //Residential_1
+     parent _tpm_rt_B2;
+     schedule_skew -97;
+     Rroof 21.61;
+     Rwall 9.30;
+     Rfloor 11.38;
+     Rdoors 3;
+     Rwindows 1.56;
+     airchange_per_hour 1.02;
+     hvac_power_factor 0.97;
+     cooling_system_type ELECTRIC;
+     heating_system_type RESISTANCE;
+     fan_type ONE_SPEED;
+     hvac_breaker_rating 200;
+     total_thermal_mass_per_floor_area 4.59;
+     motor_efficiency AVERAGE;
+     motor_model BASIC;
+     cooling_COP 3.75;
+     floor_area 1438;
+     number_of_doors 2;
+     air_temperature 71.9;
+     mass_temperature 71.9;
+  object waterheater {
+    name wh_2;
+    object metrics_collector {
+      interval 300;
+    };
+  };
+  object metrics_collector {
+    interval 300;
+  };
+}
+
+object triplex_line {
+     from _triplex_node_B;
+     to _tpm_flatrate_B3;
+     groupid _Triplex_Line;
+     phases BS;
+     length 10;
+     configuration TLCFG;
+}
+
+object triplex_meter {
+     nominal_voltage 124;
+     phases BS;
+     name _tpm_flatrate_B3;
+     groupid _flatrate_meter;
+}
+
+object triplex_meter {
+     nominal_voltage 124;
+     phases BS;
+     name _tpm_rt_B3;
+     groupid _rt_meter;
+     parent _tpm_flatrate_B3;
+}
+
+object house {
+     name H_3;
+     //Residential_3
+     parent _tpm_rt_B3;
+     schedule_skew -481;
+     Rroof 18.58;
+     Rwall 11.08;
+     Rfloor 11.36;
+     Rdoors 3;
+     Rwindows 0.91;
+     airchange_per_hour 0.97;
+     hvac_power_factor 0.97;
+     cooling_system_type ELECTRIC;
+     heating_system_type RESISTANCE;
+     fan_type ONE_SPEED;
+     hvac_breaker_rating 200;
+     total_thermal_mass_per_floor_area 3.64;
+     motor_efficiency AVERAGE;
+     motor_model BASIC;
+     cooling_COP 3.22;
+     floor_area 3176;
+     number_of_doors 4;
+     air_temperature 71.2;
+     mass_temperature 71.2;
+  object waterheater {
+    name wh_3;
+    schedule_skew -2094;
+    heating_element_capacity 5.0 kW;
+    thermostat_deadband 1.0;
+    location INSIDE;
+    tank_diameter 1.5;
+    tank_UA 3.5;
+    water_demand 10.03;
+    tank_volume 70;
+    waterheater_model MULTILAYER;
+    discrete_step_size 60.0;
+    lower_tank_setpoint 119.2;
+    upper_tank_setpoint 129.2;
+    T_mixing_valve 124.2;
+    object metrics_collector {
+      interval 300;
+    };
+  };  
+  object metrics_collector {
+    interval 300;
+  };
+}
+
+object triplex_line {
+     from _triplex_node_C;
+     to _tpm_flatrate_C4;
+     groupid _Triplex_Line;
+     phases CS;
+     length 10;
+     configuration TLCFG;
+}
+
+object triplex_meter {
+     nominal_voltage 124;
+     phases CS;
+     name _tpm_flatrate_C4;
+     groupid _flatrate_meter;
+}
+
+object triplex_meter {
+     nominal_voltage 124;
+     phases CS;
+     name _tpm_rt_C4;
+     groupid _rt_meter;
+     parent _tpm_flatrate_C4;
+}
+
+object house {
+     name H_4;
+     //Residential_1
+     parent _tpm_rt_C4;
+     schedule_skew 1997;
+     Rroof 16.68;
+     Rwall 11.39;
+     Rfloor 11.98;
+     Rdoors 3;
+     Rwindows 1.08;
+     airchange_per_hour 0.81;
+     hvac_power_factor 0.97;
+     cooling_system_type ELECTRIC;
+     heating_system_type RESISTANCE;
+     fan_type ONE_SPEED;
+     hvac_breaker_rating 200;
+     total_thermal_mass_per_floor_area 4.35;
+     motor_efficiency AVERAGE;
+     motor_model BASIC;
+     cooling_COP 3.18;
+     floor_area 618;
+     number_of_doors 1;
+     air_temperature 71.7;
+     mass_temperature 71.7;
+  object waterheater {
+    name wh_4;
+    schedule_skew -13972;
+    heating_element_capacity 5.5 kW;
+    thermostat_deadband 1.0;
+    location INSIDE;
+    tank_diameter 1.5;
+    tank_UA 3.9;
+    water_demand 8.01;
+    tank_volume 60;
+    waterheater_model MULTILAYER;
+    discrete_step_size 60.0;
+    lower_tank_setpoint 113.2;
+    upper_tank_setpoint 123.2;
+    T_mixing_valve 118.2;
+    object metrics_collector {
+      interval 300;
+    };
+  };
+  object metrics_collector {
+    interval 300;
+  };
+}
+
+object triplex_line {
+     from _triplex_node_C;
+     to _tpm_flatrate_C5;
+     groupid _Triplex_Line;
+     phases CS;
+     length 10;
+     configuration TLCFG;
+}
+
+object triplex_meter {
+     nominal_voltage 124;
+     phases CS;
+     name _tpm_flatrate_C5;
+     groupid _flatrate_meter;
+}
+
+object triplex_meter {
+     nominal_voltage 124;
+     phases CS;
+     name _tpm_rt_C5;
+     groupid _rt_meter;
+     parent _tpm_flatrate_C5;
+}
+
+object house {
+     name H_5;
+     //Residential_1
+     parent _tpm_rt_C5;
+     schedule_skew -2380;
+     Rroof 17.77;
+     Rwall 8.67;
+     Rfloor 10.59;
+     Rdoors 3;
+     Rwindows 1.14;
+     airchange_per_hour 1.16;
+     hvac_power_factor 0.97;
+     cooling_system_type ELECTRIC;
+     heating_system_type RESISTANCE;
+     fan_type ONE_SPEED;
+     hvac_breaker_rating 200;
+     total_thermal_mass_per_floor_area 4.90;
+     motor_efficiency AVERAGE;
+     motor_model BASIC;
+     cooling_COP 2.82;
+     floor_area 746;
+     number_of_doors 1;
+     air_temperature 69.5;
+     mass_temperature 69.5;
+  object waterheater {
+    name wh_5;
+    object metrics_collector {
+      interval 300;
+    };
+  };
+  object metrics_collector {
+    interval 300;
+  };
+}

--- a/tape/metrics_collector.h
+++ b/tape/metrics_collector.h
@@ -73,7 +73,22 @@
 #define WH_MIN_TEMP         9
 #define WH_MAX_TEMP        10
 #define WH_AVG_TEMP        11
-#define WH_ARRAY_SIZE      12
+
+#define WH_MIN_L_SETPOINT  12
+#define WH_MAX_L_SETPOINT  13
+#define WH_AVG_L_SETPOINT  14
+#define WH_MIN_U_SETPOINT  15
+#define WH_MAX_U_SETPOINT  16
+#define WH_AVG_U_SETPOINT  17
+#define WH_MIN_L_TEMP      18
+#define WH_MAX_L_TEMP      19
+#define WH_AVG_L_TEMP      20
+#define WH_MIN_U_TEMP      21
+#define WH_MAX_U_TEMP      22
+#define WH_AVG_U_TEMP      23
+#define WH_ELEM_L_MODE     24
+#define WH_ELEM_U_MODE     25
+#define WH_ARRAY_SIZE      26
 
 #define INV_MIN_REAL_POWER 0
 #define INV_MAX_REAL_POWER 1
@@ -202,6 +217,13 @@ private:
 	static PROPERTY *propWaterDemand;
 	static PROPERTY *propWaterTemp;
 
+	static PROPERTY *propWaterLSetPoint;
+	static PROPERTY *propWaterUSetPoint;
+	static PROPERTY *propWaterLTemp;
+	static PROPERTY *propWaterUTemp;
+	static PROPERTY *propWaterElemLMode;
+	static PROPERTY *propWaterElemUMode;
+
 	static PROPERTY *propInverterS;
 
 	static PROPERTY *propCapCountA;
@@ -255,6 +277,13 @@ private:
 	double *wh_setpoint_array;
 	double *wh_demand_array; 	
 	double *wh_temp_array; 		
+
+	double *wh_l_setpoint_array;
+	double *wh_l_temp_array;
+	double *wh_u_setpoint_array;
+	double *wh_u_temp_array;
+	int elem_l_mode;
+	int elem_u_mode;
 	char waterheaterName[256];				// char array storing names of the waterheater
 
 	// Parameters related to inverter object

--- a/tape/metrics_collector_writer.cpp
+++ b/tape/metrics_collector_writer.cpp
@@ -8,8 +8,6 @@
 
 #include "metrics_collector_writer.h"
 
-#define USE_DEPRECATED_FASTWRITER
-
 CLASS *metrics_collector_writer::oclass = NULL;
 
 void new_metrics_collector_writer(MODULE *mod) {
@@ -301,6 +299,22 @@ int metrics_collector_writer::init(OBJECT *parent) {
 	jsn[m_index] = idx++;	jsn[m_units] = "degF";	meta[m_waterheater_temp_min] = jsn;
 	jsn[m_index] = idx++;	jsn[m_units] = "degF";	meta[m_waterheater_temp_max] = jsn;
 	jsn[m_index] = idx++;	jsn[m_units] = "degF";	meta[m_waterheater_temp_avg] = jsn;
+
+	jsn[m_index] = idx++;	jsn[m_units] = "degF";	meta[m_wh_lower_setpoint_min] = jsn;
+	jsn[m_index] = idx++;	jsn[m_units] = "degF";	meta[m_wh_lower_setpoint_max] = jsn;
+	jsn[m_index] = idx++;	jsn[m_units] = "degF";	meta[m_wh_lower_setpoint_avg] = jsn;
+	jsn[m_index] = idx++;	jsn[m_units] = "degF";	meta[m_wh_upper_setpoint_min] = jsn;
+	jsn[m_index] = idx++;	jsn[m_units] = "degF";	meta[m_wh_upper_setpoint_max] = jsn;
+	jsn[m_index] = idx++;	jsn[m_units] = "degF";	meta[m_wh_upper_setpoint_avg] = jsn;
+	jsn[m_index] = idx++;	jsn[m_units] = "degF";	meta[m_wh_lower_temp_min] = jsn;
+	jsn[m_index] = idx++;	jsn[m_units] = "degF";	meta[m_wh_lower_temp_max] = jsn;
+	jsn[m_index] = idx++;	jsn[m_units] = "degF";	meta[m_wh_lower_temp_avg] = jsn;
+	jsn[m_index] = idx++;	jsn[m_units] = "degF";	meta[m_wh_upper_temp_min] = jsn;
+	jsn[m_index] = idx++;	jsn[m_units] = "degF";	meta[m_wh_upper_temp_max] = jsn;
+	jsn[m_index] = idx++;	jsn[m_units] = "degF";	meta[m_wh_upper_temp_avg] = jsn;
+	jsn[m_index] = idx++;	jsn[m_units] = "";		meta[m_wh_lower_elem_state] = jsn;
+	jsn[m_index] = idx++;	jsn[m_units] = "";		meta[m_wh_upper_elem_state] = jsn;
+
 	ary_houses.resize(idx);
 	writeMetadata(meta, metadata, time_str, filename_house);
 
@@ -372,13 +386,8 @@ int metrics_collector_writer::init(OBJECT *parent) {
 void metrics_collector_writer::writeMetadata(Json::Value &meta,
 		Json::Value &metadata, char *time_str, char256 filename) {
 	if (strcmp(extension, m_json.c_str()) == 0) {
-#ifdef USE_DEPRECATED_FASTWRITER
-    Json::FastWriter writer;
-    writer.omitEndingLineFeed();
-#else
-    Json::StreamWriterBuilder builder; // FastWriter is deprecated
-    builder["indentation"] = "";
-#endif
+		Json::StreamWriterBuilder builder;
+		builder["indentation"] = "";
 		ofstream out_file;
 
 		metadata[m_starttime] = time_str;
@@ -387,11 +396,7 @@ void metrics_collector_writer::writeMetadata(Json::Value &meta,
 		if (strcmp(alternate, "yes") == 0)
 			FileName.append("." + m_json);
 		out_file.open (FileName);
-#ifdef USE_DEPRECATED_FASTWRITER
-		out_file << writer.write(metadata);
-#else
-    out_file << Json::writeString(builder, metadata);
-#endif
+		out_file << Json::writeString(builder, metadata);
 		out_file.close();
 #ifdef HAVE_HDF5
 		if (both) {
@@ -561,6 +566,22 @@ int metrics_collector_writer::write_line(TIMESTAMP t1) {
 			ary_houses[idx++] = metrics[WH_MIN_TEMP];
 			ary_houses[idx++] = metrics[WH_MAX_TEMP];
 			ary_houses[idx++] = metrics[WH_AVG_TEMP];
+
+			ary_houses[idx++] = metrics[WH_MIN_L_SETPOINT];
+			ary_houses[idx++] = metrics[WH_MAX_L_SETPOINT];
+			ary_houses[idx++] = metrics[WH_AVG_L_SETPOINT];
+			ary_houses[idx++] = metrics[WH_MIN_U_SETPOINT];
+			ary_houses[idx++] = metrics[WH_MAX_U_SETPOINT];
+			ary_houses[idx++] = metrics[WH_AVG_U_SETPOINT];
+			ary_houses[idx++] = metrics[WH_MIN_L_TEMP];
+			ary_houses[idx++] = metrics[WH_MAX_L_TEMP];
+			ary_houses[idx++] = metrics[WH_AVG_L_TEMP];
+			ary_houses[idx++] = metrics[WH_MIN_U_TEMP];
+			ary_houses[idx++] = metrics[WH_MAX_U_TEMP];
+			ary_houses[idx++] = metrics[WH_AVG_U_TEMP];
+			ary_houses[idx++] = metrics[WH_ELEM_L_MODE];
+			ary_houses[idx++] = metrics[WH_ELEM_U_MODE];
+
 			house_objects[key] = ary_houses;
 
 		} // End of recording metrics_collector data attached to one waterheater
@@ -710,13 +731,8 @@ int metrics_collector_writer::write_line(TIMESTAMP t1) {
 
 // Write seperate JSON files for each object
 void metrics_collector_writer::writeJsonFile (char256 filename, Json::Value& metrics) {
-#ifdef USE_DEPRECATED_FASTWRITER
-	Json::FastWriter writer;
-	writer.omitEndingLineFeed();
-#else
-	Json::StreamWriterBuilder builder; // FastWriter is deprecated
+	Json::StreamWriterBuilder builder;
 	builder["indentation"] = "";
-#endif
 	long pos = 0;
 	long offset = 1;
 	ofstream out_file;
@@ -725,25 +741,14 @@ void metrics_collector_writer::writeJsonFile (char256 filename, Json::Value& met
 	if (strcmp(alternate, "yes") == 0)
 		FileName.append("." + m_json);
 	out_file.open (FileName, ofstream::in | ofstream::ate);
-//	std::cout << "** opened " << FileName << std::endl;
 	pos = out_file.tellp();
-//	std::cout << "   tellp " << pos << " offset " << offset << std::endl;
-#ifdef USE_DEPRECATED_FASTWRITER
-	out_file << writer.write(metrics);
-#else
 	out_file << Json::writeString(builder, metrics);
-#endif
-//	std::cout << "   write metrics" << std::endl;
 	out_file.seekp(pos-offset);
-//	std::cout << "   seekp " << (pos-offset) << std::endl;
 	out_file << ", ";
 	out_file.close();
-//	std::cout << "   closed " << FileName << std::endl;
 	if (!both) {
 		metrics.clear();
-//		std::cout << "   cleared metrics" << std::endl;
 	}
-//	std::cout << "   returning" << std::endl;
 }
 
 #ifdef HAVE_HDF5
@@ -822,6 +827,21 @@ void metrics_collector_writer::hdfHouse () {
 	mtype_houses->insertMember(m_waterheater_temp_min, HOFFSET(House, waterheater_temp_min), H5::PredType::NATIVE_DOUBLE);
 	mtype_houses->insertMember(m_waterheater_temp_max, HOFFSET(House, waterheater_temp_max), H5::PredType::NATIVE_DOUBLE);
 	mtype_houses->insertMember(m_waterheater_temp_avg, HOFFSET(House, waterheater_temp_avg), H5::PredType::NATIVE_DOUBLE);
+
+	mtype_houses->insertMember(m_wh_lower_setpoint_min, HOFFSET(House, wh_lower_setpoint_min), H5::PredType::NATIVE_DOUBLE);
+	mtype_houses->insertMember(m_wh_lower_setpoint_max, HOFFSET(House, wh_lower_setpoint_max), H5::PredType::NATIVE_DOUBLE);
+	mtype_houses->insertMember(m_wh_lower_setpoint_avg, HOFFSET(House, wh_lower_setpoint_avg), H5::PredType::NATIVE_DOUBLE);
+	mtype_houses->insertMember(m_wh_upper_setpoint_min, HOFFSET(House, wh_upper_setpoint_min), H5::PredType::NATIVE_DOUBLE);
+	mtype_houses->insertMember(m_wh_upper_setpoint_max, HOFFSET(House, wh_upper_setpoint_max), H5::PredType::NATIVE_DOUBLE);
+	mtype_houses->insertMember(m_wh_upper_setpoint_avg, HOFFSET(House, wh_upper_setpoint_avg), H5::PredType::NATIVE_DOUBLE);
+	mtype_houses->insertMember(m_wh_lower_temp_min, HOFFSET(House, wh_lower_temp_min), H5::PredType::NATIVE_DOUBLE);
+	mtype_houses->insertMember(m_wh_lower_temp_max, HOFFSET(House, wh_lower_temp_max), H5::PredType::NATIVE_DOUBLE);
+	mtype_houses->insertMember(m_wh_lower_temp_avg, HOFFSET(House, wh_lower_temp_avg), H5::PredType::NATIVE_DOUBLE);
+	mtype_houses->insertMember(m_wh_upper_temp_min, HOFFSET(House, wh_upper_temp_min), H5::PredType::NATIVE_DOUBLE);
+	mtype_houses->insertMember(m_wh_upper_temp_max, HOFFSET(House, wh_upper_temp_max), H5::PredType::NATIVE_DOUBLE);
+	mtype_houses->insertMember(m_wh_upper_temp_avg, HOFFSET(House, wh_upper_temp_avg), H5::PredType::NATIVE_DOUBLE);
+	mtype_houses->insertMember(m_wh_lower_elem_state, HOFFSET(House, wh_lower_elem_state), H5::PredType::NATIVE_INT);
+	mtype_houses->insertMember(m_wh_upper_elem_state, HOFFSET(House, wh_upper_elem_state), H5::PredType::NATIVE_INT);
 }
 
 void metrics_collector_writer::hdfInverter () {
@@ -1255,6 +1275,26 @@ void metrics_collector_writer::hdfHouseWrite (size_t objs, Json::Value& metrics)
 			tbl[idx].waterheater_temp_min = mtr[HSE_SYSTEM_MODE + 10].asDouble();
 			tbl[idx].waterheater_temp_max = mtr[HSE_SYSTEM_MODE + 11].asDouble();
 			tbl[idx].waterheater_temp_avg = mtr[HSE_SYSTEM_MODE + 12].asDouble();
+
+
+			tbl[idx].wh_lower_setpoint_min = mtr[HSE_SYSTEM_MODE + 13].asDouble();
+			tbl[idx].wh_lower_setpoint_max = mtr[HSE_SYSTEM_MODE + 14].asDouble();
+			tbl[idx].wh_lower_setpoint_avg = mtr[HSE_SYSTEM_MODE + 15].asDouble();
+			tbl[idx].wh_upper_setpoint_min = mtr[HSE_SYSTEM_MODE + 16].asDouble();
+			tbl[idx].wh_upper_setpoint_max = mtr[HSE_SYSTEM_MODE + 17].asDouble();
+			tbl[idx].wh_upper_setpoint_avg = mtr[HSE_SYSTEM_MODE + 18].asDouble();
+			tbl[idx].wh_lower_temp_min = mtr[HSE_SYSTEM_MODE + 19].asDouble();
+			tbl[idx].wh_lower_temp_max = mtr[HSE_SYSTEM_MODE + 20].asDouble();
+			tbl[idx].wh_lower_temp_avg = mtr[HSE_SYSTEM_MODE + 21].asDouble();
+			tbl[idx].wh_upper_temp_min = mtr[HSE_SYSTEM_MODE + 22].asDouble();
+			tbl[idx].wh_upper_temp_max = mtr[HSE_SYSTEM_MODE + 23].asDouble();
+			tbl[idx].wh_upper_temp_avg = mtr[HSE_SYSTEM_MODE + 24].asDouble();
+			tbl[idx].wh_lower_elem_state = mtr[HSE_SYSTEM_MODE + 25].asInt();
+			tbl[idx].wh_upper_elem_state = mtr[HSE_SYSTEM_MODE + 26].asInt();
+
+
+
+
 			idx++;
 		}
 	}

--- a/tape/metrics_collector_writer.cpp
+++ b/tape/metrics_collector_writer.cpp
@@ -676,9 +676,11 @@ int metrics_collector_writer::write_line(TIMESTAMP t1) {
 	metrics_writer_evchargerdets[time_str] = evchargerdet_objects;
 
 	if (writeTime == (interim_length * interim_cnt) || final_write - startTime <= writeTime) {
-		cout << "meterics collected -> " << index << endl;
-		cout << "interim write time -> " << writeTime << endl;
+        gl_debug("metrics collected -> %d\n", index);
+        gl_debug("interim write time -> %d\n", writeTime);
 		/*
+		 cout << "meterics collected -> " << index << endl;
+		 cout << "interim write time -> " << writeTime << endl;
 		 cout << "final_write -> " << final_write-startTime << endl;
 		 cout << "interim_length -> " << interim_length << endl;
 		 cout << "interim_cnt -> " << interim_cnt << endl;

--- a/tape/metrics_collector_writer.h
+++ b/tape/metrics_collector_writer.h
@@ -121,6 +121,21 @@ const string m_waterheater_temp_min ("waterheater_temp_min");
 const string m_waterheater_temp_max ("waterheater_temp_max");
 const string m_waterheater_temp_avg ("waterheater_temp_avg");
 
+const string m_wh_lower_setpoint_min ("wh_lower_setpoint_min");
+const string m_wh_lower_setpoint_max ("wh_lower_setpoint_max");
+const string m_wh_lower_setpoint_avg ("wh_lower_setpoint_avg");
+const string m_wh_upper_setpoint_min ("wh_upper_setpoint_min");
+const string m_wh_upper_setpoint_max ("wh_upper_setpoint_max");
+const string m_wh_upper_setpoint_avg ("wh_upper_setpoint_avg");
+const string m_wh_lower_temp_min ("wh_lower_temp_min");
+const string m_wh_lower_temp_max ("wh_lower_temp_max");
+const string m_wh_lower_temp_avg ("wh_lower_temp_avg");
+const string m_wh_upper_temp_min ("wh_upper_temp_min");
+const string m_wh_upper_temp_max ("wh_upper_temp_max");
+const string m_wh_upper_temp_avg ("wh_upper_temp_avg");
+const string m_wh_lower_elem_state ("wh_lower_elem_state");
+const string m_wh_upper_elem_state ("wh_upper_elem_state");
+
 const string m_operation_count ("operation_count");
 
 const string m_trans_overload_perc ("trans_overload_perc");
@@ -203,6 +218,21 @@ typedef struct _House {
 	double waterheater_temp_min;
 	double waterheater_temp_max;
 	double waterheater_temp_avg;
+
+	double wh_lower_setpoint_min;
+	double wh_lower_setpoint_max;
+	double wh_lower_setpoint_avg;
+	double wh_upper_setpoint_min;
+	double wh_upper_setpoint_max;
+	double wh_upper_setpoint_avg;
+	double wh_lower_temp_min;
+	double wh_lower_temp_max;
+	double wh_lower_temp_avg;
+	double wh_upper_temp_min;
+	double wh_upper_temp_max;
+	double wh_upper_temp_avg;
+	int wh_lower_elem_state;
+	int wh_upper_elem_state;
 } House;
 
 typedef struct _Inverter {


### PR DESCRIPTION
#### What's this Pull Request do?
The metrics_collector object collects appropriate data for the traditional GridLAB-D waterheater model ("[tank_setpoint] the multilayer water heater model; it uses properties such as "[upper_tank_setpoint] or "[lower_tank_temperature]

#### Where should the reviewer start?
Tape module

#### How should this be tested?
Validate  autotest using test_metrics_collector.glm

#### Any background context you want to provide?
#### What are the relevant issues?
#### Screenshots (if appropriate)
#### Questions:
- [ ] Does this add new dependencies?
- [X] Is there appropriate logging included?

Resolves #1414 