### PR TITLE
object_declaration and checkpointing fix

### DIFF
--- a/gldcore/loader.cpp
+++ b/gldcore/loader.cpp
@@ -660,6 +660,7 @@ STATUS loader::loadObject(const string className, ojson objInstance)
     nameObj.name = clsName;
     int64 id = -1;
     int64 id2 = -1;
+    bool idSpecified = false;
     if (objInstance.contains("object_declaration"))
     {
         string objectDeclaration = objInstance["object_declaration"].get<string>();
@@ -700,6 +701,7 @@ STATUS loader::loadObject(const string className, ojson objInstance)
         }
         else
         {
+            idSpecified = true;
             id = stoll(classNameStripped);
         }
     }
@@ -763,6 +765,29 @@ STATUS loader::loadObject(const string className, ojson objInstance)
                 break;
             }
         }
+        if (obj->name == nullptr)
+        {
+            if (idSpecified)
+            {
+                string objName = className + ":" + to_string(id);
+                if (object_set_name(obj, objName.data()) == nullptr)
+                {
+                    output_error_raw("loader::loadObject() parsing file, %s: property name %s could not be used",
+                                     this->filename.string().c_str(), objName.c_str());
+                    rv = FAILED;
+                }
+            }
+            else
+            {
+                string objName = className + ":" + to_string(obj->id);
+                if (object_set_name(obj, objName.data()) == nullptr)
+                {
+                    output_error_raw("loader::loadObject() parsing file, %s: property name %s could not be used",
+                                     this->filename.string().c_str(), objName.c_str());
+                    rv = FAILED;
+                }
+            }
+        }
         if (rv == FAILED)
         {
             break;
@@ -778,7 +803,7 @@ STATUS loader::loadObject(const string className, ojson objInstance)
     }
 
     // Override rng_state with name (if present) and randomseed (if present) based hash
-    if (global_randomseed > 0 && obj->flags & OF_RANDOMSEEDSET != OF_RANDOMSEEDSET)
+    if (rv != FAILED && global_randomseed > 0 && obj->flags & OF_RANDOMSEEDSET != OF_RANDOMSEEDSET)
     {
         if (obj->name == nullptr)
         {


### PR DESCRIPTION
Currently information contained in "object_declaration" gets lost by the time creating a checkpoint file occurs. This proposed fix places the effect of object_declaration in the object's name if the name is null. object_declaration can be used to specify an object by "classname:id", or can be used to create a range of objects from 0-range by "classname:..range" or a specific range a-b "classname:a..b".

in the case of identifying a single object through "classname:id", if the object's name is also null the code sets the object's name to "classname:id". if it's either of the latter range specifications of objects, then have their name set to "classname:{obj->id}". This guarantees name uniqueness for resulting checkpointed files as well as not needing to try and recreate the "object_declaration" key:value pair.