### PR TITLE
Include `sys/wait` to provide `WEXITSTATUS` in some platforms

### DIFF
--- a/gldcore/exec.cpp
+++ b/gldcore/exec.cpp
@@ -96,6 +96,7 @@
 #include <unistd.h>
 #include <sys/types.h>
 #include <sys/socket.h>
+#include <sys/wait.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
 #include <cerrno>


### PR DESCRIPTION
#### What's this Pull Request do?

This PR aims to fix a missing reference to `WEXITSTATUS` in some platforms.

#### Where should the reviewer start?

This PR affects a single file.

#### How should this be tested?

Through the regular build CI pipeline.

#### Any background context you want to provide?

See #1535.

#### What are the relevant issues?

Compilation will fail for Linux/MUSL without the included header file.

#### Screenshots (if appropriate)

None.

#### Questions:
- [x] Does this add new dependencies? No. `sys/wait.h` is already included in other files.
- [x] Is there appropriate logging included? There's no relevant logging to be included.
