### PR TITLE
Remove redundant variables from link.h

### DIFF
--- a/climate/weather.cpp
+++ b/climate/weather.cpp
@@ -31,7 +31,7 @@ weather::weather(MODULE *module){
 			PT_double,"solar_diff[W/sf]",PADDR(solar_diff),
 			PT_double,"solar_diffuse[W/sf]",PADDR(solar_diff),
 			PT_double,"solar_global[W/sf]",PADDR(solar_global),
-      PT_double,"global_horizontal_extra[W/sf]",PADDR(global_horizontal_extra),
+			PT_double,"global_horizontal_extra[W/sf]",PADDR(global_horizontal_extra),
 			PT_double,"wind_speed[mph]", PADDR(wind_speed),
 			PT_double,"wind_dir[deg]", PADDR(wind_dir),
 			PT_double,"opq_sky_cov[pu]",PADDR(opq_sky_cov),

--- a/climate/weather.h
+++ b/climate/weather.h
@@ -25,7 +25,7 @@ public:
 	double solar_dir;
 	double solar_diff;
 	double solar_global;
-  double global_horizontal_extra;
+	double global_horizontal_extra;
 	double wind_speed;
 	double wind_dir;
 	double opq_sky_cov;

--- a/powerflow/link.h
+++ b/powerflow/link.h
@@ -119,12 +119,6 @@ public:
 	int isa(char *classname);
 public:
 	/* status values */
-	gld::set affected_phases;				/* use this to determine which phases are affected by status change */
-	#define IMPEDANCE_CHANGED		1	/* use this status to indicate an impedance change (e.g., line contact) */
-	double resistance;					/* use this resistance when status=IMPEDANCE_CHANGED */
-	#define LINE_CONTACT			2	/* use this to indicate line contact */
-	gld::set line_contacted;					/* use this to indicate which line was contacted (N means ground) */
-	#define CONTROL_FAILED			4	/* use this status to indicate a controller failure (e.g., PLC failure) */
 
 	class node *get_from(void) const;
 	class node *get_to(void) const;


### PR DESCRIPTION
Cleaning up redundant variables from link.h
