### PR TITLE
Expose GLM-to-JSON converter in Python package

### DIFF
--- a/python_bindings/CMakeLists.txt
+++ b/python_bindings/CMakeLists.txt
@@ -130,6 +130,30 @@ endif()
 install(FILES ${GRIDLABD_DATA_FILES}
         DESTINATION gridlabd/share)
 
+# Install the existing Python GLM-to-JSON converter with the Python package so
+# gridlabd.glm_to_json() works from built wheels as well as source checkouts.
+if(PYPI_MODE AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/prebuilt/json_schema/glm_to_json.py")
+    set(GLM_JSON_SCHEMA_DIR "${CMAKE_CURRENT_SOURCE_DIR}/prebuilt/json_schema")
+else()
+    set(GLM_JSON_SCHEMA_DIR "${GRIDLABD_ROOT}/utilities/json_schema")
+endif()
+if(EXISTS "${GLM_JSON_SCHEMA_DIR}/glm_to_json.py")
+    install(FILES
+            ${GLM_JSON_SCHEMA_DIR}/__init__.py
+            ${GLM_JSON_SCHEMA_DIR}/glm_to_json.py
+            ${GLM_JSON_SCHEMA_DIR}/glm_parser.py
+            ${GLM_JSON_SCHEMA_DIR}/glm_entities.py
+            ${GLM_JSON_SCHEMA_DIR}/glm_utils.py
+            DESTINATION gridlabd/json_schema)
+
+    install(FILES
+            ${GLM_JSON_SCHEMA_DIR}/references/glm_classes.json
+            ${GLM_JSON_SCHEMA_DIR}/references/glm_schema.json
+            DESTINATION gridlabd/json_schema/references)
+else()
+    message(WARNING "GLM-to-JSON converter not found at ${GLM_JSON_SCHEMA_DIR}; gridlabd.glm_to_json() will require a source checkout")
+endif()
+
 # Install dummy bin/gridlabd so set_install_root() can work automatically
 # The C++ code expects bin/gridlabd to exist for proper path resolution
 if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/prebuilt/bin/gridlabd")

--- a/python_bindings/README.md
+++ b/python_bindings/README.md
@@ -70,6 +70,22 @@ assert result == 0, "Simulation failed"
 print("Simulation completed successfully!")
 ```
 
+### Converting GLM to JSON
+
+```python
+import gridlabd
+
+# Write model.json next to model.glm
+json_path = gridlabd.glm_to_json("model.glm")
+
+# Or choose an explicit output file
+json_path = gridlabd.convert_glm_to_json("model.glm", "output/model.json")
+
+# The same converter is available from GridLabD instances
+gld = gridlabd.GridLabD()
+json_path = gld.convert_glm_to_json("model.glm")
+```
+
 ### Querying Objects and Properties
 
 ```python
@@ -199,4 +215,3 @@ gld.clear_messages()
 gld.set_message_capture_limit(5000)
 limit = gld.get_message_capture_limit()
 ```
-   

--- a/python_bindings/prepare_pypi_build.sh
+++ b/python_bindings/prepare_pypi_build.sh
@@ -34,6 +34,7 @@ echo "Creating prebuilt directory structure..."
 rm -rf prebuilt
 mkdir -p prebuilt/lib
 mkdir -p prebuilt/share
+mkdir -p prebuilt/json_schema/references
 
 # Copy GridLAB-D API library
 echo "Copying GridLAB-D libraries..."
@@ -51,6 +52,16 @@ find ../build/lib -name "*.so" -not -name "libgldapi.so" -exec cp {} prebuilt/li
 echo "Copying data files..."
 cp ../gldcore/tzinfo.txt prebuilt/share/
 cp ../gldcore/unitfile.txt prebuilt/share/
+
+# Copy the Python GLM-to-JSON converter used by gridlabd.glm_to_json()
+echo "Copying GLM-to-JSON converter..."
+cp ../utilities/json_schema/__init__.py prebuilt/json_schema/
+cp ../utilities/json_schema/glm_to_json.py prebuilt/json_schema/
+cp ../utilities/json_schema/glm_parser.py prebuilt/json_schema/
+cp ../utilities/json_schema/glm_entities.py prebuilt/json_schema/
+cp ../utilities/json_schema/glm_utils.py prebuilt/json_schema/
+cp ../utilities/json_schema/references/glm_classes.json prebuilt/json_schema/references/
+cp ../utilities/json_schema/references/glm_schema.json prebuilt/json_schema/references/
 
 # Copy header files needed for compilation
 echo "Copying header files..."

--- a/python_bindings/src/gridlabd/__init__.py
+++ b/python_bindings/src/gridlabd/__init__.py
@@ -91,6 +91,7 @@ if install_root:
 
 # Import isolated GridLabD wrapper (process isolation for multiple instances)
 from ._isolated import IsolatedGridLabD
+from ._glm_json import convert_glm_to_json, glm_to_json
 
 # Save the original C++ class before we wrap it
 _CppGridLabD = GridLabD
@@ -124,6 +125,10 @@ class GridLabDSingleton:
     def load(self, filename: str):
         """Load a GLM file (convenience method that wraps load_glm)."""
         return self._cpp_instance.load_glm([filename])
+
+    def convert_glm_to_json(self, glm_path, output_path=None):
+        """Convert a GLM file to JSON using the Python converter."""
+        return glm_to_json(glm_path, output_path)
     
     # Expose static methods from the C++ class
     @staticmethod
@@ -149,6 +154,10 @@ class GridLabDWrapper(_CppGridLabD):
         """Load a GLM file (convenience method that wraps load_glm)."""
         return self.load_glm([filename])
 
+    def convert_glm_to_json(self, glm_path, output_path=None):
+        """Convert a GLM file to JSON using the Python converter."""
+        return glm_to_json(glm_path, output_path)
+
 # By default, use the isolated wrapper to provide proper process isolation
 # This allows multiple GridLabD instances to coexist without conflicts
 GridLabD = IsolatedGridLabD
@@ -168,6 +177,8 @@ __all__ = [
     "__version__",
     "version",
     "info",
+    "glm_to_json",
+    "convert_glm_to_json",
     
 ]
 
@@ -182,4 +193,3 @@ def info():
     print(hello())
     print("GridLAB-D API integration: ✓ Available")
     print("GridLabD Mode: Isolated (multiple instances supported)")
-

--- a/python_bindings/src/gridlabd/_glm_json.py
+++ b/python_bindings/src/gridlabd/_glm_json.py
@@ -1,0 +1,94 @@
+"""Python package API for converting GLM files to JSON."""
+
+from __future__ import annotations
+
+from contextlib import redirect_stdout
+import importlib.util
+import io
+from pathlib import Path
+from types import ModuleType
+
+
+def _candidate_converter_dirs() -> list[Path]:
+    package_dir = Path(__file__).resolve().parent
+    repo_root = package_dir.parents[2]
+
+    return [
+        package_dir / "json_schema",
+        repo_root / "utilities" / "json_schema",
+    ]
+
+
+def _load_converter_module() -> ModuleType:
+    for converter_dir in _candidate_converter_dirs():
+        converter = converter_dir / "glm_to_json.py"
+        if converter.exists():
+            spec = importlib.util.spec_from_file_location("gridlabd_glm_to_json", converter)
+            if spec is None or spec.loader is None:
+                continue
+            module = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(module)
+            return module
+
+    searched = ", ".join(str(path) for path in _candidate_converter_dirs())
+    raise ImportError("Unable to locate GridLAB-D GLM-to-JSON converter. Searched: {0}".format(searched))
+
+
+def glm_to_json(glm_path, output_path=None):
+    """Convert a GridLAB-D ``.glm`` file to JSON.
+
+    Args:
+        glm_path: Path to the input ``.glm`` file.
+        output_path: Optional output JSON file path or output directory. When
+            omitted, the JSON file is written next to the input file.
+
+    Returns:
+        pathlib.Path: Path to the generated JSON file.
+
+    Raises:
+        FileNotFoundError: If ``glm_path`` does not exist.
+        RuntimeError: If the existing converter reports failure.
+    """
+
+    glm_path = Path(glm_path)
+    if not glm_path.exists():
+        raise FileNotFoundError(str(glm_path))
+    if glm_path.suffix.lower() != ".glm":
+        raise ValueError("expected a .glm file: {0}".format(glm_path))
+
+    output_dir = None
+    output_name = None
+    expected_output = glm_path.with_suffix(".json")
+
+    if output_path is not None:
+        output_path = Path(output_path)
+        if output_path.suffix.lower() == ".json":
+            output_dir = str(output_path.parent)
+            output_name = output_path.stem
+            expected_output = output_path
+        else:
+            output_dir = str(output_path)
+            output_name = glm_path.stem
+            expected_output = output_path / "{0}.json".format(glm_path.stem)
+
+    converter = _load_converter_module()
+    converter_output = io.StringIO()
+    with redirect_stdout(converter_output):
+        success = converter.glm_to_json(
+            glm_path.stem,
+            input_dir=str(glm_path.parent),
+            output_dir=output_dir,
+            output_name=output_name,
+        )
+
+    if not success:
+        details = converter_output.getvalue().strip()
+        message = "failed to convert GLM file to JSON: {0}".format(glm_path)
+        if details:
+            message = "{0}\n{1}".format(message, details)
+        raise RuntimeError(message)
+
+    return expected_output
+
+
+convert_glm_to_json = glm_to_json

--- a/python_bindings/src/gridlabd/_isolated.py
+++ b/python_bindings/src/gridlabd/_isolated.py
@@ -15,6 +15,7 @@ from datetime import datetime
 from subprocess import PIPE
 from typing import Any, Optional
 
+from ._glm_json import glm_to_json
 from ._protocol import Command, Message, Response
 from ._time_utils import gld_to_iso
 
@@ -204,6 +205,10 @@ class IsolatedGridLabD:
         """Get the GridLAB-D executable path."""
         from .gridlabd_core import GridLabD as CppGridLabD
         return CppGridLabD.get_executable_path()
+
+    def convert_glm_to_json(self, glm_path, output_path=None):
+        """Convert a GLM file to JSON using the Python converter."""
+        return glm_to_json(glm_path, output_path)
     
     # Configuration methods
     def set_config_file(self, config_file: str) -> int:

--- a/python_bindings/tests/test_glm_to_json_api.py
+++ b/python_bindings/tests/test_glm_to_json_api.py
@@ -1,0 +1,139 @@
+import json
+from pathlib import Path
+
+import gridlabd
+
+
+def test_glm_to_json_package_api(tmp_path, capsys):
+    glm_file = tmp_path / "minimal.glm"
+    glm_file.write_text(
+        """
+        module powerflow;
+        object node {
+            name source;
+            phases ABCN;
+            nominal_voltage 7200;
+        }
+        """,
+        encoding="utf-8",
+    )
+
+    output_file = gridlabd.glm_to_json(glm_file, tmp_path / "converted.json")
+
+    assert output_file == tmp_path / "converted.json"
+    assert output_file.exists()
+
+    data = json.loads(output_file.read_text(encoding="utf-8"))
+    assert "objects" in data
+    assert "node" in data["objects"]
+    assert capsys.readouterr().out == ""
+
+
+def test_gridlabd_instance_glm_to_json_package_api(tmp_path):
+    glm_file = tmp_path / "minimal.glm"
+    glm_file.write_text(
+        """
+        module powerflow;
+        object node {
+            name source;
+        }
+        """,
+        encoding="utf-8",
+    )
+
+    gld = gridlabd.DirectGridLabD()
+    output_file = gld.convert_glm_to_json(glm_file)
+
+    assert output_file == glm_file.with_suffix(".json")
+    assert output_file.exists()
+
+
+def test_nested_object_with_explicit_name_keeps_name(tmp_path):
+    glm_file = tmp_path / "nested_named.glm"
+    glm_file.write_text(
+        """
+        object house {
+            name H_1;
+            object controller {
+                name DC_1;
+            };
+        }
+        """,
+        encoding="utf-8",
+    )
+
+    output_file = gridlabd.glm_to_json(glm_file)
+    data = json.loads(output_file.read_text(encoding="utf-8"))
+
+    controller = data["objects"]["controller"]["instances"][0]
+    assert controller["name"] == "DC_1"
+    assert controller["parent"] == "H_1"
+
+
+def test_nested_object_under_object_declaration_uses_resolvable_parent_names(tmp_path):
+    glm_file = tmp_path / "nested_oid.glm"
+    glm_file.write_text(
+        """
+        object house:23 {
+            floor_area 2500.0;
+            object double_assert {
+                target floor_area;
+                within 0.01;
+                object player {
+                    property value;
+                    file floorArea.player;
+                };
+            };
+        }
+        """,
+        encoding="utf-8",
+    )
+
+    output_file = gridlabd.glm_to_json(glm_file)
+    data = json.loads(output_file.read_text(encoding="utf-8"))
+
+    double_assert = data["objects"]["double_assert"]["instances"][0]
+    player = data["objects"]["player"]["instances"][0]
+
+    assert double_assert["name"].startswith("house:23double_assert_")
+    assert double_assert["parent"] == "house:23"
+    assert player["parent"] == double_assert["name"]
+
+
+def test_nested_object_generated_names_are_unique_across_anonymous_parents(tmp_path):
+    glm_file = tmp_path / "nested_oids.glm"
+    glm_file.write_text(
+        """
+        object house:23 {
+            object double_assert {
+                target floor_area;
+                object player {
+                    property value;
+                };
+            };
+        }
+        object house:24 {
+            object double_assert {
+                target floor_area;
+                object player {
+                    property value;
+                };
+            };
+        }
+        """,
+        encoding="utf-8",
+    )
+
+    output_file = gridlabd.glm_to_json(glm_file)
+    data = json.loads(output_file.read_text(encoding="utf-8"))
+
+    double_asserts = data["objects"]["double_assert"]["instances"]
+    names = {entry["name"] for entry in double_asserts}
+    parents = {entry["parent"] for entry in double_asserts}
+    player_parents = {entry["parent"] for entry in data["objects"]["player"]["instances"]}
+
+    assert len(names) == 2
+    assert any(name.startswith("house:23double_assert_") for name in names)
+    assert any(name.startswith("house:24double_assert_") for name in names)
+    assert parents == {"house:23", "house:24"}
+    assert player_parents == names

--- a/utilities/json_schema/README.md
+++ b/utilities/json_schema/README.md
@@ -30,16 +30,14 @@ json_schema/
 ## Requirements
 
 - Python 3.6+
-- Required packages:
-  - `pyjson5`
-  - `importlib_resources`
+- Required packages: none beyond Python's standard library
 - Optional (for schema validation):
   - `jsonschema`
 
 ## Installation
 
 ```bash
-pip install pyjson5 importlib_resources jsonschema
+pip install jsonschema
 ```
 
 Requires Python 3.6+.

--- a/utilities/json_schema/glm_parser.py
+++ b/utilities/json_schema/glm_parser.py
@@ -13,8 +13,8 @@ raise GLMConditionalError and must be resolved before conversion.
 
 import os
 import re
-import pyjson5
-from importlib_resources import files
+import json
+from pathlib import Path
 
 # Import the modular components with fallback
 try:
@@ -26,7 +26,7 @@ except (ImportError, ValueError):
     from glm_entities import Item, Entity, O_Entity, GLM
     from glm_utils import gld_strict_name, add_attr_to_entity, convert_suffix_id
 
-glm_entities_path = files('references').joinpath('glm_classes.json')
+glm_entities_path = Path(__file__).resolve().parent / 'references' / 'glm_classes.json'
 
 def create_conditional_error_message(directive, line, context=""):
     """Create a standardized error message for conditional directives.
@@ -111,7 +111,7 @@ class GLMModel:
         self.outside_starts = []
         
         with open(glm_entities_path, 'r', encoding='utf-8') as json_file:
-            self.classes = pyjson5.load(json_file)
+            self.classes = json.load(json_file)
             entity = Entity("clock", None)
             entity.add_attr("TEXT", "Time zone", "", "timezone", value=None)
             entity.add_attr("TEXT", "Start time", "", "timestamp", value=None)
@@ -1002,17 +1002,22 @@ class GLMModel:
             if oid:
                 params['object_declaration'] = oid
             counter += 1
-            # Generate internal tracking name (without parent prefix)
-            name = _type + "_" + str(counter)
+            # Generate an internal tracking name. Nested unnamed objects include
+            # the parent reference so generated parent links remain unique and
+            # resolvable when multiple anonymous object declarations exist.
+            name = (parent if parent else '') + _type + "_" + str(counter)
             params['_auto_generated_name'] = True
+            if parent:
+                params['parent'] = parent
             self.add_object(_type, name, params)
             return line, counter, name
 
         # Collect parameters
         counter += 1
         name_prefix = parent if parent else ''
-        # Generate internal tracking name initially (without parent prefix)
-        name = _type + "_" + str(counter)
+        # Generate internal tracking name initially. An explicit name property
+        # later in the object block replaces this value.
+        name = name_prefix + _type + "_" + str(counter)
         params = {}
         params['_auto_generated_name'] = True
         
@@ -1526,5 +1531,3 @@ class GLMModel:
         if directive in ['set', 'define']:
             return (line, None)
         return line
-
-


### PR DESCRIPTION
## Summary
- add gridlabd.glm_to_json() / gridlabd.convert_glm_to_json() package APIs
- expose conversion from GridLabD instances
- package the existing utilities/json_schema converter and references for wheel builds
- fix nested anonymous object naming so generated parent links remain resolvable

## What This Adds
- A Python package entry point for converting `.glm` files to JSON without importing utilities/json_schema directly.
- Wheel packaging support for the converter implementation and its schema/reference files.
- Regression coverage for package API conversion, explicit output paths, nested named objects, and nested anonymous object parent references.

## Main Python File Logic
- `python_bindings/src/gridlabd/_glm_json.py` locates the existing converter from either the installed package path (`gridlabd/json_schema`) or a source checkout (`utilities/json_schema`).
- `glm_to_json()` validates that the input exists and is a `.glm` file, then maps the optional output argument to either an explicit `.json` file path or an output directory.
- The wrapper calls the existing converter with the expected stem/input/output arguments, suppresses successful CLI-style stdout for package API use, and raises `RuntimeError` with captured converter details when conversion fails.
- `convert_glm_to_json` is an alias of `glm_to_json`, and the public package/API classes delegate to this wrapper.

## Test File Coverage
- `python_bindings/tests/test_glm_to_json_api.py` verifies the top-level package API writes an explicit JSON file, returns the output path, produces expected object JSON, and stays quiet on stdout.
- It verifies the `DirectGridLabD` instance method delegates to the same converter and defaults output next to the input GLM.
- It verifies nested objects with explicit names keep their original names while still receiving the correct parent reference.
- It verifies unnamed nested objects under `object class:id` declarations use resolvable parent names, and that generated nested names remain unique across multiple anonymous parents.

## What Remains
- Broader converted-JSON runtime/order issues tracked in #1694 are not fully addressed here.
- Full local pytest execution still depends on a built/importable gridlabd.gridlabd_core extension.

## Issues
- Fixes #1614
- Fixes #1592
- Fixes #1603
- Related to #1694

## Verification
- python -m compileall -q python_bindings/src/gridlabd/_glm_json.py python_bindings/tests/test_glm_to_json_api.py utilities/json_schema/glm_parser.py utilities/json_schema/glm_to_json.py
- git diff --check HEAD
- direct _glm_json conversion smoke test, including quiet stdout behavior

## Not run
- python -m pytest python_bindings/tests/test_glm_to_json_api.py -q; blocked locally because gridlabd.gridlabd_core is not built/importable and this environment lacks a Linux C/C++ compiler for editable install/build.