### PR TITLE
changing raw parameter of schedule struct to string due to namespace

### DIFF
--- a/gldcore/loader.cpp
+++ b/gldcore/loader.cpp
@@ -1038,7 +1038,6 @@ STATUS loader::loadSchedules()
 	std::string cron_schedule;
 	std::string	sub_schedule;
 	SCHEDULE* sch;
-	json raw = json::array();
 	for (auto& [name, schedule] : j_obj.items())
     {
         if(rv == FAILED)
@@ -1047,6 +1046,7 @@ STATUS loader::loadSchedules()
         }
 		if (schedule.is_array())
         {
+
 			cron_schedule = "";
 			for (auto& element : schedule)
             {
@@ -1062,7 +1062,6 @@ STATUS loader::loadSchedules()
 						for (auto& item : element["items"])
                         {
 							cron_schedule += item.get_ref<const std::string&>() + ";\n";
-							raw.push_back(item.get_ref<const std::string&>());
                         }
 					}
                     else
@@ -1084,7 +1083,7 @@ STATUS loader::loadSchedules()
 			if (cron_schedule != "")
             {
 				sch = schedule_create(name.data(), cron_schedule.data());
-				sch->raw = raw;
+				sch->raw = schedule.dump();
             }
             else
             {

--- a/gldcore/schedule.h
+++ b/gldcore/schedule.h
@@ -35,9 +35,10 @@
 #include "class.h"
 #include "timestamp.h"
 #include <iostream>
-#include <nlohmann/json.hpp>
+#include <string>
+// #include <nlohmann/json.hpp>
 
-using json = nlohmann::json;
+//using json = nlohmann::json;
 
 #define MAXNAME 64
 #define MAXDEFINITION 65536
@@ -79,7 +80,7 @@ struct s_schedule {
 	double abs[MAXBLOCKS];				/**< the sum of the absolute values for each block -- used to normalize */
 	unsigned int count[MAXBLOCKS];		/**< the number of values given in each block */
 	unsigned int minutes[MAXBLOCKS];	/**< the total number of minutes associate with each block */
-	json raw = json::array();
+	std::string raw;
 #ifdef _DEBUG
 	unsigned int magic2;
 	unsigned int checksum;


### PR DESCRIPTION
fixing namespace clash with including nlohmann::json.hpp in schedule.h. Going to have to store the raw json array as a string for checkpointing.
