### PR TITLE
Revert "Update validate.cpp"

### DIFF
--- a/gldcore/validate.cpp
+++ b/gldcore/validate.cpp
@@ -702,7 +702,7 @@ static size_t process_dir(const char *path, bool runglms=false)
 		else if ( dp->d_type==DT_DIR )
 #endif
 			count+=process_dir(item);
-		else if ( runglms==true && strstr(item,"/test_")!=0 && ext!=NULL && strcmp(ext,".glm")==0 )
+		else if ( runglms==true && strstr(item,"/test_")!=0 && strcmp(ext,".glm")==0 )
 		{
 			pushdir(item);
 			count++;


### PR DESCRIPTION
Reverts gridlab-d/gridlab-d#1495. I think the original fix-validate-segfault was branched off of master and overwrote some other files other than just the fix to validate.cpp.