### PR TITLE
Feature/1454

### DIFF
--- a/connection/helics_msg.cpp
+++ b/connection/helics_msg.cpp
@@ -1615,7 +1615,7 @@ EXPORT void publish_helics_string(OBJECT *helicsMsgObj, string helicsPublication
 				gl_debug("helics_msg::publish_helics_string(): The publication specified to send data exists but is not valid. Data was not published.");
 			}
 		} catch(...) {
-			throw("helics_msg::publish_helics_string(): The name given to send the data on does not match an existing Publication or Endpoint. Please check your glm file and your HELICS configuration file.");
+			throw("helics_msg::publish_helics_string(): The name given to send the data on does not match an existing Publication. Please check your glm file and your HELICS configuration file.");
 		}
 	} else {
 		gl_warning("helics_msg::publish_helics_string(): Can't publish or send messages outside of execution state. data was not sent!");
@@ -1641,7 +1641,7 @@ EXPORT void send_helics_message(OBJECT *helicsMsgObj, string helicsEndpointName,
 				gl_debug("helics_msg::send_helics_message(): The endpoint specified to send data exists but is not valid. Data was not sent.");
 			}
 		} catch(...) {
-			throw("helics_msg::send_helics_message(): The name given to send the data on does not match an existing Publication or Endpoint. Please check your glm file and your HELICS configuration file.");
+			throw("helics_msg::send_helics_message(): The name given to send the data on does not match an existing Endpoint. Please check your glm file and your HELICS configuration file.");
 		}
 	} else {
 		gl_warning("helics_msg::send_helics_message(): Can't publish or send messages outside of execution state. data was not sent!");

--- a/connection/helics_msg.h
+++ b/connection/helics_msg.h
@@ -35,21 +35,7 @@ using std::vector;
 
 class helics_msg;
 
-///< Function relays
-/*typedef struct s_functionsrelay {
-	char localclass[64]; ///< local class info
-	char localcall[64]; ///< local function call address (NULL for outgoing)
-	char remoteclass[64]; ///< remote class name
-	char remotename[64]; ///< remote function name
-	helics_msg *route; ///< routing of relay
-	TRANSLATOR *xlate; ///< output translation call
-	struct s_functionsrelay *next;
-	DATAEXCHANGEDIRECTION drtn;
-	COMMUNICATIONTYPE ctype; ///<identifies which helics communication function to call. Only used for communicating with helics.
-} FUNCTIONSRELAY;*/
-//extern "C" FUNCTIONADDR add_helics_function(helics_msg *route, const char *fclass,const char *flocal, const char *rclass, const char *rname, TRANSLATOR *xlate, DATAEXCHANGEDIRECTION direction, COMMUNICATIONTYPE ctype );
-//extern "C" FUNCTIONSRELAY *find_helics_function(const char *rclass, const char *rname);
-//extern "C" size_t helics_from_hex(void *buf, size_t len, const char *hex, size_t hexlen);
+EXPORT void publish_helics_string(OBJECT *helicsMsgObj, string helicsObjName, string helicsData);
 
 class json_publication {
 public:
@@ -191,9 +177,7 @@ private:
 #endif
 	vector<string> *inFunctionTopics;
 	varmap *vmap[14];
-#if HAVE_HELICS
-	helicscpp::CombinationFederate *gld_helics_federate;
-#endif
+
 	TIMESTAMP last_approved_helics_time;
 	TIMESTAMP initial_sim_time;
 	TIMESTAMP publish_time;
@@ -226,7 +210,9 @@ public:
 	SIMULATIONMODE deltaClockUpdate(double t1, unsigned long timestep, SIMULATIONMODE sysmode);
 	enumeration message_type;
 	int32 publish_period;
-
+#if HAVE_HELICS
+	helicscpp::CombinationFederate *gld_helics_federate;
+#endif
 	// TODO add other event handlers here
 public:
 	// special variables for GridLAB-D classes

--- a/connection/helics_msg.h
+++ b/connection/helics_msg.h
@@ -35,7 +35,8 @@ using std::vector;
 
 class helics_msg;
 
-EXPORT void publish_helics_string(OBJECT *helicsMsgObj, string helicsObjName, string helicsData);
+EXPORT void publish_helics_string(OBJECT *helicsMsgObj, string helicsPublicationName, string helicsData);
+EXPORT void send_helics_message(OBJECT *helicsMsgObj, string helicsEndpointName, string helicsData);
 
 class json_publication {
 public:

--- a/tape/violation_recorder.cpp
+++ b/tape/violation_recorder.cpp
@@ -60,6 +60,8 @@ violation_recorder::violation_recorder(MODULE *mod){
 				PT_KEYWORD,"VIOLATION7",(set)VIOLATION7,
 				PT_KEYWORD,"VIOLATION8",(set)VIOLATION8,
 				PT_KEYWORD,"ALLVIOLATIONS",(set)ALLVIOLATIONS,
+			PT_char1024, "helics_sender_name", PADDR(helics_sender_name), PT_DESCRIPTION, "The name of the HELICS Publication or Endpoint to send Violation data on.",
+			PT_bool, "helics_only", PADDR(helics_only), PT_DESCRIPTION, "True by default. Flag that indicates whether to write violations to the recorder file when sending violations through HELICS as well.",
 		NULL) < 1){
 			;//GL_THROW("unable to publish properties in %s",__FILE__);
 		}
@@ -72,6 +74,8 @@ violation_recorder::violation_recorder(MODULE *mod){
 int violation_recorder::create(){
 	memcpy(this, defaults, sizeof(violation_recorder));
 	strict = false;
+	helics_msg_object = nullptr;
+	helics_only = true;
 	return 1;
 }
 
@@ -174,7 +178,27 @@ int violation_recorder::init(OBJECT *obj){
 	inverter_list_v6 = uniqueList_alloc_fxn(inverter_list_v6);
 	tplx_meter_list_v7 = uniqueList_alloc_fxn(tplx_meter_list_v7);
 	comm_meter_list_v7 = uniqueList_alloc_fxn(comm_meter_list_v7);
-
+	if(helics_sender_name[0] == 0){
+		helics_msg_object = nullptr;
+		helics_publish_function = nullptr;
+	} else {
+		FINDLIST *helics_msg_objs = gl_find_objects(FL_NEW,FT_CLASS,SAME,"helics_msg",FT_END);
+		if(helics_msg_objs != nullptr){
+			if(helics_msg_objs->hit_count > 0){
+				helics_msg_object = gl_find_next(helics_msg_objs,nullptr);
+				helics_publish_function = (FUNCTIONADDR)(gl_get_function(helics_msg_object, "publish_helics_string"));
+				if(helics_publish_function == nullptr){
+					gl_error("violation_recorder::init(): Unable to map to the helics_msg object!");
+					tape_status = TS_ERROR;
+					return 0;
+				}
+			} else {
+				gl_error("violation_recorder::init(): The violation recorder has been setup to send violations through HELICS but no helics_msg object is present in the model! please add an appropriate helics_msg object to the glm file.");
+				tape_status = TS_ERROR;
+				return 0;
+			}
+		}
+	}
 	return 1;
 }
 
@@ -1297,75 +1321,88 @@ int violation_recorder::get_violation_count(int number, int type) {
 int violation_recorder::write_to_stream (TIMESTAMP t1, bool echo, char *fmt, ...) {
 	char time_str[64];
 	DATETIME dt;
-	if(TS_OPEN != tape_status){
-		gl_error("violation_recorder::write_line(): trying to write line when the tape is not open");
-		// could be ERROR or CLOSED, should not have happened
-		return 0;
-	}
-	if(0 == rec_file){
-		gl_error("violation_recorder::write_line(): no output file open and state is 'open'");
-		/* TROUBLESHOOT
-			violation_recorder claimed to be open and attempted to write to a file when
-			a file had not successfully	opened.
-		 */
-		tape_status = TS_ERROR;
-		return 0;
-	}
-	if(0 == gl_localtime(t1, &dt)){
-		gl_error("violation_recorder::write_line(): error when converting the sync time");
-		/* TROUBLESHOOT
-			Unprintable timestamp.
-		 */
-		tape_status = TS_ERROR;
-		return 0;
-	}
-	if(0 == gl_strtime(&dt, time_str, sizeof(time_str) ) ){
-		gl_error("violation_recorder::write_line(): error when writing the sync time as a string");
-		/* TROUBLESHOOT
-			Error printing the timestamp.
-		 */
-		tape_status = TS_ERROR;
-		return 0;
-	}
-	char buffer[1024];
-	va_list ptr;
-	va_start(ptr,fmt);
-	vsprintf(buffer,fmt,ptr); /* note the lack of check on buffer overrun */
-	va_end(ptr);
-	// print line to file
-	if(0 >= fprintf(rec_file, "%s,%s\n", time_str, buffer)){
-		gl_error("violation_recorder::write_line(): error when writing to the output file");
-		/* TROUBLESHOOT
-			File I/O error.
-		 */
-		tape_status = TS_ERROR;
-		return 0;
-	}
-	++write_count;
-	// if periodic flush, check for flush
-	if(flush_interval > 0){
-		if(last_flush + flush_interval <= t1){
-			last_flush = t1;
-		}
-	} else if(flush_interval < 0){
-		if( ((write_count + 1) % (-flush_interval)) == 0 ){
-			flush_line();
-		}
-	} // if 0, no flush
-	// check if write limit
-	if(limit > 0 && write_count >= limit){
-		// write footer
-		write_footer();
-		fclose(rec_file);
-		rec_file = 0;
-		free(line_buffer);
-		line_buffer = 0;
-		line_size = 0;
-		tape_status = TS_DONE;
-	}
-	if (echo)
-		gl_output("%s", buffer);
+	bool write_to_file = true;
 
+	if(helics_sender_name[0] != '\0'){
+		std::string pubEpName(const_cast<const char *>(helics_sender_name.get_string()));
+		std::string helicsData = std::to_string(t1) + ",";
+		helicsData.append(const_cast<const char *>(fmt));
+		((void(*)(OBJECT*,std::string,std::string))(*helics_publish_function))(helics_msg_object, pubEpName, helicsData);
+		if(helics_only){
+			write_to_file = false;
+		}
+	}
+	if(write_to_file){
+		if(TS_OPEN != tape_status){
+			gl_error("violation_recorder::write_line(): trying to write line when the tape is not open");
+			// could be ERROR or CLOSED, should not have happened
+			return 0;
+		}
+		if(0 == rec_file){
+			gl_error("violation_recorder::write_line(): no output file open and state is 'open'");
+			/* TROUBLESHOOT
+				violation_recorder claimed to be open and attempted to write to a file when
+				a file had not successfully	opened.
+			*/
+			tape_status = TS_ERROR;
+			return 0;
+		}
+		if(0 == gl_localtime(t1, &dt)){
+			gl_error("violation_recorder::write_line(): error when converting the sync time");
+			/* TROUBLESHOOT
+				Unprintable timestamp.
+			*/
+			tape_status = TS_ERROR;
+			return 0;
+		}
+		if(0 == gl_strtime(&dt, time_str, sizeof(time_str) ) ){
+			gl_error("violation_recorder::write_line(): error when writing the sync time as a string");
+			/* TROUBLESHOOT
+				Error printing the timestamp.
+			*/
+			tape_status = TS_ERROR;
+			return 0;
+		}
+		char buffer[1024];
+		va_list ptr;
+		va_start(ptr,fmt);
+		vsprintf(buffer,fmt,ptr); /* note the lack of check on buffer overrun */
+		va_end(ptr);
+		// print line to file
+
+		if(0 >= fprintf(rec_file, "%s,%s\n", time_str, buffer)){
+			gl_error("violation_recorder::write_line(): error when writing to the output file");
+			/* TROUBLESHOOT
+				File I/O error.
+			*/
+			tape_status = TS_ERROR;
+			return 0;
+		}
+		++write_count;
+		// if periodic flush, check for flush
+		if(flush_interval > 0){
+			if(last_flush + flush_interval <= t1){
+				last_flush = t1;
+			}
+		} else if(flush_interval < 0){
+			if( ((write_count + 1) % (-flush_interval)) == 0 ){
+				flush_line();
+			}
+		} // if 0, no flush
+		// check if write limit
+		if(limit > 0 && write_count >= limit){
+			// write footer
+			write_footer();
+			fclose(rec_file);
+			rec_file = 0;
+			free(line_buffer);
+			line_buffer = 0;
+			line_size = 0;
+			tape_status = TS_DONE;
+		}
+		if (echo)
+			gl_output("%s", buffer);
+	}
 	return 1;
 }
 

--- a/tape/violation_recorder.h
+++ b/tape/violation_recorder.h
@@ -9,6 +9,7 @@
 #include "../powerflow/line.h"
 
 #include <new>
+#include <string>
 
 EXPORT void new_violation_recorder(MODULE *);
 
@@ -250,6 +251,8 @@ public:
 	double inverter_v_chng_per_interval_lower_bound;
 	double inverter_v_chng_interval;
 	TIMESTAMP violation_start_delay;
+	char1024 helics_sender_name;
+	bool helics_only;
 private:
 	int write_header();
 	int flush_line();
@@ -340,6 +343,8 @@ private:
 	size_t line_size;
 	bool interval_write;
 	TIMESTAMP sim_start;
+	OBJECT *helics_msg_object;
+	FUNCTIONADDR helics_publish_function;
 };
 
 #endif // C++

--- a/tape/violation_recorder.h
+++ b/tape/violation_recorder.h
@@ -7,7 +7,7 @@
 #include "../powerflow/transformer_configuration.h"
 #include "../powerflow/transformer.h"
 #include "../powerflow/line.h"
-
+#include <json/json.h>
 #include <new>
 #include <string>
 

--- a/tape/violation_recorder.h
+++ b/tape/violation_recorder.h
@@ -251,7 +251,7 @@ public:
 	double inverter_v_chng_per_interval_lower_bound;
 	double inverter_v_chng_interval;
 	TIMESTAMP violation_start_delay;
-	char1024 helics_sender_name;
+	char1024 helics_endpoint_name;
 	bool helics_only;
 private:
 	int write_header();
@@ -344,7 +344,7 @@ private:
 	bool interval_write;
 	TIMESTAMP sim_start;
 	OBJECT *helics_msg_object;
-	FUNCTIONADDR helics_publish_function;
+	FUNCTIONADDR helics_send_function;
 };
 
 #endif // C++


### PR DESCRIPTION
This PR includes the capability for the violation recorder to send it's output through the GridLAB-D HELICS Federate Publication or Endpoint.

To test:
add a HELICS Endpoint or Publication with a name of your choice to your HELICS configuration file.
add the following parameter to your violation_recorder object in your glm file:

helics_sender_name <name of the HELICS Endpoint or Publication>;

an optional parameter to set:

helics_only true/false; 

the above parameter is true by default. If true the violation_recorder will not write to it's csv output file when helics_sender_name is specifed. If you want the violation_recorder to send it's data through HELICS and write to it's output file set this parameter to false.