### PR TITLE
Use `get_if` instead of `get` to support  MacOS cross-compilation

### DIFF
--- a/connection/varmap.h
+++ b/connection/varmap.h
@@ -85,11 +85,11 @@ public:
 	void set(Ti in) { last_value = in; }
 
 	// These can be removed and refactored to use the templated getter above once C++17 is adopted.
-	std::string getString() {return std::get<std::string>(last_value); }
-	gld::complex getComplex() {return std::get<gld::complex>(last_value); }
-	int64 getInt() {return std::get<int64>(last_value); }
-	bool getBool() {return std::get<bool>(last_value); }
-	double getDouble() {return std::get<double>(last_value); }
+	std::string getString() {return std::get_if<std::string>(&last_value); }
+	gld::complex getComplex() {return std::get_if<gld::complex>(&last_value); }
+	int64 getInt() {return std::get_if<int64>(&last_value); }
+	bool getBool() {return std::get_if<bool>(&last_value); }
+	double getDouble() {return std::get_if<double>(&last_value); }
 
 #endif
 };

--- a/connection/varmap.h
+++ b/connection/varmap.h
@@ -85,11 +85,31 @@ public:
 	void set(Ti in) { last_value = in; }
 
 	// These can be removed and refactored to use the templated getter above once C++17 is adopted.
-	std::string getString() {return std::get_if<std::string>(&last_value); }
-	gld::complex getComplex() {return std::get_if<gld::complex>(&last_value); }
-	int64 getInt() {return std::get_if<int64>(&last_value); }
-	bool getBool() {return std::get_if<bool>(&last_value); }
-	double getDouble() {return std::get_if<double>(&last_value); }
+	std::string getString() {
+		std::string* p = std::get_if<std::string>(&last_value);
+		
+		return *p;
+	}
+	gld::complex getComplex() {
+		gld::complex* p = std::get_if<gld::complex>(&last_value);
+		
+		return *p;
+	}
+	int64 getInt() {
+		int64* p = std::get_if<int64>(&last_value);
+		
+		return *p;
+	}
+	bool getBool() {
+		bool* p = std::get_if<bool>(&last_value);
+		
+		return *p;
+	}
+	double getDouble() {
+		double* p = std::get_if<double>(&last_value);
+		
+		return *p;
+	}
 
 #endif
 };


### PR DESCRIPTION
#### What's this Pull Request do?

This PR aims to use `std::get_if<...>` instead of `std::get<...>` to avoid build problems for `MacOS < 10.14`.
This change partially implements what is suggested at https://github.com/gridlab-d/gridlab-d/blob/e1841e1eebced819e45209f4a899763ce337b177/connection/varmap.h#L87C2-L87C81
Fully implementing this suggestion and resort to the templated method could be interesting too!

#### Where should the reviewer start?

This PR affects a single file.

#### How should this be tested?

Through the regular build CI pipeline.

#### Any background context you want to provide?

See #1535.

#### What are the relevant issues?
#### Screenshots (if appropriate)

None.

#### Questions:
- [x] Does this add new dependencies? No.
- [x] Is there appropriate logging included? There's no relevant logging to be included.
