### PR TITLE
Use `unistd.h` instead of `sys/unistd.h` to comply with modern standards

### DIFF
--- a/gldcore/platform.h
+++ b/gldcore/platform.h
@@ -30,7 +30,7 @@
 	#else
 		#define __WORDSIZE__ __WORDSIZE
 	#endif
-	#include <sys/unistd.h>
+	#include <unistd.h>
 	#if __WORDSIZE__ == 64
 		#define X64
 		#define int64 long long /**< standard 64-bit integers on 64-bit machines */


### PR DESCRIPTION
#### What's this Pull Request do?

Adopts `unistd.h` instead of `sys/unistd.h`, as the latter is not usually available in modern POSIX-compliant systems.

#### Where should the reviewer start?

This PR affects a single file.

#### How should this be tested?

Through the regular build CI pipeline.

#### Any background context you want to provide?

See #1535.

#### What are the relevant issues?

Using `sys/unistd.h` disturbs the build process for UNIX-based platforms. Moreover `unistd.h` is already used in other files throughout the project.

#### Screenshots (if appropriate)

None.

#### Questions:
- [x] Does this add new dependencies? No. `unistd.h` is already used throughout the project.
- [x] Is there appropriate logging included? I don't think logging is necessary.
